### PR TITLE
Fixes visualizations for model flag

### DIFF
--- a/plip/exchange/report.py
+++ b/plip/exchange/report.py
@@ -40,6 +40,8 @@ class StructureReport:
             mode.text = 'default'
         pdbid = et.SubElement(report, 'pdbid')
         pdbid.text = self.mol.pymol_name.upper()
+        model = et.SubElement(report, 'model')
+        model.text = str(config.MODEL)
         filetype = et.SubElement(report, 'filetype')
         filetype.text = self.mol.filetype.upper()
         pdbfile = et.SubElement(report, 'pdbfile')
@@ -72,7 +74,8 @@ class StructureReport:
         if len(self.excluded) != 0:
             textlines.append('Excluded molecules as ligands: %s\n' % ','.join([lig for lig in self.excluded]))
         if config.DNARECEPTOR:
-            textlines.append('DNA/RNA in structure was chosen to be part of the receptor.\n')
+            textlines.append('DNA/RNA in structure was chosen to be part of the receptor.')
+        textlines.append(f'Analysis was done on model {config.MODEL}.\n')
         return textlines
 
     def get_bindingsite_data(self):

--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -86,6 +86,7 @@ class PDBParser:
                 except KeyError:
                     corrected_pdb = ''.join(model_dict[1])
                     corrected_lines = model_dict[1]
+                    config.MODEL = 1
                     logger.warning('invalid model number specified, using first model instead')
             else:
                 corrected_pdb = self.pdbpath

--- a/plip/visualization/pymol.py
+++ b/plip/visualization/pymol.py
@@ -5,6 +5,8 @@ from time import sleep
 
 from pymol import cmd
 
+from plip.basic import config
+
 
 class PyMOLVisualizer:
 
@@ -340,10 +342,11 @@ class PyMOLVisualizer:
         cmd.viewport(width, height)
         cmd.zoom('visible', 1.5)  # Adapt the zoom to the viewport
         cmd.set('ray_trace_frames', 1)  # Frames are raytraced before saving an image.
-        cmd.mpng(filepath, 1, 1)  # Use batch png mode with 1 frame only
+        cmd.mpng(filepath, config.MODEL, config.MODEL)  # Use batch png mode with 1 frame only
         cmd.mplay()  # cmd.mpng needs the animation to 'run'
         cmd.refresh()
-        originalfile = "".join([filepath, '0001.png'])
+        originalfile = "".join(
+            [filepath, (4 - len(str(config.MODEL))) * '0' + str(config.MODEL) + '.png'])
         newfile = "".join([filepath, '.png'])
 
         #################################################

--- a/plip/visualization/visualize.py
+++ b/plip/visualization/visualize.py
@@ -38,6 +38,7 @@ def visualize_in_pymol(plcomplex):
     vis.set_initial_representations()
 
     cmd.load(plcomplex.sourcefile)
+    cmd.frame(config.MODEL)
     current_name = cmd.get_object_list(selection='(all)')[0]
 
     logger.debug(f'setting current_name to {current_name} and PDB-ID to {pdbid}')


### PR DESCRIPTION
For models >1, visualizations were faulty due to the wrong frame/model being chosen in pymol.

These changes should fix the issue and additionally add the information on which model was used to the txt and xml reports.

I hope I didn't miss anything. :)