### PR TITLE
Make --dnareceptor flag behave consistently

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -115,11 +115,11 @@ $ plip -i 5b2m --intra A -yv
 Please note that detection within a chain takes much longer than detection of protein-ligand interactions, especially for large structures.
 
 ### Interactions of Molecules with DNA/RNA
-PLIP can characterize interactions between ligands and DNA/RNA. A special mode allows to switch from protein to DNA/RNA as the receptor molecule in the structure. To change the receptor mode, start PLIP with the option `--dnareceptor`.
+PLIP can characterize interactions between ligands and DNA/RNA. A special mode allows to switch from treating DNA/RNA molecules as ligands to treating them as part of the receptor in the structure. If a protein is present, too, interactions of the ligand with both, protein and nucleic acids, will be shown. To use this mode, start PLIP with the option `--dnareceptor`.
 
 ## Changing detection thresholds
 The PLIP algorithm uses a rule-based detection to report non-covalent interaction between proteins and their partners. The current settings are based on literature values and have been refined based on extensive testing with independent cases from mainly crystallography journals, covering a broad range of structure resolutions. For most users, it is not recommended to change the standard settings. However, there may be cases where changing detection thresholds is advisable (e.g. sets with multiple very low resolution structures).
- 
+
 PLIP allows you to change the setting permanently or for one run.
 
 ### Permanent change
@@ -147,7 +147,7 @@ PLIP offers further command line options which enables you to switch advanced se
 ## Web Service
 A web service for analysis of protein-ligand complexes using PLIP is available at
 [plip.biotec.tu-dresden.de](http://plip.biotec.tu-dresden.de/)
- 
+
 The web site offers advanced functions to search for specific entries from PDB and lists the interaction results in the browser. Additionally, the service used the BioLiP database to annotate biologically relevant ligands. The option to change threshold, ligand filtering, and batch processing is only available in the command line tool and with the Python modules.
 
 ## Algorithm

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Analyze noncovalent protein-ligand interactions in 3D structures with ease.
 | "I love the Linux command line and want to build a workflow around PLIP!" | :x:                | :heavy_check_mark: | :heavy_check_mark: | :yellow_circle:    |
 | "I'm a Python programmer and want to use PLIP in my project!"             | :x:                | :yellow_circle:    | :yellow_circle:    | :heavy_check_mark: |
 
-:exclamation: **Note:** The web server is currently running an outdated version of PLIP, which will be replaced soon. For production use and data analysis we highly recommend to use the current command line release. :exclamation:
-
 ---
 
 ## Quickstart

--- a/plip/exchange/report.py
+++ b/plip/exchange/report.py
@@ -72,7 +72,7 @@ class StructureReport:
         if len(self.excluded) != 0:
             textlines.append('Excluded molecules as ligands: %s\n' % ','.join([lig for lig in self.excluded]))
         if config.DNARECEPTOR:
-            textlines.append('DNA/RNA in structure was chosen as the receptor part.\n')
+            textlines.append('DNA/RNA in structure was chosen to be part of the receptor.\n')
         return textlines
 
     def get_bindingsite_data(self):

--- a/plip/plipcmd.py
+++ b/plip/plipcmd.py
@@ -210,7 +210,7 @@ def main():
                         help="Turns off calculation of mapping between canonical and PDB atom order for ligands.",
                         action="store_true")
     parser.add_argument("--dnareceptor", dest="dnareceptor", default=False,
-                        help="Uses the DNA instead of the protein as a receptor for interactions.",
+                        help="Treat nucleic acids as part of the receptor structure (together with any present protein) instead of as a ligand.",
                         action="store_true")
     parser.add_argument("--name", dest="outputfilename", default="report",
                         help="Set a filename for the report TXT and XML files. Will only work when processing single structures.")

--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -1407,7 +1407,9 @@ class PDBComplex:
 
         if config.DNARECEPTOR:
             self.resis = [obres for obres in pybel.ob.OBResidueIter(
-                self.protcomplex.OBMol) if obres.GetName() in config.DNA + config.RNA]
+                self.protcomplex.OBMol) if obres.GetName() in config.DNA + config.RNA
+                ] + [obres for obres in pybel.ob.OBResidueIter(
+                    self.protcomplex.OBMol) if obres.GetResidueProperty(0)]
         else:
             self.resis = [obres for obres in pybel.ob.OBResidueIter(
                 self.protcomplex.OBMol) if obres.GetResidueProperty(0)]


### PR DESCRIPTION
The --dnareceptor flag so far was intended to switch from protein to nucleic acids as the receptor molecule(s). However, for metal complexes and salt bridges interactions between ligands and protein residues were still showing up when using the flag. 

These changes tweak the flag's behaviour to allow it to switch from treating nucleic acids as ligands to treating them as PART OF the receptor - also keeping a potentially present protein as part of the receptor structure.

This behaviour is already implemented in the web tool. A use case, where this behaviour is handy, is the PDB structure 2e2h (GTP binds RNA polymerase II and DNA/RNA). The structure shows salt bridges and metal complexes between GTP and the protein when using the --dnareceptor flag without these changes, and in addition two hydrogen bonds with the protein when running plip with these changes.

I also adapted the documentation and hope I did not miss anything and the changes are correct.