### PR TITLE
Fixes a bug when using --nofix

### DIFF
--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -1370,7 +1370,7 @@ class PDBComplex:
 
         if not as_string:
             self.sourcefiles['filename'] = os.path.basename(self.sourcefiles['pdbcomplex'])
-        self.protcomplex, self.filetype = read_pdb(self.corrected_pdb, as_string=True)
+        self.protcomplex, self.filetype = read_pdb(self.corrected_pdb, as_string= (self.corrected_pdb != pdbpath)) # self.corrected_pdb may fallback to pdbpath
 
         # Update the model in the Mapper class instance
         self.Mapper.original_structure = self.protcomplex.OBMol


### PR DESCRIPTION
```
self.protcomplex, self.filetype = read_pdb(self.corrected_pdb, as_string=True)
```
This line ([link](https://github.com/pharmai/plip/blob/8efd24f6d9d59f91d0dbf88237dcf92e0be9f694/plip/structure/preparation.py#L1373) ) sets `as_string=True`, but the `self.corrected_pdb` may fallback to `pdbpath` (when use `--nofix` or PDBParser meets some errors, see [link1](https://github.com/pharmai/plip/blob/8efd24f6d9d59f91d0dbf88237dcf92e0be9f694/plip/structure/preparation.py#L100) and [link2](https://github.com/pharmai/plip/blob/8efd24f6d9d59f91d0dbf88237dcf92e0be9f694/plip/structure/preparation.py#L97) ).

I changed this line to fix this problem.
 
```
self.protcomplex, self.filetype = read_pdb(self.corrected_pdb, as_string= (self.corrected_pdb != pdbpath)) 
```

Thank you.