### PR TITLE
License was changed to GNU GPLv2 in 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Do you have feature requests, found a bug or want to use `PLIP` in your project?
 Write me an email to joachim.haupt (at) biotec.tu-dresden.de
 
 ## License Information
-PLIP is published under the Apache License. For more information, please read the LICENSE.txt file.
+PLIP is published under the GNU GPLv2. For more information, please read the LICENSE.txt file.
 Using PLIP in your commercial or non-commercial project is generally possible when giving a proper reference to this project and the publication in NAR.
 If you are unsure about usage options, don't hesitate to contact me.
 


### PR DESCRIPTION
The PLIP License was updated to GPLv2 in commit 6beada32812ea9d7b5f0f13df4462421044593df in 2017, but apparently the README was missed and is still mentioning the Apache License.

I assume the correct license is the GNU GPLv2 as indicated in the LICENSE.txt file.


