### PR TITLE
fixes salt bridge detection for nucleic acid receptors

### DIFF
--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -967,7 +967,7 @@ class BindingSite(Mol):
                                       restype=res.GetName(),
                                       resnr=res.GetNum(),
                                       reschain=res.GetChain()))
-            if res.GetName() in ('U', 'A', 'C', 'G', 'DA', 'DT', 'DC', 'DG') and config.DNARECEPTOR: #nucleic acids
+            if res.GetName() in config.DNA + config.RNA and config.DNARECEPTOR: # nucleic acids have negative charge in sugar phosphate
                 for a in pybel.ob.OBResidueAtomIter(res):
                     if a.GetType().startswith('P') and res.GetAtomProperty(a, 9) \
                             and not self.Mapper.mapid(a.GetIdx(), mtype='protein') in self.altconf:

--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -929,6 +929,7 @@ class BindingSite(Mol):
 
     def find_charged(self, mol):
         """Looks for positive charges in arginine, histidine or lysine, for negative in aspartic and glutamic acid."""
+        """If nucleic acids are part of the receptor, looks for negative charges in phosphate backbone"""
         data = namedtuple('pcharge', 'atoms atoms_orig_idx type center restype resnr reschain')
         a_set = []
         # Iterate through all residue, exclude those in chains defined as peptides
@@ -964,6 +965,17 @@ class BindingSite(Mol):
                                       type='negative',
                                       center=centroid([ac.coords for ac in a_contributing]),
                                       restype=res.GetName(),
+                                      resnr=res.GetNum(),
+                                      reschain=res.GetChain()))
+            if res.GetName() in ('U', 'A', 'C', 'G', 'DA', 'DT', 'DC', 'DG') and config.DNARECEPTOR: #nucleic acids
+                for a in pybel.ob.OBResidueAtomIter(res):
+                    if a.GetType().startswith('P') and res.GetAtomProperty(a, 9) \
+                            and not self.Mapper.mapid(a.GetIdx(), mtype='protein') in self.altconf:
+                        a_contributing.append(pybel.Atom(a))
+                        a_contributing_orig_idx.append(self.Mapper.mapid(a.GetIdx(), mtype='protein'))
+                if not len(a_contributing) == 0:
+                    a_set.append(data(atoms=a_contributing,atoms_orig_idx=a_contributing_orig_idx, type='negative', 
+                                      center=centroid([ac.coords for ac in a_contributing]), restype=res.GetName(),
                                       resnr=res.GetNum(),
                                       reschain=res.GetChain()))
         return a_set

--- a/plip/test/pdb/4yb0.pdb
+++ b/plip/test/pdb/4yb0.pdb
@@ -1,0 +1,8191 @@
+HEADER    RNA                                     18-FEB-15   4YB0              
+TITLE     3',3'-CGAMP RIBOSWITCH BOUND WITH C-DI-GMP                            
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: RNA (84-MER);                                              
+COMPND   3 CHAIN: R, A;                                                         
+COMPND   4 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: GEOBACTER;                                      
+SOURCE   3 ORGANISM_TAXID: 28231;                                               
+SOURCE   4 GENE: AE017180.2;                                                    
+SOURCE   5 EXPRESSION_SYSTEM: IN VITRO TRANSCRIPTION VECTOR PT7-FLUC(DELTAI);   
+SOURCE   6 EXPRESSION_SYSTEM_TAXID: 905932                                      
+KEYWDS    RIBOSWITCH, 3', 3'-CGAMP, SPINACH, RNA STRUCTURE, C-DI-GMP, RNA       
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    A.M.REN,D.J.PATEL,R.K.RAJASHANKAR                                     
+REVDAT   2   22-APR-15 4YB0    1       JRNL                                     
+REVDAT   1   15-APR-15 4YB0    0                                                
+JRNL        AUTH   A.REN,X.C.WANG,C.A.KELLENBERGER,K.R.RAJASHANKAR,R.A.JONES,   
+JRNL        AUTH 2 M.C.HAMMOND,D.J.PATEL                                        
+JRNL        TITL   STRUCTURAL BASIS FOR MOLECULAR DISCRIMINATION BY A           
+JRNL        TITL 2 3',3'-CGAMP SENSING RIBOSWITCH.                              
+JRNL        REF    CELL REP                      V.  11     1 2015              
+JRNL        REFN                   ESSN 2211-1247                               
+JRNL        PMID   25818298                                                     
+JRNL        DOI    10.1016/J.CELREP.2015.03.004                                 
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.12 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : PHENIX (PHENIX.REFINE: 1.9_1692)                     
+REMARK   3   AUTHORS     : PAUL ADAMS,PAVEL AFONINE,VINCENT CHEN,IAN            
+REMARK   3               : DAVIS,KRESHNA GOPAL,RALF GROSSE-KUNSTLEVE,           
+REMARK   3               : LI-WEI HUNG,ROBERT IMMORMINO,TOM IOERGER,            
+REMARK   3               : AIRLIE MCCOY,ERIK MCKEE,NIGEL MORIARTY,              
+REMARK   3               : REETAL PAI,RANDY READ,JANE RICHARDSON,               
+REMARK   3               : DAVID RICHARDSON,TOD ROMO,JIM SACCHETTINI,           
+REMARK   3               : NICHOLAS SAUTER,JACOB SMITH,LAURENT                  
+REMARK   3               : STORONI,TOM TERWILLIGER,PETER ZWART                  
+REMARK   3                                                                      
+REMARK   3    REFINEMENT TARGET : ML                                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.12                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 85.10                          
+REMARK   3   MIN(FOBS/SIGMA_FOBS)              : 1.350                          
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 97.7                           
+REMARK   3   NUMBER OF REFLECTIONS             : 28916                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.230                           
+REMARK   3   R VALUE            (WORKING SET) : 0.228                           
+REMARK   3   FREE R VALUE                     : 0.262                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 5.070                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 1466                            
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT (IN BINS).                           
+REMARK   3   BIN  RESOLUTION RANGE  COMPL.    NWORK NFREE   RWORK  RFREE        
+REMARK   3     1 85.1271 -  4.5702    0.96     2796   141  0.1728 0.2059        
+REMARK   3     2  4.5702 -  3.6274    0.98     2777   163  0.1843 0.2052        
+REMARK   3     3  3.6274 -  3.1689    0.97     2747   148  0.2032 0.2649        
+REMARK   3     4  3.1689 -  2.8791    0.99     2785   150  0.2649 0.3020        
+REMARK   3     5  2.8791 -  2.6728    0.98     2741   137  0.3321 0.3403        
+REMARK   3     6  2.6728 -  2.5152    0.99     2748   128  0.3250 0.3415        
+REMARK   3     7  2.5152 -  2.3892    0.99     2774   132  0.3395 0.3938        
+REMARK   3     8  2.3892 -  2.2852    0.97     2695   159  0.3508 0.3983        
+REMARK   3     9  2.2852 -  2.1972    0.98     2710   157  0.3394 0.3571        
+REMARK   3    10  2.1972 -  2.1210    0.97     2677   151  0.3560 0.3713        
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELLING.                                             
+REMARK   3   METHOD USED        : FLAT BULK SOLVENT MODEL                       
+REMARK   3   SOLVENT RADIUS     : 1.11                                          
+REMARK   3   SHRINKAGE RADIUS   : 0.90                                          
+REMARK   3   K_SOL              : NULL                                          
+REMARK   3   B_SOL              : NULL                                          
+REMARK   3                                                                      
+REMARK   3  ERROR ESTIMATES.                                                    
+REMARK   3   COORDINATE ERROR (MAXIMUM-LIKELIHOOD BASED)     : 0.350            
+REMARK   3   PHASE ERROR (DEGREES, MAXIMUM-LIKELIHOOD BASED) : 33.790           
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : NULL                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : NULL                           
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  TWINNING INFORMATION.                                               
+REMARK   3   FRACTION: NULL                                                     
+REMARK   3   OPERATOR: NULL                                                     
+REMARK   3                                                                      
+REMARK   3  DEVIATIONS FROM IDEAL VALUES.                                       
+REMARK   3                 RMSD          COUNT                                  
+REMARK   3   BOND      :  0.007           4152                                  
+REMARK   3   ANGLE     :  1.457           6470                                  
+REMARK   3   CHIRALITY :  0.060            854                                  
+REMARK   3   PLANARITY :  0.008            172                                  
+REMARK   3   DIHEDRAL  : 16.739           2052                                  
+REMARK   3                                                                      
+REMARK   3  TLS DETAILS                                                         
+REMARK   3   NUMBER OF TLS GROUPS  : 1                                          
+REMARK   3   TLS GROUP : 1                                                      
+REMARK   3    SELECTION: ALL                                                    
+REMARK   3    ORIGIN FOR THE GROUP (A): 161.1264  34.9699 150.5993              
+REMARK   3    T TENSOR                                                          
+REMARK   3      T11:   0.4339 T22:   0.4342                                     
+REMARK   3      T33:   0.4793 T12:   0.0343                                     
+REMARK   3      T13:   0.1348 T23:  -0.0701                                     
+REMARK   3    L TENSOR                                                          
+REMARK   3      L11:   0.6981 L22:   0.9247                                     
+REMARK   3      L33:   1.7555 L12:  -0.3071                                     
+REMARK   3      L13:   0.9327 L23:  -0.3079                                     
+REMARK   3    S TENSOR                                                          
+REMARK   3      S11:  -0.0342 S12:  -0.0705 S13:   0.1592                       
+REMARK   3      S21:  -0.0499 S22:  -0.0721 S23:   0.0709                       
+REMARK   3      S31:  -0.3250 S32:  -0.3889 S33:   0.0925                       
+REMARK   3                                                                      
+REMARK   3  NCS DETAILS                                                         
+REMARK   3   NUMBER OF NCS GROUPS : NULL                                        
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 4YB0 COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 25-FEB-15.                  
+REMARK 100 THE DEPOSITION ID IS D_1000207148.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 14-AUG-14                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : 6.2-6.6                            
+REMARK 200  NUMBER OF CRYSTALS USED        : NULL                               
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : APS                                
+REMARK 200  BEAMLINE                       : 24-ID-C                            
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 0.9792                             
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : ADSC QUANTUM 315R                  
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : XDS                                
+REMARK 200  DATA SCALING SOFTWARE          : XDS                                
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 28937                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.120                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 85.100                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : 1.300                              
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 98.1                               
+REMARK 200  DATA REDUNDANCY                : 3.300                              
+REMARK 200  R MERGE                    (I) : 0.04400                            
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 16.3000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 2.12                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 2.24                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 97.9                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : 3.40                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 1.300                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: PHASER                                                
+REMARK 200 STARTING MODEL: 4YAZ                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 48.48                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.39                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: 0.1 M NA/K-PHOSPHATE, PH 6.2-6.6, 0.2    
+REMARK 280  M NACL AND 40-45% PEG400, PH 6.5, VAPOR DIFFUSION, SITTING DROP,    
+REMARK 280  TEMPERATURE 293K                                                    
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: C 1 2 1                          
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,Y,-Z                                                 
+REMARK 290       3555   X+1/2,Y+1/2,Z                                           
+REMARK 290       4555   -X+1/2,Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   3  1.000000  0.000000  0.000000       87.41450            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       22.45050            
+REMARK 290   SMTRY3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   4 -1.000000  0.000000  0.000000       87.41450            
+REMARK 290   SMTRY2   4  0.000000  1.000000  0.000000       22.45050            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1, 2                                                    
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: MONOMERIC                  
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: R                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 2                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: MONOMERIC                  
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   O5'    G R     2     O3'  GDP R   101              1.92            
+REMARK 500   OP1    G A     2     O3'  GDP A   101              1.94            
+REMARK 500   OP1    G R     2     O3'  GDP R   101              2.03            
+REMARK 500   O3'    A R    14     O    HOH R   201              2.17            
+REMARK 500   O    HOH A   206     O    HOH A   213              2.19            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500      C R  25   O5' -  P   -  OP2 ANGL. DEV. =  -5.8 DEGREES          
+REMARK 500      G R  30   O5' -  P   -  OP2 ANGL. DEV. =  -5.5 DEGREES          
+REMARK 500      G R  31   C5  -  C6  -  O6  ANGL. DEV. =  -4.6 DEGREES          
+REMARK 500      G R  37   O4' -  C1' -  N9  ANGL. DEV. =   4.3 DEGREES          
+REMARK 500      A R  42   O4' -  C1' -  N9  ANGL. DEV. =   4.4 DEGREES          
+REMARK 500      G R  51   C5  -  C6  -  O6  ANGL. DEV. =  -4.0 DEGREES          
+REMARK 500      U R  59   N1  -  C2  -  O2  ANGL. DEV. =   5.5 DEGREES          
+REMARK 500      U R  59   N3  -  C2  -  O2  ANGL. DEV. =  -5.2 DEGREES          
+REMARK 500      U R  59   C2  -  N1  -  C1' ANGL. DEV. =   8.6 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              MG R 104  MG                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1   A R  11   OP1                                                    
+REMARK 620 2   A R  11   OP2  60.8                                              
+REMARK 620 3   A R  12   OP2  73.6 118.0                                        
+REMARK 620 N                    1     2                                         
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                               K R 107   K                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1   G R  36   O6                                                     
+REMARK 620 2 HOH R 223   O    97.2                                              
+REMARK 620 3 HOH R 216   O   132.0  97.8                                        
+REMARK 620 4 HOH R 221   O    80.3  77.7  59.1                                  
+REMARK 620 N                    1     2     3                                   
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              MG R 105  MG                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1   A R  41   O3'                                                    
+REMARK 620 2   A R  41   O2'  58.6                                              
+REMARK 620 3 HOH R 213   O   151.8 146.6                                        
+REMARK 620 N                    1     2                                         
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                               K R 106   K                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1   G R  51   O6                                                     
+REMARK 620 2 HOH R 211   O    91.4                                              
+REMARK 620 3 HOH R 217   O   124.7 119.4                                        
+REMARK 620 N                    1     2                                         
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              MG A 103  MG                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1   G A  28   OP1                                                    
+REMARK 620 2 HOH A 202   O    90.4                                              
+REMARK 620 3 HOH A 203   O   136.5  79.1                                        
+REMARK 620 4 HOH A 208   O   134.1  92.7  88.9                                  
+REMARK 620 N                    1     2     3                                   
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              MG A 104  MG                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1   A A  41   O2'                                                    
+REMARK 620 2 HOH A 215   O   144.8                                              
+REMARK 620 N                    1                                               
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              MG R 103  MG                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 HOH R 208   O                                                      
+REMARK 620 2 HOH R 214   O    75.2                                              
+REMARK 620 3 HOH R 226   O    94.2 124.3                                        
+REMARK 620 4 HOH R 205   O   114.6 102.4 130.4                                  
+REMARK 620 N                    1     2     3                                   
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue GDP R 101                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue C2E R 102                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue MG R 103                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC4                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue MG R 104                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC5                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue MG R 105                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC6                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue K R 106                   
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC7                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue K R 107                   
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC8                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue C2E A 102                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC9                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue MG A 103                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AD1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for residue MG A 104                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AD2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: binding site for GDP A 101                         
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 4YAZ   RELATED DB: PDB                                   
+REMARK 900 RELATED ID: 4YB1   RELATED DB: PDB                                   
+DBREF  4YB0 R    2    84  PDB    4YB0     4YB0             2     84             
+DBREF  4YB0 A    2    84  PDB    4YB0     4YB0             2     84             
+SEQRES   1 R   83    G   U   A   C   A   C   G   A   C   A   A   U   A          
+SEQRES   2 R   83    C   U   A   A   A   C   C   A   U   C   C   G   C          
+SEQRES   3 R   83    G   A   G   G   A   U   G   G   G   G   C   G   G          
+SEQRES   4 R   83    A   A   A   G   C   C   U   A   A   G   G   G   U          
+SEQRES   5 R   83    C   U   C   C   C   U   G   A   G   A   C   A   G          
+SEQRES   6 R   83    C   C   G   G   G   C   U   G   C   C   G   A   A          
+SEQRES   7 R   83    A   U   A   U   C                                          
+SEQRES   1 A   83    G   U   A   C   A   C   G   A   C   A   A   U   A          
+SEQRES   2 A   83    C   U   A   A   A   C   C   A   U   C   C   G   C          
+SEQRES   3 A   83    G   A   G   G   A   U   G   G   G   G   C   G   G          
+SEQRES   4 A   83    A   A   A   G   C   C   U   A   A   G   G   G   U          
+SEQRES   5 A   83    C   U   C   C   C   U   G   A   G   A   C   A   G          
+SEQRES   6 A   83    C   C   G   G   G   C   U   G   C   C   G   A   A          
+SEQRES   7 A   83    A   U   A   U   C                                          
+HET    GDP  R 101      28                                                       
+HET    C2E  R 102      46                                                       
+HET     MG  R 103       1                                                       
+HET     MG  R 104       1                                                       
+HET     MG  R 105       1                                                       
+HET      K  R 106       1                                                       
+HET      K  R 107       1                                                       
+HET    GDP  A 101      28                                                       
+HET    C2E  A 102      46                                                       
+HET     MG  A 103       1                                                       
+HET     MG  A 104       1                                                       
+HETNAM     GDP GUANOSINE-5'-DIPHOSPHATE                                         
+HETNAM     C2E 9,9'-[(2R,3R,3AS,5S,7AR,9R,10R,10AS,12S,14AR)-3,5,10,            
+HETNAM   2 C2E  12-TETRAHYDROXY-5,12-DIOXIDOOCTAHYDRO-2H,7H-DIFURO[3,           
+HETNAM   3 C2E  2-D:3',2'-J][1,3,7,9,2,                                         
+HETNAM   4 C2E  8]TETRAOXADIPHOSPHACYCLODODECINE-2,9-DIYL]BIS(2-AMINO-          
+HETNAM   5 C2E  1,9-DIHYDRO-6H-PURIN-6-ONE)                                     
+HETNAM      MG MAGNESIUM ION                                                    
+HETNAM       K POTASSIUM ION                                                    
+HETSYN     C2E C-DI-GMP, CYCLIC DIGUANOSINE MONOPHOSPHATE                       
+FORMUL   3  GDP    2(C10 H15 N5 O11 P2)                                         
+FORMUL   4  C2E    2(C20 H24 N10 O14 P2)                                        
+FORMUL   5   MG    5(MG 2+)                                                     
+FORMUL   8    K    2(K 1+)                                                      
+FORMUL  14  HOH   *42(H2 O)                                                     
+LINK         P     G R   2                 O3' GDP R 101     1555   1555  1.68  
+LINK         OP1   A R  11                MG    MG R 104     1555   1555  2.55  
+LINK         OP2   A R  11                MG    MG R 104     1555   1555  2.53  
+LINK         OP2   A R  12                MG    MG R 104     1555   1555  2.06  
+LINK         O6    G R  36                 K     K R 107     1555   1555  2.82  
+LINK         O3'   A R  41                MG    MG R 105     1555   1555  2.89  
+LINK         O2'   A R  41                MG    MG R 105     1555   1555  2.62  
+LINK         O6    G R  51                 K     K R 106     1555   1555  2.69  
+LINK         P     G A   2                 O3' GDP A 101     1555   1555  1.65  
+LINK         OP1   G A  28                MG    MG A 103     1555   1555  2.47  
+LINK         O2'   A A  41                MG    MG A 104     1555   1555  2.88  
+LINK        MG    MG R 103                 O   HOH R 208     1555   1555  2.12  
+LINK        MG    MG R 103                 O   HOH R 214     1555   1555  2.33  
+LINK        MG    MG R 103                 O   HOH R 226     1555   1555  1.83  
+LINK        MG    MG R 103                 O   HOH R 205     1555   1555  2.04  
+LINK        MG    MG R 105                 O   HOH R 213     1555   1555  1.95  
+LINK         K     K R 106                 O   HOH R 211     1555   1555  2.59  
+LINK         K     K R 106                 O   HOH R 217     1555   1555  2.45  
+LINK         K     K R 107                 O   HOH R 223     1555   1555  2.75  
+LINK         K     K R 107                 O   HOH R 216     1555   1555  2.89  
+LINK         K     K R 107                 O   HOH R 221     1555   1555  2.62  
+LINK        MG    MG A 103                 O   HOH A 202     1555   1555  2.69  
+LINK        MG    MG A 103                 O   HOH A 203     1555   1555  2.04  
+LINK        MG    MG A 103                 O   HOH A 208     1555   1555  2.17  
+LINK        MG    MG A 104                 O   HOH A 215     1555   1555  2.38  
+SITE     1 AC1  2   G R   2    C R  84                                          
+SITE     1 AC2 10   G R   8    A R  11    A R  12    A R  14                    
+SITE     2 AC2 10   G R  40    A R  41    A R  42    C R  75                    
+SITE     3 AC2 10   C R  76   MG R 105                                          
+SITE     1 AC3  6   G R  26    G R  28  HOH R 205  HOH R 208                    
+SITE     2 AC3  6 HOH R 214  HOH R 226                                          
+SITE     1 AC4  2   A R  11    A R  12                                          
+SITE     1 AC5  5   G R   8    A R  41    A R  42  C2E R 102                    
+SITE     2 AC5  5 HOH R 213                                                     
+SITE     1 AC6  6   A R  48    G R  50    G R  51    A R  65                    
+SITE     2 AC6  6 HOH R 211  HOH R 217                                          
+SITE     1 AC7  6   G R  34    G R  35    G R  36  HOH R 216                    
+SITE     2 AC7  6 HOH R 221  HOH R 223                                          
+SITE     1 AC8 11   G A   8    A A   9    A A  11    A A  12                    
+SITE     2 AC8 11   A A  14    G A  40    A A  41    A A  42                    
+SITE     3 AC8 11   C A  75    C A  76   MG A 104                               
+SITE     1 AC9  5   G A  26    G A  28  HOH A 202  HOH A 203                    
+SITE     2 AC9  5 HOH A 208                                                     
+SITE     1 AD1  4   A A  41    A A  42  C2E A 102  HOH A 215                    
+SITE     1 AD2  4   U A   3    A A  82    U A  83    C A  84                    
+CRYST1  174.829   44.901   68.210  90.00 103.33  90.00 C 1 2 1       8          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.005720  0.000000  0.001355        0.00000                         
+SCALE2      0.000000  0.022271  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.015067        0.00000                         
+ATOM      1  P     G R   2     205.153  39.753 140.589  1.00 89.83           P  
+ANISOU    1  P     G R   2     8497  13360  12274  -2172   2187   3157       P  
+ATOM      2  OP1   G R   2     205.402  38.441 139.928  1.00 96.94           O  
+ANISOU    2  OP1   G R   2     9281  14499  13054  -1938   2345   3079       O  
+ATOM      3  OP2   G R   2     203.797  40.096 141.098  1.00 71.19           O  
+ANISOU    3  OP2   G R   2     6359  10729   9959  -2201   2110   3060       O  
+ATOM      4  O5'   G R   2     206.102  39.975 141.850  1.00 73.25           O  
+ANISOU    4  O5'   G R   2     6306  11209  10318  -2308   2059   3187       O  
+ATOM      5  C5'   G R   2     205.548  39.932 143.154  1.00 68.98           C  
+ANISOU    5  C5'   G R   2     5879  10439   9890  -2349   1942   3072       C  
+ATOM      6  C4'   G R   2     205.794  41.199 143.936  1.00 72.29           C  
+ANISOU    6  C4'   G R   2     6370  10663  10434  -2582   1761   3164       C  
+ATOM      7  O4'   G R   2     205.804  42.358 143.054  1.00 83.92           O  
+ANISOU    7  O4'   G R   2     7888  12123  11873  -2709   1739   3319       O  
+ATOM      8  C3'   G R   2     204.736  41.530 144.976  1.00 71.23           C  
+ANISOU    8  C3'   G R   2     6446  10230  10387  -2631   1634   3050       C  
+ATOM      9  O3'   G R   2     204.893  40.787 146.176  1.00 72.76           O  
+ANISOU    9  O3'   G R   2     6612  10373  10659  -2589   1587   2932       O  
+ATOM     10  C2'   G R   2     204.902  43.033 145.156  1.00 82.08           C  
+ANISOU   10  C2'   G R   2     7915  11438  11833  -2849   1475   3180       C  
+ATOM     11  O2'   G R   2     206.000  43.308 146.014  1.00 91.13           O  
+ANISOU   11  O2'   G R   2     8962  12585  13080  -2970   1362   3242       O  
+ATOM     12  C1'   G R   2     205.259  43.480 143.729  1.00 84.40           C  
+ANISOU   12  C1'   G R   2     8135  11906  12027  -2871   1569   3335       C  
+ATOM     13  N9    G R   2     204.076  43.976 142.975  1.00 80.58           N  
+ANISOU   13  N9    G R   2     7829  11310  11477  -2853   1592   3328       N  
+ATOM     14  C8    G R   2     203.660  43.612 141.676  1.00 80.60           C  
+ANISOU   14  C8    G R   2     7818  11461  11344  -2731   1748   3341       C  
+ATOM     15  N7    G R   2     202.556  44.233 141.256  1.00 79.80           N  
+ANISOU   15  N7    G R   2     7905  11204  11214  -2747   1724   3336       N  
+ATOM     16  C5    G R   2     202.259  45.059 142.349  1.00 79.31           C  
+ANISOU   16  C5    G R   2     7986  10876  11273  -2884   1540   3317       C  
+ATOM     17  C6    G R   2     201.206  45.950 142.501  1.00 78.53           C  
+ANISOU   17  C6    G R   2     8111  10524  11203  -2949   1430   3300       C  
+ATOM     18  O6    G R   2     200.259  46.220 141.709  1.00 78.01           O  
+ANISOU   18  O6    G R   2     8169  10407  11065  -2907   1472   3303       O  
+ATOM     19  N1    G R   2     201.252  46.585 143.742  1.00 78.37           N  
+ANISOU   19  N1    G R   2     8189  10282  11306  -3067   1246   3272       N  
+ATOM     20  C2    G R   2     202.189  46.398 144.688  1.00 78.89           C  
+ANISOU   20  C2    G R   2     8150  10369  11457  -3123   1177   3267       C  
+ATOM     21  N2    G R   2     202.043  47.140 145.791  1.00 78.74           N  
+ANISOU   21  N2    G R   2     8269  10107  11541  -3230    988   3236       N  
+ATOM     22  N3    G R   2     203.190  45.551 144.583  1.00 79.58           N  
+ANISOU   22  N3    G R   2     8020  10693  11526  -3070   1277   3287       N  
+ATOM     23  C4    G R   2     203.143  44.918 143.381  1.00 79.74           C  
+ANISOU   23  C4    G R   2     7944  10929  11425  -2947   1458   3309       C  
+ATOM     24  P     U R   3     203.732  39.782 146.667  1.00 91.03           P  
+ANISOU   24  P     U R   3     9034  12592  12960  -2428   1632   2735       P  
+ATOM     25  OP1   U R   3     204.218  39.101 147.893  1.00 96.87           O  
+ANISOU   25  OP1   U R   3     9709  13309  13786  -2413   1573   2650       O  
+ATOM     26  OP2   U R   3     203.248  39.003 145.498  1.00 86.95           O  
+ANISOU   26  OP2   U R   3     8491  12239  12309  -2248   1806   2697       O  
+ATOM     27  O5'   U R   3     202.586  40.744 147.193  1.00 73.24           O  
+ANISOU   27  O5'   U R   3     7023  10038  10766  -2529   1503   2698       O  
+ATOM     28  C5'   U R   3     202.872  41.618 148.268  1.00 77.68           C  
+ANISOU   28  C5'   U R   3     7662  10408  11445  -2692   1319   2723       C  
+ATOM     29  C4'   U R   3     201.871  42.732 148.361  1.00 75.63           C  
+ANISOU   29  C4'   U R   3     7629   9899  11209  -2780   1208   2724       C  
+ATOM     30  O4'   U R   3     201.940  43.592 147.194  1.00 84.29           O  
+ANISOU   30  O4'   U R   3     8735  11048  12245  -2848   1234   2866       O  
+ATOM     31  C3'   U R   3     200.425  42.307 148.401  1.00 75.01           C  
+ANISOU   31  C3'   U R   3     7701   9700  11098  -2662   1253   2586       C  
+ATOM     32  O3'   U R   3     200.053  41.790 149.662  1.00 83.47           O  
+ANISOU   32  O3'   U R   3     8835  10637  12241  -2626   1186   2445       O  
+ATOM     33  C2'   U R   3     199.705  43.591 148.005  1.00 80.45           C  
+ANISOU   33  C2'   U R   3     8573  10211  11783  -2757   1165   2650       C  
+ATOM     34  O2'   U R   3     199.667  44.505 149.091  1.00 85.35           O  
+ANISOU   34  O2'   U R   3     9335  10592  12503  -2880    968   2635       O  
+ATOM     35  C1'   U R   3     200.664  44.159 146.958  1.00 82.18           C  
+ANISOU   35  C1'   U R   3     8672  10596  11955  -2841   1202   2828       C  
+ATOM     36  N1    U R   3     200.238  43.862 145.573  1.00 80.09           N  
+ANISOU   36  N1    U R   3     8377  10483  11569  -2742   1362   2864       N  
+ATOM     37  C2    U R   3     199.166  44.583 145.081  1.00 79.06           C  
+ANISOU   37  C2    U R   3     8426  10206  11408  -2755   1334   2874       C  
+ATOM     38  O2    U R   3     198.561  45.423 145.729  1.00 84.16           O  
+ANISOU   38  O2    U R   3     9251  10607  12119  -2836   1185   2849       O  
+ATOM     39  N3    U R   3     198.817  44.283 143.790  1.00 72.37           N  
+ANISOU   39  N3    U R   3     7548   9507  10442  -2660   1481   2910       N  
+ATOM     40  C4    U R   3     199.402  43.355 142.956  1.00 75.06           C  
+ANISOU   40  C4    U R   3     7710  10121  10689  -2545   1648   2928       C  
+ATOM     41  O4    U R   3     198.959  43.205 141.812  1.00 79.77           O  
+ANISOU   41  O4    U R   3     8316  10818  11175  -2460   1762   2954       O  
+ATOM     42  C5    U R   3     200.498  42.646 143.546  1.00 75.93           C  
+ANISOU   42  C5    U R   3     7645  10368  10839  -2530   1665   2911       C  
+ATOM     43  C6    U R   3     200.870  42.915 144.804  1.00 78.45           C  
+ANISOU   43  C6    U R   3     7981  10550  11278  -2631   1525   2884       C  
+ATOM     44  P     A R   4     199.172  40.445 149.766  1.00 91.11           P  
+ANISOU   44  P     A R   4     9803  11642  13171  -2438   1309   2289       P  
+ATOM     45  OP1   A R   4     199.344  39.899 151.139  1.00 94.35           O  
+ANISOU   45  OP1   A R   4    10216  11965  13668  -2433   1231   2182       O  
+ATOM     46  OP2   A R   4     199.454  39.555 148.610  1.00 86.69           O  
+ANISOU   46  OP2   A R   4     9091  11344  12503  -2305   1493   2314       O  
+ATOM     47  O5'   A R   4     197.687  40.994 149.637  1.00 95.17           O  
+ANISOU   47  O5'   A R   4    10530  11955  13675  -2421   1280   2235       O  
+ATOM     48  C5'   A R   4     197.320  42.229 150.235  1.00 86.72           C  
+ANISOU   48  C5'   A R   4     9638  10642  12669  -2548   1107   2251       C  
+ATOM     49  C4'   A R   4     195.935  42.607 149.808  1.00 78.55           C  
+ANISOU   49  C4'   A R   4     8772   9471  11604  -2499   1116   2213       C  
+ATOM     50  O4'   A R   4     196.002  43.559 148.711  1.00 85.72           O  
+ANISOU   50  O4'   A R   4     9709  10403  12456  -2571   1115   2350       O  
+ATOM     51  C3'   A R   4     195.128  41.466 149.223  1.00 82.03           C  
+ANISOU   51  C3'   A R   4     9193  10024  11951  -2296   1281   2091       C  
+ATOM     52  O3'   A R   4     194.655  40.492 150.147  1.00 92.17           O  
+ANISOU   52  O3'   A R   4    10520  11265  13236  -2163   1283   1888       O  
+ATOM     53  C2'   A R   4     194.085  42.209 148.400  1.00 88.24           C  
+ANISOU   53  C2'   A R   4    10137  10719  12672  -2269   1276   2096       C  
+ATOM     54  O2'   A R   4     193.124  42.845 149.233  1.00 94.52           O  
+ANISOU   54  O2'   A R   4    11147  11267  13501  -2263   1137   1977       O  
+ATOM     55  C1'   A R   4     194.962  43.293 147.781  1.00 86.21           C  
+ANISOU   55  C1'   A R   4     9819  10493  12443  -2461   1230   2331       C  
+ATOM     56  N9    A R   4     195.545  42.807 146.511  1.00 87.15           N  
+ANISOU   56  N9    A R   4     9779  10876  12459  -2406   1391   2419       N  
+ATOM     57  C8    A R   4     196.601  41.939 146.335  1.00 87.72           C  
+ANISOU   57  C8    A R   4     9651  11178  12499  -2359   1489   2434       C  
+ATOM     58  N7    A R   4     196.876  41.659 145.084  1.00 86.13           N  
+ANISOU   58  N7    A R   4     9353  11183  12191  -2295   1623   2505       N  
+ATOM     59  C5    A R   4     195.920  42.374 144.380  1.00 82.59           C  
+ANISOU   59  C5    A R   4     9048  10632  11700  -2304   1617   2543       C  
+ATOM     60  C6    A R   4     195.672  42.488 143.004  1.00 77.34           C  
+ANISOU   60  C6    A R   4     8380  10085  10921  -2253   1722   2619       C  
+ATOM     61  N6    A R   4     196.407  41.851 142.088  1.00 76.45           N  
+ANISOU   61  N6    A R   4     8110  10228  10709  -2173   1858   2665       N  
+ATOM     62  N1    A R   4     194.643  43.283 142.620  1.00 77.14           N  
+ANISOU   62  N1    A R   4     8525   9901  10884  -2279   1675   2644       N  
+ATOM     63  C2    A R   4     193.918  43.908 143.565  1.00 73.06           C  
+ANISOU   63  C2    A R   4     8170   9126  10465  -2343   1532   2590       C  
+ATOM     64  N3    A R   4     194.061  43.876 144.890  1.00 75.64           N  
+ANISOU   64  N3    A R   4     8521   9321  10898  -2389   1422   2509       N  
+ATOM     65  C4    A R   4     195.087  43.077 145.239  1.00 82.43           C  
+ANISOU   65  C4    A R   4     9209  10344  11767  -2370   1474   2491       C  
+ATOM     66  P     C R   5     193.760  40.863 151.428  1.00115.12           P  
+ANISOU   66  P     C R   5    13633  13918  16190  -2152   1138   1730       P  
+ATOM     67  OP1   C R   5     193.339  42.284 151.368  1.00114.40           O  
+ANISOU   67  OP1   C R   5    13699  13643  16125  -2259   1010   1799       O  
+ATOM     68  OP2   C R   5     194.474  40.359 152.628  1.00113.49           O  
+ANISOU   68  OP2   C R   5    13364  13698  16059  -2185   1079   1682       O  
+ATOM     69  O5'   C R   5     192.468  39.955 151.238  1.00102.95           O  
+ANISOU   69  O5'   C R   5    12178  12388  14551  -1945   1230   1536       O  
+ATOM     70  C5'   C R   5     191.750  39.451 152.359  1.00104.10           C  
+ANISOU   70  C5'   C R   5    12426  12422  14704  -1860   1181   1351       C  
+ATOM     71  C4'   C R   5     190.368  40.049 152.440  1.00105.99           C  
+ANISOU   71  C4'   C R   5    12861  12505  14906  -1798   1127   1250       C  
+ATOM     72  O4'   C R   5     190.370  41.113 153.436  1.00108.62           O  
+ANISOU   72  O4'   C R   5    13320  12638  15313  -1898    961   1254       O  
+ATOM     73  C3'   C R   5     189.857  40.676 151.141  1.00105.62           C  
+ANISOU   73  C3'   C R   5    12854  12478  14797  -1785   1172   1328       C  
+ATOM     74  O3'   C R   5     188.444  40.485 151.039  1.00105.53           O  
+ANISOU   74  O3'   C R   5    12969  12412  14717  -1644   1192   1182       O  
+ATOM     75  C2'   C R   5     190.173  42.161 151.337  1.00108.18           C  
+ANISOU   75  C2'   C R   5    13268  12646  15189  -1942   1025   1448       C  
+ATOM     76  O2'   C R   5     189.386  43.052 150.572  1.00105.88           O  
+ANISOU   76  O2'   C R   5    13101  12275  14854  -1932    998   1480       O  
+ATOM     77  C1'   C R   5     189.944  42.329 152.840  1.00111.33           C  
+ANISOU   77  C1'   C R   5    13777  12877  15647  -1950    896   1330       C  
+ATOM     78  N1    C R   5     190.702  43.441 153.451  1.00110.33           N  
+ANISOU   78  N1    C R   5    13698  12609  15613  -2121    734   1439       N  
+ATOM     79  C2    C R   5     190.076  44.683 153.652  1.00112.39           C  
+ANISOU   79  C2    C R   5    14154  12666  15884  -2153    591   1436       C  
+ATOM     80  O2    C R   5     188.892  44.839 153.304  1.00111.89           O  
+ANISOU   80  O2    C R   5    14207  12555  15750  -2033    611   1342       O  
+ATOM     81  N3    C R   5     190.787  45.693 154.215  1.00114.33           N  
+ANISOU   81  N3    C R   5    14458  12769  16214  -2314    424   1537       N  
+ATOM     82  C4    C R   5     192.059  45.509 154.580  1.00111.73           C  
+ANISOU   82  C4    C R   5    13990  12499  15962  -2447    400   1642       C  
+ATOM     83  N4    C R   5     192.709  46.537 155.131  1.00110.45           N  
+ANISOU   83  N4    C R   5    13898  12184  15886  -2612    220   1743       N  
+ATOM     84  C5    C R   5     192.721  44.260 154.396  1.00108.29           C  
+ANISOU   84  C5    C R   5    13343  12282  15520  -2412    550   1646       C  
+ATOM     85  C6    C R   5     192.007  43.271 153.841  1.00106.74           C  
+ANISOU   85  C6    C R   5    13106  12216  15236  -2245    710   1541       C  
+ATOM     86  P     A R   6     187.783  39.958 149.667  1.00108.81           P  
+ANISOU   86  P     A R   6    13361  12956  15027  -1524   1325   1171       P  
+ATOM     87  OP1   A R   6     186.311  39.891 149.879  1.00 99.72           O  
+ANISOU   87  OP1   A R   6    12348  11715  13827  -1402   1307   1015       O  
+ATOM     88  OP2   A R   6     188.504  38.732 149.217  1.00 95.41           O  
+ANISOU   88  OP2   A R   6    11499  11457  13297  -1473   1451   1186       O  
+ATOM     89  O5'   A R   6     188.065  41.142 148.632  1.00 85.34           O  
+ANISOU   89  O5'   A R   6    10409   9970  12049  -1623   1303   1345       O  
+ATOM     90  C5'   A R   6     187.175  42.246 148.501  1.00 80.33           C  
+ANISOU   90  C5'   A R   6     9941   9176  11405  -1628   1210   1338       C  
+ATOM     91  C4'   A R   6     187.445  42.998 147.222  1.00 84.92           C  
+ANISOU   91  C4'   A R   6    10514   9800  11952  -1695   1233   1505       C  
+ATOM     92  O4'   A R   6     188.848  43.376 147.181  1.00 86.09           O  
+ANISOU   92  O4'   A R   6    10545  10004  12161  -1864   1215   1687       O  
+ATOM     93  C3'   A R   6     187.220  42.196 145.945  1.00 84.89           C  
+ANISOU   93  C3'   A R   6    10432   9977  11845  -1585   1388   1512       C  
+ATOM     94  O3'   A R   6     185.875  42.256 145.504  1.00 78.56           O  
+ANISOU   94  O3'   A R   6     9756   9118  10975  -1459   1391   1406       O  
+ATOM     95  C2'   A R   6     188.209  42.812 144.959  1.00 86.15           C  
+ANISOU   95  C2'   A R   6    10506  10229  11997  -1711   1419   1731       C  
+ATOM     96  O2'   A R   6     187.675  43.993 144.378  1.00 83.59           O  
+ANISOU   96  O2'   A R   6    10320   9785  11654  -1758   1342   1804       O  
+ATOM     97  C1'   A R   6     189.367  43.197 145.879  1.00 88.90           C  
+ANISOU   97  C1'   A R   6    10784  10539  12454  -1876   1335   1824       C  
+ATOM     98  N9    A R   6     190.443  42.174 145.923  1.00 87.78           N  
+ANISOU   98  N9    A R   6    10439  10594  12320  -1876   1440   1860       N  
+ATOM     99  C8    A R   6     190.949  41.538 147.033  1.00 79.12           C  
+ANISOU   99  C8    A R   6     9274   9498  11289  -1881   1417   1786       C  
+ATOM    100  N7    A R   6     191.921  40.693 146.776  1.00 75.95           N  
+ANISOU  100  N7    A R   6     8687   9296  10877  -1870   1522   1841       N  
+ATOM    101  C5    A R   6     192.091  40.781 145.397  1.00 81.90           C  
+ANISOU  101  C5    A R   6     9375  10197  11545  -1856   1628   1962       C  
+ATOM    102  C6    A R   6     192.977  40.139 144.494  1.00 76.34           C  
+ANISOU  102  C6    A R   6     8485   9742  10779  -1825   1770   2066       C  
+ATOM    103  N6    A R   6     193.899  39.239 144.849  1.00 72.11           N  
+ANISOU  103  N6    A R   6     7784   9352  10261  -1798   1828   2061       N  
+ATOM    104  N1    A R   6     192.877  40.455 143.185  1.00 76.02           N  
+ANISOU  104  N1    A R   6     8435   9800  10647  -1811   1850   2174       N  
+ATOM    105  C2    A R   6     191.951  41.353 142.818  1.00 83.56           C  
+ANISOU  105  C2    A R   6     9560  10605  11583  -1832   1785   2177       C  
+ATOM    106  N3    A R   6     191.072  42.031 143.560  1.00 84.58           N  
+ANISOU  106  N3    A R   6     9871  10497  11767  -1857   1648   2085       N  
+ATOM    107  C4    A R   6     191.189  41.695 144.861  1.00 85.35           C  
+ANISOU  107  C4    A R   6     9971  10510  11950  -1865   1577   1978       C  
+ATOM    108  P     C R   7     185.259  41.074 144.612  1.00 90.42           P  
+ANISOU  108  P     C R   7    11210  10773  12373  -1294   1531   1320       P  
+ATOM    109  OP1   C R   7     184.058  41.635 143.928  1.00 91.97           O  
+ANISOU  109  OP1   C R   7    11542  10892  12509  -1219   1504   1282       O  
+ATOM    110  OP2   C R   7     185.151  39.863 145.479  1.00 71.65           O  
+ANISOU  110  OP2   C R   7     8779   8437  10008  -1213   1565   1173       O  
+ATOM    111  O5'   C R   7     186.358  40.796 143.484  1.00 67.85           O  
+ANISOU  111  O5'   C R   7     8205   8109   9468  -1333   1647   1482       O  
+ATOM    112  C5'   C R   7     186.243  41.367 142.187  1.00 74.23           C  
+ANISOU  112  C5'   C R   7     9040   8961  10203  -1339   1684   1597       C  
+ATOM    113  C4'   C R   7     187.007  40.560 141.167  1.00 71.75           C  
+ANISOU  113  C4'   C R   7     8577   8875   9808  -1294   1832   1679       C  
+ATOM    114  O4'   C R   7     188.413  40.523 141.521  1.00 67.37           O  
+ANISOU  114  O4'   C R   7     7868   8417   9311  -1411   1852   1801       O  
+ATOM    115  C3'   C R   7     186.593  39.101 141.065  1.00 63.56           C  
+ANISOU  115  C3'   C R   7     7500   7944   8705  -1119   1924   1525       C  
+ATOM    116  O3'   C R   7     185.512  38.940 140.168  1.00 56.96           O  
+ANISOU  116  O3'   C R   7     6760   7107   7776   -996   1953   1459       O  
+ATOM    117  C2'   C R   7     187.867  38.397 140.611  1.00 66.65           C  
+ANISOU  117  C2'   C R   7     7711   8550   9062  -1118   2038   1621       C  
+ATOM    118  O2'   C R   7     188.015  38.498 139.208  1.00 75.73           O  
+ANISOU  118  O2'   C R   7     8835   9835  10105  -1080   2130   1730       O  
+ATOM    119  C1'   C R   7     188.954  39.249 141.260  1.00 68.42           C  
+ANISOU  119  C1'   C R   7     7861   8743   9391  -1308   1975   1766       C  
+ATOM    120  N1    C R   7     189.465  38.681 142.528  1.00 69.07           N  
+ANISOU  120  N1    C R   7     7877   8804   9562  -1331   1938   1690       N  
+ATOM    121  C2    C R   7     190.426  37.677 142.473  1.00 67.55           C  
+ANISOU  121  C2    C R   7     7520   8796   9349  -1282   2032   1704       C  
+ATOM    122  O2    C R   7     190.793  37.277 141.366  1.00 75.82           O  
+ANISOU  122  O2    C R   7     8484  10025  10300  -1211   2147   1773       O  
+ATOM    123  N3    C R   7     190.925  37.163 143.624  1.00 68.56           N  
+ANISOU  123  N3    C R   7     7589   8903   9557  -1304   1992   1640       N  
+ATOM    124  C4    C R   7     190.493  37.614 144.802  1.00 69.51           C  
+ANISOU  124  C4    C R   7     7810   8830   9769  -1372   1868   1564       C  
+ATOM    125  N4    C R   7     191.016  37.081 145.905  1.00 60.33           N  
+ANISOU  125  N4    C R   7     6591   7654   8678  -1391   1831   1504       N  
+ATOM    126  C5    C R   7     189.507  38.642 144.894  1.00 73.36           C  
+ANISOU  126  C5    C R   7     8467   9133  10275  -1414   1774   1544       C  
+ATOM    127  C6    C R   7     189.035  39.144 143.744  1.00 73.95           C  
+ANISOU  127  C6    C R   7     8595   9228  10274  -1392   1810   1609       C  
+ATOM    128  P     G R   8     184.493  37.713 140.329  1.00 73.76           P  
+ANISOU  128  P     G R   8     8929   9241   9857   -827   1978   1257       P  
+ATOM    129  OP1   G R   8     183.444  37.869 139.285  1.00 77.97           O  
+ANISOU  129  OP1   G R   8     9565   9761  10300   -733   1988   1230       O  
+ATOM    130  OP2   G R   8     184.128  37.560 141.768  1.00 72.57           O  
+ANISOU  130  OP2   G R   8     8813   8965   9797   -847   1894   1133       O  
+ATOM    131  O5'   G R   8     185.368  36.457 139.920  1.00 63.99           O  
+ANISOU  131  O5'   G R   8     7553   8200   8559   -748   2094   1262       O  
+ATOM    132  C5'   G R   8     185.853  36.317 138.588  1.00 62.12           C  
+ANISOU  132  C5'   G R   8     7259   8126   8217   -699   2197   1367       C  
+ATOM    133  C4'   G R   8     186.569  35.010 138.439  1.00 63.16           C  
+ANISOU  133  C4'   G R   8     7275   8427   8295   -595   2289   1330       C  
+ATOM    134  O4'   G R   8     187.667  34.978 139.393  1.00 62.82           O  
+ANISOU  134  O4'   G R   8     7112   8411   8345   -692   2278   1377       O  
+ATOM    135  C3'   G R   8     185.713  33.786 138.752  1.00 65.12           C  
+ANISOU  135  C3'   G R   8     7584   8643   8514   -453   2275   1136       C  
+ATOM    136  O3'   G R   8     186.217  32.675 138.029  1.00 77.83           O  
+ANISOU  136  O3'   G R   8     9126  10422  10022   -319   2367   1119       O  
+ATOM    137  C2'   G R   8     186.034  33.546 140.216  1.00 61.77           C  
+ANISOU  137  C2'   G R   8     7122   8143   8204   -522   2213   1073       C  
+ATOM    138  O2'   G R   8     185.753  32.242 140.684  1.00 66.27           O  
+ANISOU  138  O2'   G R   8     7698   8723   8759   -416   2211    924       O  
+ATOM    139  C1'   G R   8     187.524  33.853 140.225  1.00 48.81           C  
+ANISOU  139  C1'   G R   8     5331   6621   6595   -613   2261   1225       C  
+ATOM    140  N9    G R   8     188.052  34.146 141.551  1.00 52.78           N  
+ANISOU  140  N9    G R   8     5791   7039   7223   -735   2189   1229       N  
+ATOM    141  C8    G R   8     187.383  34.876 142.496  1.00 63.64           C  
+ANISOU  141  C8    G R   8     7267   8225   8687   -822   2079   1180       C  
+ATOM    142  N7    G R   8     188.025  34.959 143.622  1.00 67.01           N  
+ANISOU  142  N7    G R   8     7644   8605   9212   -913   2025   1184       N  
+ATOM    143  C5    G R   8     189.178  34.221 143.423  1.00 53.65           C  
+ANISOU  143  C5    G R   8     5802   7083   7500   -886   2102   1237       C  
+ATOM    144  C6    G R   8     190.242  33.966 144.327  1.00 57.37           C  
+ANISOU  144  C6    G R   8     6160   7587   8049   -952   2081   1262       C  
+ATOM    145  O6    G R   8     190.374  34.363 145.493  1.00 54.15           O  
+ANISOU  145  O6    G R   8     5773   7057   7745  -1055   1987   1245       O  
+ATOM    146  N1    G R   8     191.222  33.163 143.748  1.00 62.47           N  
+ANISOU  146  N1    G R   8     6660   8436   8638   -878   2180   1311       N  
+ATOM    147  C2    G R   8     191.164  32.683 142.458  1.00 56.02           C  
+ANISOU  147  C2    G R   8     5821   7769   7697   -750   2286   1330       C  
+ATOM    148  N2    G R   8     192.215  31.933 142.109  1.00 57.66           N  
+ANISOU  148  N2    G R   8     5880   8171   7857   -677   2370   1371       N  
+ATOM    149  N3    G R   8     190.165  32.906 141.601  1.00 48.49           N  
+ANISOU  149  N3    G R   8     4981   6778   6666   -690   2303   1305       N  
+ATOM    150  C4    G R   8     189.211  33.691 142.147  1.00 49.53           C  
+ANISOU  150  C4    G R   8     5245   6714   6859   -768   2207   1261       C  
+ATOM    151  P     A R   9     185.823  32.405 136.500  1.00 77.05           P  
+ANISOU  151  P     A R   9     9078  10426   9774   -184   2439   1133       P  
+ATOM    152  OP1   A R   9     186.089  33.636 135.716  1.00 81.66           O  
+ANISOU  152  OP1   A R   9     9654  11038  10334   -274   2468   1302       O  
+ATOM    153  OP2   A R   9     184.485  31.764 136.456  1.00 79.67           O  
+ANISOU  153  OP2   A R   9     9540  10658  10071    -79   2384    971       O  
+ATOM    154  O5'   A R   9     186.877  31.292 136.090  1.00 65.97           O  
+ANISOU  154  O5'   A R   9     7556   9222   8287    -65   2536   1139       O  
+ATOM    155  C5'   A R   9     188.264  31.508 136.299  1.00 70.79           C  
+ANISOU  155  C5'   A R   9     8006   9962   8931   -138   2593   1266       C  
+ATOM    156  C4'   A R   9     189.057  30.957 135.149  1.00 70.80           C  
+ANISOU  156  C4'   A R   9     7919  10192   8791     -7   2715   1333       C  
+ATOM    157  O4'   A R   9     190.477  31.256 135.314  1.00 69.28           O  
+ANISOU  157  O4'   A R   9     7541  10152   8630    -89   2779   1481       O  
+ATOM    158  C3'   A R   9     188.960  29.445 134.969  1.00 71.03           C  
+ANISOU  158  C3'   A R   9     7971  10286   8729    198   2734   1182       C  
+ATOM    159  O3'   A R   9     189.023  29.178 133.570  1.00 83.85           O  
+ANISOU  159  O3'   A R   9     9608  12061  10190    342   2824   1218       O  
+ATOM    160  C2'   A R   9     190.248  28.959 135.630  1.00 70.31           C  
+ANISOU  160  C2'   A R   9     7718  10315   8683    193   2769   1211       C  
+ATOM    161  O2'   A R   9     190.688  27.683 135.219  1.00 68.36           O  
+ANISOU  161  O2'   A R   9     7439  10208   8326    392   2821   1132       O  
+ATOM    162  C1'   A R   9     191.213  30.055 135.202  1.00 71.01           C  
+ANISOU  162  C1'   A R   9     7667  10534   8778     67   2844   1426       C  
+ATOM    163  N9    A R   9     192.453  30.154 135.983  1.00 74.09           N  
+ANISOU  163  N9    A R   9     7883  11011   9259    -27   2857   1511       N  
+ATOM    164  C8    A R   9     193.705  29.740 135.581  1.00 82.39           C  
+ANISOU  164  C8    A R   9     8762  12298  10245     42   2950   1590       C  
+ATOM    165  N7    A R   9     194.666  29.940 136.453  1.00 80.18           N  
+ANISOU  165  N7    A R   9     8351  12041  10073    -75   2914   1643       N  
+ATOM    166  C5    A R   9     193.992  30.532 137.509  1.00 69.23           C  
+ANISOU  166  C5    A R   9     7046  10429   8830   -226   2819   1619       C  
+ATOM    167  C6    A R   9     194.455  30.983 138.748  1.00 65.88           C  
+ANISOU  167  C6    A R   9     6562   9908   8560   -392   2737   1649       C  
+ATOM    168  N6    A R   9     195.740  30.902 139.108  1.00 64.97           N  
+ANISOU  168  N6    A R   9     6267   9932   8486   -438   2757   1733       N  
+ATOM    169  N1    A R   9     193.535  31.523 139.584  1.00 69.75           N  
+ANISOU  169  N1    A R   9     7196  10154   9154   -502   2619   1578       N  
+ATOM    170  C2    A R   9     192.251  31.589 139.174  1.00 73.99           C  
+ANISOU  170  C2    A R   9     7907  10565   9642   -448   2592   1488       C  
+ATOM    171  N3    A R   9     191.690  31.203 138.032  1.00 69.17           N  
+ANISOU  171  N3    A R   9     7364  10021   8897   -304   2656   1455       N  
+ATOM    172  C4    A R   9     192.633  30.671 137.239  1.00 69.55           C  
+ANISOU  172  C4    A R   9     7280  10302   8843   -198   2769   1523       C  
+ATOM    173  P     C R  10     187.778  28.529 132.791  1.00 98.96           P  
+ANISOU  173  P     C R  10    11700  13906  11994    498   2790   1082       P  
+ATOM    174  OP1   C R  10     187.697  29.230 131.482  1.00 93.94           O  
+ANISOU  174  OP1   C R  10    11088  13359  11246    519   2861   1200       O  
+ATOM    175  OP2   C R  10     186.575  28.476 133.665  1.00 82.61           O  
+ANISOU  175  OP2   C R  10     9754  11609  10024    440   2665    950       O  
+ATOM    176  O5'   C R  10     188.264  27.032 132.561  1.00 90.58           O  
+ANISOU  176  O5'   C R  10    10619  12969  10830    707   2824    976       O  
+ATOM    177  C5'   C R  10     188.082  26.047 133.570  1.00 88.50           C  
+ANISOU  177  C5'   C R  10    10386  12609  10631    741   2741    826       C  
+ATOM    178  C4'   C R  10     188.538  24.689 133.102  1.00 83.66           C  
+ANISOU  178  C4'   C R  10     9776  12118   9891    961   2769    736       C  
+ATOM    179  O4'   C R  10     187.933  24.413 131.811  1.00 86.31           O  
+ANISOU  179  O4'   C R  10    10229  12493  10072   1110   2790    706       O  
+ATOM    180  C3'   C R  10     190.044  24.554 132.909  1.00 85.20           C  
+ANISOU  180  C3'   C R  10     9791  12542  10039   1020   2879    835       C  
+ATOM    181  O3'   C R  10     190.468  23.239 133.262  1.00 88.68           O  
+ANISOU  181  O3'   C R  10    10230  13021  10444   1175   2851    712       O  
+ATOM    182  C2'   C R  10     190.225  24.768 131.410  1.00 90.32           C  
+ANISOU  182  C2'   C R  10    10438  13363  10517   1140   2986    921       C  
+ATOM    183  O2'   C R  10     191.369  24.141 130.867  1.00 93.39           O  
+ANISOU  183  O2'   C R  10    10725  13957  10801   1282   3042    935       O  
+ATOM    184  C1'   C R  10     188.937  24.171 130.844  1.00 91.05           C  
+ANISOU  184  C1'   C R  10    10740  13326  10528   1256   2909    780       C  
+ATOM    185  N1    C R  10     188.541  24.774 129.556  1.00 93.61           N  
+ANISOU  185  N1    C R  10    11124  13711  10732   1296   2967    858       N  
+ATOM    186  C2    C R  10     187.585  25.805 129.427  1.00 98.00           C  
+ANISOU  186  C2    C R  10    11764  14128  11345   1154   2926    904       C  
+ATOM    187  O2    C R  10     186.988  26.269 130.411  1.00101.31           O  
+ANISOU  187  O2    C R  10    12209  14367  11916    993   2839    876       O  
+ATOM    188  N3    C R  10     187.306  26.298 128.191  1.00 95.25           N  
+ANISOU  188  N3    C R  10    11471  13847  10873   1204   2981    978       N  
+ATOM    189  C4    C R  10     187.927  25.822 127.107  1.00 96.89           C  
+ANISOU  189  C4    C R  10    11654  14256  10902   1387   3079   1009       C  
+ATOM    190  N4    C R  10     187.615  26.338 125.914  1.00 95.63           N  
+ANISOU  190  N4    C R  10    11561  14149  10624   1424   3119   1079       N  
+ATOM    191  C5    C R  10     188.899  24.787 127.201  1.00 95.37           C  
+ANISOU  191  C5    C R  10    11387  14184  10667   1515   3079    943       C  
+ATOM    192  C6    C R  10     189.165  24.310 128.426  1.00 92.94           C  
+ANISOU  192  C6    C R  10    11020  13818  10476   1476   3043    878       C  
+ATOM    193  P     A R  11     191.069  22.946 134.726  1.00100.35           P  
+ANISOU  193  P     A R  11    11617  14442  12068   1083   2794    678       P  
+ATOM    194  OP1   A R  11     191.859  21.685 134.677  1.00 90.71           O  
+ANISOU  194  OP1   A R  11    10360  13344  10762   1284   2806    596       O  
+ATOM    195  OP2   A R  11     189.947  23.064 135.697  1.00 94.84           O  
+ANISOU  195  OP2   A R  11    11043  13496  11496    949   2669    586       O  
+ATOM    196  O5'   A R  11     192.114  24.128 134.956  1.00 84.39           O  
+ANISOU  196  O5'   A R  11     9397  12539  10129    916   2878    872       O  
+ATOM    197  C5'   A R  11     193.156  24.356 134.020  1.00 79.45           C  
+ANISOU  197  C5'   A R  11     8631  12156   9400    982   2996   1000       C  
+ATOM    198  C4'   A R  11     194.460  24.692 134.690  1.00 80.11           C  
+ANISOU  198  C4'   A R  11     8521  12338   9578    869   3004   1096       C  
+ATOM    199  O4'   A R  11     194.463  26.076 135.121  1.00 74.63           O  
+ANISOU  199  O4'   A R  11     7768  11577   9011    621   3001   1242       O  
+ATOM    200  C3'   A R  11     194.814  23.920 135.953  1.00 76.41           C  
+ANISOU  200  C3'   A R  11     8007  11822   9205    887   2956   1008       C  
+ATOM    201  O3'   A R  11     195.293  22.608 135.698  1.00 75.30           O  
+ANISOU  201  O3'   A R  11     7872  11780   8958   1113   2950    891       O  
+ATOM    202  C2'   A R  11     195.855  24.827 136.600  1.00 73.73           C  
+ANISOU  202  C2'   A R  11     7487  11537   8990    688   2958   1153       C  
+ATOM    203  O2'   A R  11     197.121  24.651 135.983  1.00 83.86           O  
+ANISOU  203  O2'   A R  11     8629  13035  10199    759   3002   1214       O  
+ATOM    204  C1'   A R  11     195.317  26.220 136.238  1.00 72.63           C  
+ANISOU  204  C1'   A R  11     7380  11326   8891    502   2969   1283       C  
+ATOM    205  N9    A R  11     194.564  26.834 137.346  1.00 74.67           N  
+ANISOU  205  N9    A R  11     7709  11358   9306    323   2889   1270       N  
+ATOM    206  C8    A R  11     193.219  27.102 137.444  1.00 74.22           C  
+ANISOU  206  C8    A R  11     7840  11087   9273    278   2811   1185       C  
+ATOM    207  N7    A R  11     192.882  27.664 138.583  1.00 73.12           N  
+ANISOU  207  N7    A R  11     7737  10763   9281    109   2713   1169       N  
+ATOM    208  C5    A R  11     194.087  27.774 139.277  1.00 72.44           C  
+ANISOU  208  C5    A R  11     7483  10763   9276     30   2721   1250       C  
+ATOM    209  C6    A R  11     194.436  28.286 140.551  1.00 68.94           C  
+ANISOU  209  C6    A R  11     6993  10211   8989   -143   2639   1277       C  
+ATOM    210  N6    A R  11     193.562  28.806 141.416  1.00 63.78           N  
+ANISOU  210  N6    A R  11     6466   9330   8438   -266   2533   1218       N  
+ATOM    211  N1    A R  11     195.733  28.238 140.927  1.00 64.70           N  
+ANISOU  211  N1    A R  11     6272   9812   8497   -180   2666   1365       N  
+ATOM    212  C2    A R  11     196.616  27.705 140.074  1.00 69.21           C  
+ANISOU  212  C2    A R  11     6708  10630   8960    -43   2777   1422       C  
+ATOM    213  N3    A R  11     196.415  27.200 138.858  1.00 72.90           N  
+ANISOU  213  N3    A R  11     7209  11220   9268    133   2859   1396       N  
+ATOM    214  C4    A R  11     195.122  27.265 138.520  1.00 73.85           C  
+ANISOU  214  C4    A R  11     7516  11190   9352    159   2830   1315       C  
+ATOM    215  P     A R  12     194.776  21.369 136.589  1.00 94.96           P  
+ANISOU  215  P     A R  12    10483  14123  11474   1219   2854    702       P  
+ATOM    216  OP1   A R  12     195.105  20.113 135.854  1.00 92.45           O  
+ANISOU  216  OP1   A R  12    10206  13927  10993   1494   2868    598       O  
+ATOM    217  OP2   A R  12     193.376  21.657 137.015  1.00 80.08           O  
+ANISOU  217  OP2   A R  12     8780  11980   9666   1094   2751    626       O  
+ATOM    218  O5'   A R  12     195.723  21.384 137.872  1.00 77.08           O  
+ANISOU  218  O5'   A R  12     8072  11864   9351   1113   2820    729       O  
+ATOM    219  C5'   A R  12     197.131  21.284 137.733  1.00 77.69           C  
+ANISOU  219  C5'   A R  12     7952  12164   9402   1170   2886    811       C  
+ATOM    220  C4'   A R  12     197.839  21.913 138.903  1.00 75.03           C  
+ANISOU  220  C4'   A R  12     7462  11813   9233    977   2867    904       C  
+ATOM    221  O4'   A R  12     197.548  23.334 138.932  1.00 79.79           O  
+ANISOU  221  O4'   A R  12     8041  12349   9926    739   2879   1044       O  
+ATOM    222  C3'   A R  12     197.404  21.413 140.272  1.00 76.64           C  
+ANISOU  222  C3'   A R  12     7766  11795   9558    913   2732    773       C  
+ATOM    223  O3'   A R  12     198.047  20.200 140.640  1.00 82.69           O  
+ANISOU  223  O3'   A R  12     8507  12622  10290   1084   2698    668       O  
+ATOM    224  C2'   A R  12     197.720  22.599 141.183  1.00 68.15           C  
+ANISOU  224  C2'   A R  12     6589  10652   8653    649   2705    898       C  
+ATOM    225  O2'   A R  12     199.098  22.645 141.515  1.00 67.58           O  
+ANISOU  225  O2'   A R  12     6299  10755   8622    635   2743    994       O  
+ATOM    226  C1'   A R  12     197.405  23.777 140.264  1.00 72.31           C  
+ANISOU  226  C1'   A R  12     7102  11223   9152    546   2783   1040       C  
+ATOM    227  N9    A R  12     196.024  24.251 140.465  1.00 67.86           N  
+ANISOU  227  N9    A R  12     6732  10420   8633    440   2708    979       N  
+ATOM    228  C8    A R  12     194.934  24.149 139.635  1.00 65.53           C  
+ANISOU  228  C8    A R  12     6595  10061   8244    518   2715    917       C  
+ATOM    229  N7    A R  12     193.834  24.667 140.154  1.00 71.61           N  
+ANISOU  229  N7    A R  12     7502  10612   9093    388   2632    872       N  
+ATOM    230  C5    A R  12     194.231  25.138 141.406  1.00 66.41           C  
+ANISOU  230  C5    A R  12     6782   9865   8585    221   2567    903       C  
+ATOM    231  C6    A R  12     193.552  25.801 142.453  1.00 62.37           C  
+ANISOU  231  C6    A R  12     6355   9142   8203     48   2468    878       C  
+ATOM    232  N6    A R  12     192.259  26.121 142.418  1.00 58.96           N  
+ANISOU  232  N6    A R  12     6082   8548   7773     12   2420    816       N  
+ATOM    233  N1    A R  12     194.251  26.120 143.566  1.00 65.27           N  
+ANISOU  233  N1    A R  12     6635   9471   8693    -80   2417    917       N  
+ATOM    234  C2    A R  12     195.552  25.813 143.617  1.00 66.83           C  
+ANISOU  234  C2    A R  12     6662   9838   8893    -46   2460    983       C  
+ATOM    235  N3    A R  12     196.295  25.198 142.707  1.00 72.38           N  
+ANISOU  235  N3    A R  12     7260  10758   9485    113   2557   1014       N  
+ATOM    236  C4    A R  12     195.571  24.881 141.613  1.00 71.19           C  
+ANISOU  236  C4    A R  12     7209  10636   9204    246   2608    968       C  
+ATOM    237  P     U R  13     197.341  19.191 141.677  1.00 91.29           P  
+ANISOU  237  P     U R  13     9778  13479  11428   1111   2547    479       P  
+ATOM    238  OP1   U R  13     198.180  17.974 141.817  1.00 88.93           O  
+ANISOU  238  OP1   U R  13     9439  13284  11068   1316   2526    392       O  
+ATOM    239  OP2   U R  13     195.902  19.101 141.294  1.00 90.92           O  
+ANISOU  239  OP2   U R  13     9947  13261  11339   1111   2500    392       O  
+ATOM    240  O5'   U R  13     197.447  19.936 143.077  1.00 80.12           O  
+ANISOU  240  O5'   U R  13     8315  11923  10203    863   2474    526       O  
+ATOM    241  C5'   U R  13     198.698  20.123 143.713  1.00 76.99           C  
+ANISOU  241  C5'   U R  13     7727  11640   9887    811   2484    608       C  
+ATOM    242  C4'   U R  13     198.508  20.771 145.059  1.00 70.36           C  
+ANISOU  242  C4'   U R  13     6904  10613   9217    581   2388    622       C  
+ATOM    243  O4'   U R  13     197.961  22.107 144.898  1.00 65.14           O  
+ANISOU  243  O4'   U R  13     6255   9881   8615    388   2411    730       O  
+ATOM    244  C3'   U R  13     197.510  20.093 145.973  1.00 74.94           C  
+ANISOU  244  C3'   U R  13     7687  10952   9834    569   2261    459       C  
+ATOM    245  O3'   U R  13     198.025  18.938 146.597  1.00 87.82           O  
+ANISOU  245  O3'   U R  13     9325  12584  11459    688   2193    355       O  
+ATOM    246  C2'   U R  13     197.132  21.211 146.936  1.00 69.16           C  
+ANISOU  246  C2'   U R  13     6971  10059   9249    320   2205    517       C  
+ATOM    247  O2'   U R  13     198.159  21.417 147.894  1.00 81.03           O  
+ANISOU  247  O2'   U R  13     8341  11588  10859    230   2166    571       O  
+ATOM    248  C1'   U R  13     197.117  22.414 145.996  1.00 67.72           C  
+ANISOU  248  C1'   U R  13     6715   9965   9052    236   2301    666       C  
+ATOM    249  N1    U R  13     195.750  22.706 145.505  1.00 66.48           N  
+ANISOU  249  N1    U R  13     6727   9681   8853    219   2296    620       N  
+ATOM    250  C2    U R  13     194.924  23.427 146.342  1.00 70.15           C  
+ANISOU  250  C2    U R  13     7291   9945   9418     49   2219    606       C  
+ATOM    251  O2    U R  13     195.276  23.819 147.438  1.00 81.15           O  
+ANISOU  251  O2    U R  13     8649  11260  10926    -82   2155    626       O  
+ATOM    252  N3    U R  13     193.666  23.658 145.860  1.00 58.71           N  
+ANISOU  252  N3    U R  13     5987   8394   7925     48   2216    561       N  
+ATOM    253  C4    U R  13     193.174  23.263 144.631  1.00 61.81           C  
+ANISOU  253  C4    U R  13     6437   8857   8190    188   2276    535       C  
+ATOM    254  O4    U R  13     192.019  23.544 144.317  1.00 66.38           O  
+ANISOU  254  O4    U R  13     7143   9331   8746    168   2259    498       O  
+ATOM    255  C5    U R  13     194.085  22.519 143.820  1.00 59.67           C  
+ANISOU  255  C5    U R  13     6070   8785   7815    361   2351    550       C  
+ATOM    256  C6    U R  13     195.310  22.272 144.279  1.00 66.75           C  
+ANISOU  256  C6    U R  13     6819   9792   8749    374   2361    590       C  
+ATOM    257  P     A R  14     197.036  17.716 146.907  1.00 98.01           P  
+ANISOU  257  P     A R  14    10842  13701  12698    791   2087    171       P  
+ATOM    258  OP1   A R  14     197.703  16.822 147.890  1.00 98.23           O  
+ANISOU  258  OP1   A R  14    10859  13700  12763    844   1998     94       O  
+ATOM    259  OP2   A R  14     196.559  17.200 145.595  1.00 90.24           O  
+ANISOU  259  OP2   A R  14     9940  12787  11562    970   2140    126       O  
+ATOM    260  O5'   A R  14     195.803  18.405 147.641  1.00 76.88           O  
+ANISOU  260  O5'   A R  14     8300  10798  10115    587   2022    153       O  
+ATOM    261  C5'   A R  14     195.237  17.821 148.800  1.00 72.73           C  
+ANISOU  261  C5'   A R  14     7905  10085   9644    533   1900     44       C  
+ATOM    262  C4'   A R  14     194.865  18.864 149.818  1.00 70.11           C  
+ANISOU  262  C4'   A R  14     7577   9620   9443    309   1862     92       C  
+ATOM    263  O4'   A R  14     194.922  20.185 149.216  1.00 74.42           O  
+ANISOU  263  O4'   A R  14     8031  10230  10014    208   1948    224       O  
+ATOM    264  C3'   A R  14     193.448  18.767 150.347  1.00 72.29           C  
+ANISOU  264  C3'   A R  14     8036   9700   9732    232   1788      3       C  
+ATOM    265  O3'   A R  14     193.289  17.795 151.359  1.00 79.23           O  
+ANISOU  265  O3'   A R  14     9010  10466  10628    243   1682   -103       O  
+ATOM    266  C2'   A R  14     193.175  20.183 150.804  1.00 70.50           C  
+ANISOU  266  C2'   A R  14     7777   9407   9604     40   1800     91       C  
+ATOM    267  O2'   A R  14     193.854  20.439 152.024  1.00 81.50           O  
+ANISOU  267  O2'   A R  14     9112  10752  11102    -66   1741    112       O  
+ATOM    268  C1'   A R  14     193.849  20.971 149.687  1.00 67.14           C  
+ANISOU  268  C1'   A R  14     7212   9145   9151     58   1910    220       C  
+ATOM    269  N9    A R  14     192.906  21.156 148.572  1.00 62.23           N  
+ANISOU  269  N9    A R  14     6669   8530   8445    108   1963    216       N  
+ATOM    270  C8    A R  14     192.935  20.593 147.319  1.00 53.12           C  
+ANISOU  270  C8    A R  14     5518   7498   7169    273   2028    205       C  
+ATOM    271  N7    A R  14     191.922  20.946 146.563  1.00 58.06           N  
+ANISOU  271  N7    A R  14     6233   8085   7743    274   2053    202       N  
+ATOM    272  C5    A R  14     191.177  21.790 147.384  1.00 58.05           C  
+ANISOU  272  C5    A R  14     6286   7932   7838    104   2003    209       C  
+ATOM    273  C6    A R  14     189.982  22.515 147.198  1.00 53.95           C  
+ANISOU  273  C6    A R  14     5862   7311   7325     29   1996    208       C  
+ATOM    274  N6    A R  14     189.265  22.500 146.067  1.00 57.58           N  
+ANISOU  274  N6    A R  14     6385   7799   7694    107   2036    200       N  
+ATOM    275  N1    A R  14     189.523  23.255 148.237  1.00 60.41           N  
+ANISOU  275  N1    A R  14     6714   7996   8242   -121   1938    209       N  
+ATOM    276  C2    A R  14     190.216  23.275 149.378  1.00 56.71           C  
+ANISOU  276  C2    A R  14     6195   7492   7860   -198   1890    213       C  
+ATOM    277  N3    A R  14     191.352  22.654 149.670  1.00 60.72           N  
+ANISOU  277  N3    A R  14     6612   8081   8378   -150   1888    219       N  
+ATOM    278  C4    A R  14     191.774  21.920 148.625  1.00 61.84           C  
+ANISOU  278  C4    A R  14     6715   8360   8421      5   1948    216       C  
+ATOM    279  P     C R  15     192.132  16.696 151.192  1.00 91.07           P  
+ANISOU  279  P     C R  15    10698  11860  12044    323   1614   -229       P  
+ATOM    280  OP1   C R  15     192.466  15.527 152.050  1.00 88.71           O  
+ANISOU  280  OP1   C R  15    10461  11500  11745    374   1511   -318       O  
+ATOM    281  OP2   C R  15     191.908  16.529 149.728  1.00 83.17           O  
+ANISOU  281  OP2   C R  15     9709  10959  10932    459   1684   -224       O  
+ATOM    282  O5'   C R  15     190.850  17.425 151.790  1.00 62.01           O  
+ANISOU  282  O5'   C R  15     7109   8032   8419    156   1586   -234       O  
+ATOM    283  C5'   C R  15     190.994  18.279 152.906  1.00 61.88           C  
+ANISOU  283  C5'   C R  15     7052   7948   8513     -2   1564   -191       C  
+ATOM    284  C4'   C R  15     189.904  19.319 152.967  1.00 61.97           C  
+ANISOU  284  C4'   C R  15     7111   7879   8554   -122   1581   -165       C  
+ATOM    285  O4'   C R  15     189.956  20.231 151.831  1.00 59.19           O  
+ANISOU  285  O4'   C R  15     6690   7617   8181   -112   1674    -78       O  
+ATOM    286  C3'   C R  15     188.482  18.807 152.936  1.00 52.42           C  
+ANISOU  286  C3'   C R  15     6047   6577   7294   -118   1539   -248       C  
+ATOM    287  O3'   C R  15     188.097  18.203 154.154  1.00 57.29           O  
+ANISOU  287  O3'   C R  15     6746   7084   7938   -177   1449   -318       O  
+ATOM    288  C2'   C R  15     187.712  20.076 152.600  1.00 54.67           C  
+ANISOU  288  C2'   C R  15     6330   6841   7602   -202   1589   -193       C  
+ATOM    289  O2'   C R  15     187.660  20.923 153.738  1.00 55.50           O  
+ANISOU  289  O2'   C R  15     6426   6865   7796   -337   1558   -171       O  
+ATOM    290  C1'   C R  15     188.649  20.729 151.580  1.00 57.86           C  
+ANISOU  290  C1'   C R  15     6613   7375   7998   -159   1677    -94       C  
+ATOM    291  N1    C R  15     188.264  20.432 150.173  1.00 61.03           N  
+ANISOU  291  N1    C R  15     7040   7852   8299    -41   1732    -97       N  
+ATOM    292  C2    C R  15     187.103  21.015 149.650  1.00 54.57           C  
+ANISOU  292  C2    C R  15     6287   6989   7457    -71   1748    -96       C  
+ATOM    293  O2    C R  15     186.413  21.747 150.373  1.00 52.09           O  
+ANISOU  293  O2    C R  15     6008   6580   7204   -185   1720    -95       O  
+ATOM    294  N3    C R  15     186.748  20.768 148.363  1.00 45.81           N  
+ANISOU  294  N3    C R  15     5207   5944   6255     36   1791    -98       N  
+ATOM    295  C4    C R  15     187.496  19.970 147.593  1.00 50.70           C  
+ANISOU  295  C4    C R  15     5797   6670   6797    176   1821   -104       C  
+ATOM    296  N4    C R  15     187.094  19.777 146.333  1.00 50.36           N  
+ANISOU  296  N4    C R  15     5795   6684   6656    282   1859   -109       N  
+ATOM    297  C5    C R  15     188.686  19.364 148.090  1.00 53.45           C  
+ANISOU  297  C5    C R  15     6073   7073   7163    220   1809   -109       C  
+ATOM    298  C6    C R  15     189.024  19.617 149.369  1.00 57.32           C  
+ANISOU  298  C6    C R  15     6530   7495   7752    105   1763   -104       C  
+ATOM    299  P     U R  16     187.146  16.904 154.150  1.00 55.24           P  
+ANISOU  299  P     U R  16     6626   6758   7605   -125   1375   -417       P  
+ATOM    300  OP1   U R  16     187.075  16.424 155.559  1.00 61.51           O  
+ANISOU  300  OP1   U R  16     7477   7455   8440   -206   1288   -463       O  
+ATOM    301  OP2   U R  16     187.488  16.015 153.019  1.00 52.49           O  
+ANISOU  301  OP2   U R  16     6293   6483   7168     33   1383   -443       O  
+ATOM    302  O5'   U R  16     185.707  17.487 153.839  1.00 53.64           O  
+ANISOU  302  O5'   U R  16     6483   6511   7387   -187   1394   -418       O  
+ATOM    303  C5'   U R  16     185.199  18.567 154.607  1.00 52.51           C  
+ANISOU  303  C5'   U R  16     6326   6315   7308   -313   1405   -389       C  
+ATOM    304  C4'   U R  16     184.089  19.265 153.876  1.00 43.89           C  
+ANISOU  304  C4'   U R  16     5259   5226   6193   -325   1447   -374       C  
+ATOM    305  O4'   U R  16     184.591  19.781 152.622  1.00 46.34           O  
+ANISOU  305  O4'   U R  16     5503   5625   6478   -254   1524   -314       O  
+ATOM    306  C3'   U R  16     182.911  18.402 153.471  1.00 43.14           C  
+ANISOU  306  C3'   U R  16     5260   5104   6027   -292   1406   -436       C  
+ATOM    307  O3'   U R  16     182.001  18.201 154.541  1.00 52.92           O  
+ANISOU  307  O3'   U R  16     6558   6267   7281   -383   1349   -476       O  
+ATOM    308  C2'   U R  16     182.307  19.201 152.320  1.00 38.06           C  
+ANISOU  308  C2'   U R  16     4603   4503   5355   -262   1470   -399       C  
+ATOM    309  O2'   U R  16     181.523  20.279 152.825  1.00 39.81           O  
+ANISOU  309  O2'   U R  16     4820   4685   5622   -354   1484   -380       O  
+ATOM    310  C1'   U R  16     183.556  19.788 151.664  1.00 42.12           C  
+ANISOU  310  C1'   U R  16     5023   5099   5883   -213   1541   -328       C  
+ATOM    311  N1    U R  16     184.003  19.054 150.457  1.00 44.82           N  
+ANISOU  311  N1    U R  16     5365   5521   6144    -77   1564   -334       N  
+ATOM    312  C2    U R  16     183.262  19.223 149.309  1.00 51.27           C  
+ANISOU  312  C2    U R  16     6217   6365   6899    -22   1595   -329       C  
+ATOM    313  O2    U R  16     182.261  19.916 149.275  1.00 55.64           O  
+ANISOU  313  O2    U R  16     6796   6879   7466    -82   1599   -321       O  
+ATOM    314  N3    U R  16     183.726  18.533 148.215  1.00 47.10           N  
+ANISOU  314  N3    U R  16     5698   5913   6286    115   1614   -337       N  
+ATOM    315  C4    U R  16     184.843  17.722 148.161  1.00 50.21           C  
+ANISOU  315  C4    U R  16     6063   6363   6651    210   1609   -352       C  
+ATOM    316  O4    U R  16     185.149  17.198 147.103  1.00 62.22           O  
+ANISOU  316  O4    U R  16     7599   7959   8084    348   1631   -362       O  
+ATOM    317  C5    U R  16     185.576  17.607 149.378  1.00 40.03           C  
+ANISOU  317  C5    U R  16     4729   5045   5436    146   1577   -354       C  
+ATOM    318  C6    U R  16     185.134  18.272 150.452  1.00 39.32           C  
+ANISOU  318  C6    U R  16     4636   4874   5430      3   1556   -344       C  
+ATOM    319  P     A R  17     181.324  16.763 154.787  1.00 51.44           P  
+ANISOU  319  P     A R  17     6471   6033   7039   -379   1258   -543       P  
+ATOM    320  OP1   A R  17     180.808  16.807 156.171  1.00 53.89           O  
+ANISOU  320  OP1   A R  17     6807   6285   7384   -492   1217   -559       O  
+ATOM    321  OP2   A R  17     182.259  15.679 154.346  1.00 51.48           O  
+ANISOU  321  OP2   A R  17     6501   6055   7006   -276   1221   -569       O  
+ATOM    322  O5'   A R  17     180.102  16.716 153.766  1.00 43.73           O  
+ANISOU  322  O5'   A R  17     5537   5072   6006   -352   1263   -553       O  
+ATOM    323  C5'   A R  17     179.341  17.876 153.461  1.00 50.26           C  
+ANISOU  323  C5'   A R  17     6328   5919   6850   -384   1322   -521       C  
+ATOM    324  C4'   A R  17     178.611  17.698 152.153  1.00 47.29           C  
+ANISOU  324  C4'   A R  17     5985   5573   6412   -316   1327   -526       C  
+ATOM    325  O4'   A R  17     179.575  17.781 151.077  1.00 45.14           O  
+ANISOU  325  O4'   A R  17     5683   5357   6112   -208   1377   -500       O  
+ATOM    326  C3'   A R  17     177.855  16.359 151.992  1.00 51.38           C  
+ANISOU  326  C3'   A R  17     6595   6056   6870   -307   1234   -578       C  
+ATOM    327  O3'   A R  17     176.499  16.569 151.628  1.00 61.01           O  
+ANISOU  327  O3'   A R  17     7835   7279   8069   -339   1222   -581       O  
+ATOM    328  C2'   A R  17     178.555  15.654 150.829  1.00 50.55           C  
+ANISOU  328  C2'   A R  17     6526   5979   6703   -174   1225   -592       C  
+ATOM    329  O2'   A R  17     177.655  15.065 149.909  1.00 53.89           O  
+ANISOU  329  O2'   A R  17     7024   6393   7059   -131   1174   -619       O  
+ATOM    330  C1'   A R  17     179.334  16.763 150.125  1.00 44.58           C  
+ANISOU  330  C1'   A R  17     5683   5293   5961   -116   1332   -537       C  
+ATOM    331  N9    A R  17     180.610  16.248 149.647  1.00 40.37           N  
+ANISOU  331  N9    A R  17     5136   4805   5396     -7   1347   -538       N  
+ATOM    332  C8    A R  17     181.677  15.846 150.417  1.00 40.08           C  
+ANISOU  332  C8    A R  17     5073   4765   5392     -4   1330   -545       C  
+ATOM    333  N7    A R  17     182.686  15.369 149.723  1.00 38.89           N  
+ANISOU  333  N7    A R  17     4908   4676   5194    123   1347   -547       N  
+ATOM    334  C5    A R  17     182.226  15.434 148.419  1.00 40.43           C  
+ANISOU  334  C5    A R  17     5132   4913   5317    208   1376   -544       C  
+ATOM    335  C6    A R  17     182.828  15.062 147.218  1.00 50.29           C  
+ANISOU  335  C6    A R  17     6386   6241   6479    365   1406   -546       C  
+ATOM    336  N6    A R  17     184.058  14.545 147.183  1.00 50.43           N  
+ANISOU  336  N6    A R  17     6368   6319   6474    466   1416   -553       N  
+ATOM    337  N1    A R  17     182.122  15.248 146.072  1.00 54.91           N  
+ANISOU  337  N1    A R  17     7014   6850   7000    420   1426   -542       N  
+ATOM    338  C2    A R  17     180.888  15.783 146.153  1.00 43.45           C  
+ANISOU  338  C2    A R  17     5590   5345   5576    321   1413   -536       C  
+ATOM    339  N3    A R  17     180.210  16.154 147.237  1.00 41.34           N  
+ANISOU  339  N3    A R  17     5312   5009   5386    177   1386   -534       N  
+ATOM    340  C4    A R  17     180.949  15.955 148.343  1.00 42.37           C  
+ANISOU  340  C4    A R  17     5407   5119   5573    128   1371   -538       C  
+ATOM    341  P     A R  18     175.338  15.609 152.189  1.00 46.47           P  
+ANISOU  341  P     A R  18     6057   5396   6204   -422   1124   -612       P  
+ATOM    342  OP1   A R  18     175.057  16.061 153.580  1.00 45.88           O  
+ANISOU  342  OP1   A R  18     5942   5313   6180   -532   1137   -602       O  
+ATOM    343  OP2   A R  18     175.620  14.156 151.955  1.00 46.49           O  
+ANISOU  343  OP2   A R  18     6154   5354   6156   -384   1024   -649       O  
+ATOM    344  O5'   A R  18     174.100  16.027 151.288  1.00 55.49           O  
+ANISOU  344  O5'   A R  18     7196   6570   7318   -414   1132   -604       O  
+ATOM    345  C5'   A R  18     173.669  17.387 151.289  1.00 56.73           C  
+ANISOU  345  C5'   A R  18     7280   6765   7509   -429   1212   -574       C  
+ATOM    346  C4'   A R  18     172.661  17.653 150.202  1.00 52.83           C  
+ANISOU  346  C4'   A R  18     6794   6299   6979   -391   1210   -570       C  
+ATOM    347  O4'   A R  18     173.324  17.756 148.917  1.00 47.89           O  
+ANISOU  347  O4'   A R  18     6189   5689   6317   -279   1241   -562       O  
+ATOM    348  C3'   A R  18     171.630  16.563 149.998  1.00 54.33           C  
+ANISOU  348  C3'   A R  18     7042   6475   7127   -426   1109   -594       C  
+ATOM    349  O3'   A R  18     170.572  16.649 150.931  1.00 59.82           O  
+ANISOU  349  O3'   A R  18     7699   7187   7842   -533   1089   -588       O  
+ATOM    350  C2'   A R  18     171.186  16.783 148.558  1.00 56.36           C  
+ANISOU  350  C2'   A R  18     7322   6753   7340   -341   1111   -591       C  
+ATOM    351  O2'   A R  18     170.241  17.832 148.501  1.00 66.50           O  
+ANISOU  351  O2'   A R  18     8544   8078   8644   -363   1154   -572       O  
+ATOM    352  C1'   A R  18     172.473  17.268 147.901  1.00 47.63           C  
+ANISOU  352  C1'   A R  18     6210   5659   6228   -239   1187   -577       C  
+ATOM    353  N9    A R  18     173.174  16.205 147.146  1.00 46.18           N  
+ANISOU  353  N9    A R  18     6106   5457   5984   -148   1138   -604       N  
+ATOM    354  C8    A R  18     174.445  15.741 147.375  1.00 43.24           C  
+ANISOU  354  C8    A R  18     5745   5077   5609   -100   1148   -613       C  
+ATOM    355  N7    A R  18     174.826  14.832 146.504  1.00 51.56           N  
+ANISOU  355  N7    A R  18     6878   6121   6591      5   1098   -643       N  
+ATOM    356  C5    A R  18     173.727  14.680 145.661  1.00 44.65           C  
+ANISOU  356  C5    A R  18     6055   5238   5671     17   1046   -654       C  
+ATOM    357  C6    A R  18     173.496  13.851 144.537  1.00 56.72           C  
+ANISOU  357  C6    A R  18     7689   6747   7115    114    968   -688       C  
+ATOM    358  N6    A R  18     174.396  12.976 144.066  1.00 64.97           N  
+ANISOU  358  N6    A R  18     8809   7779   8096    231    931   -724       N  
+ATOM    359  N1    A R  18     172.297  13.955 143.905  1.00 51.13           N  
+ANISOU  359  N1    A R  18     7008   6033   6384     95    922   -687       N  
+ATOM    360  C2    A R  18     171.404  14.838 144.387  1.00 49.07           C  
+ANISOU  360  C2    A R  18     6666   5795   6183     -7    959   -655       C  
+ATOM    361  N3    A R  18     171.507  15.652 145.435  1.00 44.62           N  
+ANISOU  361  N3    A R  18     6005   5253   5694    -91   1033   -627       N  
+ATOM    362  C4    A R  18     172.706  15.528 146.034  1.00 43.55           C  
+ANISOU  362  C4    A R  18     5854   5114   5581    -78   1072   -627       C  
+ATOM    363  P     A R  19     169.829  15.315 151.412  1.00 63.57           P  
+ANISOU  363  P     A R  19     8224   7638   8291   -626    973   -598       P  
+ATOM    364  OP1   A R  19     168.748  15.674 152.357  1.00 74.32           O  
+ANISOU  364  OP1   A R  19     9516   9051   9672   -730    983   -578       O  
+ATOM    365  OP2   A R  19     170.883  14.318 151.767  1.00 59.29           O  
+ANISOU  365  OP2   A R  19     7754   7032   7741   -620    921   -618       O  
+ATOM    366  O5'   A R  19     169.157  14.751 150.089  1.00 52.88           O  
+ANISOU  366  O5'   A R  19     6930   6277   6887   -579    900   -606       O  
+ATOM    367  C5'   A R  19     167.996  15.336 149.532  1.00 49.21           C  
+ANISOU  367  C5'   A R  19     6418   5863   6416   -583    908   -592       C  
+ATOM    368  C4'   A R  19     167.707  14.705 148.196  1.00 47.40           C  
+ANISOU  368  C4'   A R  19     6270   5607   6134   -518    830   -607       C  
+ATOM    369  O4'   A R  19     168.890  14.796 147.372  1.00 45.71           O  
+ANISOU  369  O4'   A R  19     6107   5367   5894   -389    870   -624       O  
+ATOM    370  C3'   A R  19     167.412  13.212 148.230  1.00 46.13           C  
+ANISOU  370  C3'   A R  19     6204   5385   5937   -577    684   -618       C  
+ATOM    371  O3'   A R  19     166.079  12.913 148.612  1.00 52.61           O  
+ANISOU  371  O3'   A R  19     6988   6238   6765   -700    614   -591       O  
+ATOM    372  C2'   A R  19     167.759  12.779 146.817  1.00 47.85           C  
+ANISOU  372  C2'   A R  19     6524   5561   6096   -452    634   -648       C  
+ATOM    373  O2'   A R  19     166.721  13.154 145.932  1.00 59.85           O  
+ANISOU  373  O2'   A R  19     8028   7114   7599   -437    614   -638       O  
+ATOM    374  C1'   A R  19     168.964  13.665 146.519  1.00 46.45           C  
+ANISOU  374  C1'   A R  19     6315   5408   5925   -335    764   -653       C  
+ATOM    375  N9    A R  19     170.254  12.973 146.726  1.00 45.43           N  
+ANISOU  375  N9    A R  19     6248   5233   5780   -279    752   -678       N  
+ATOM    376  C8    A R  19     171.198  13.189 147.704  1.00 44.63           C  
+ANISOU  376  C8    A R  19     6102   5133   5721   -300    815   -673       C  
+ATOM    377  N7    A R  19     172.264  12.421 147.626  1.00 43.95           N  
+ANISOU  377  N7    A R  19     6084   5008   5606   -226    782   -702       N  
+ATOM    378  C5    A R  19     171.981  11.630 146.518  1.00 44.43           C  
+ANISOU  378  C5    A R  19     6251   5035   5593   -147    690   -732       C  
+ATOM    379  C6    A R  19     172.708  10.606 145.895  1.00 47.10           C  
+ANISOU  379  C6    A R  19     6707   5325   5862    -30    612   -778       C  
+ATOM    380  N6    A R  19     173.908  10.194 146.331  1.00 44.68           N  
+ANISOU  380  N6    A R  19     6417   5006   5554     27    622   -799       N  
+ATOM    381  N1    A R  19     172.164  10.032 144.800  1.00 49.06           N  
+ANISOU  381  N1    A R  19     7058   5542   6039     37    520   -804       N  
+ATOM    382  C2    A R  19     170.971  10.450 144.368  1.00 48.94           C  
+ANISOU  382  C2    A R  19     7020   5544   6029    -19    506   -782       C  
+ATOM    383  N3    A R  19     170.188  11.390 144.876  1.00 49.82           N  
+ANISOU  383  N3    A R  19     7017   5708   6206   -128    575   -738       N  
+ATOM    384  C4    A R  19     170.760  11.953 145.954  1.00 47.72           C  
+ANISOU  384  C4    A R  19     6659   5471   6004   -183    667   -717       C  
+ATOM    385  P     C R  20     165.790  11.783 149.715  1.00 47.20           P  
+ANISOU  385  P     C R  20     6332   5520   6083   -848    512   -572       P  
+ATOM    386  OP1   C R  20     164.345  11.534 149.815  1.00 47.31           O  
+ANISOU  386  OP1   C R  20     6296   5585   6095   -966    441   -532       O  
+ATOM    387  OP2   C R  20     166.540  12.158 150.936  1.00 48.18           O  
+ANISOU  387  OP2   C R  20     6408   5656   6243   -877    598   -569       O  
+ATOM    388  O5'   C R  20     166.471  10.482 149.086  1.00 47.26           O  
+ANISOU  388  O5'   C R  20     6502   5414   6042   -797    383   -607       O  
+ATOM    389  C5'   C R  20     165.964   9.891 147.897  1.00 49.77           C  
+ANISOU  389  C5'   C R  20     6908   5690   6312   -755    272   -621       C  
+ATOM    390  C4'   C R  20     166.880   8.805 147.397  1.00 52.82           C  
+ANISOU  390  C4'   C R  20     7456   5967   6646   -668    170   -668       C  
+ATOM    391  O4'   C R  20     168.155   9.386 147.015  1.00 49.79           O  
+ANISOU  391  O4'   C R  20     7070   5596   6254   -510    286   -703       O  
+ATOM    392  C3'   C R  20     167.244   7.739 148.418  1.00 53.53           C  
+ANISOU  392  C3'   C R  20     7618   5983   6738   -761     73   -666       C  
+ATOM    393  O3'   C R  20     166.253   6.727 148.520  1.00 53.85           O  
+ANISOU  393  O3'   C R  20     7726   5972   6762   -896    -96   -637       O  
+ATOM    394  C2'   C R  20     168.593   7.246 147.912  1.00 48.93           C  
+ANISOU  394  C2'   C R  20     7151   5330   6112   -600     57   -728       C  
+ATOM    395  O2'   C R  20     168.418   6.401 146.788  1.00 47.25           O  
+ANISOU  395  O2'   C R  20     7084   5040   5829   -521    -82   -764       O  
+ATOM    396  C1'   C R  20     169.215   8.543 147.407  1.00 48.87           C  
+ANISOU  396  C1'   C R  20     7043   5408   6118   -472    237   -736       C  
+ATOM    397  N1    C R  20     170.039   9.236 148.440  1.00 46.19           N  
+ANISOU  397  N1    C R  20     6604   5111   5833   -488    366   -724       N  
+ATOM    398  C2    C R  20     171.372   8.842 148.605  1.00 45.06           C  
+ANISOU  398  C2    C R  20     6513   4931   5677   -396    373   -758       C  
+ATOM    399  O2    C R  20     171.838   7.929 147.897  1.00 48.21           O  
+ANISOU  399  O2    C R  20     7038   5267   6013   -291    278   -803       O  
+ATOM    400  N3    C R  20     172.135   9.451 149.535  1.00 44.72           N  
+ANISOU  400  N3    C R  20     6383   4922   5687   -415    477   -745       N  
+ATOM    401  C4    C R  20     171.637  10.425 150.287  1.00 44.33           C  
+ANISOU  401  C4    C R  20     6214   4935   5696   -512    570   -705       C  
+ATOM    402  N4    C R  20     172.460  10.981 151.181  1.00 42.39           N  
+ANISOU  402  N4    C R  20     5901   4709   5497   -523    656   -697       N  
+ATOM    403  C5    C R  20     170.287  10.855 150.154  1.00 42.28           C  
+ANISOU  403  C5    C R  20     5901   4719   5445   -594    570   -674       C  
+ATOM    404  C6    C R  20     169.542  10.250 149.223  1.00 42.90           C  
+ANISOU  404  C6    C R  20     6053   4771   5478   -581    470   -682       C  
+ATOM    405  P     C R  21     165.896   6.034 149.937  1.00 50.86           P  
+ANISOU  405  P     C R  21     7340   5576   6410  -1091   -168   -586       P  
+ATOM    406  OP1   C R  21     164.700   5.199 149.671  1.00 60.58           O  
+ANISOU  406  OP1   C R  21     8623   6773   7622  -1223   -337   -543       O  
+ATOM    407  OP2   C R  21     165.859   6.993 151.066  1.00 49.44           O  
+ANISOU  407  OP2   C R  21     7002   5501   6283  -1158    -13   -551       O  
+ATOM    408  O5'   C R  21     167.149   5.096 150.215  1.00 49.94           O  
+ANISOU  408  O5'   C R  21     7369   5340   6264  -1026   -243   -634       O  
+ATOM    409  C5'   C R  21     167.493   4.064 149.302  1.00 50.75           C  
+ANISOU  409  C5'   C R  21     7654   5323   6305   -932   -398   -684       C  
+ATOM    410  C4'   C R  21     168.738   3.341 149.735  1.00 48.76           C  
+ANISOU  410  C4'   C R  21     7514   4981   6032   -857   -444   -732       C  
+ATOM    411  O4'   C R  21     169.911   4.163 149.496  1.00 48.01           O  
+ANISOU  411  O4'   C R  21     7357   4943   5943   -685   -281   -777       O  
+ATOM    412  C3'   C R  21     168.835   3.002 151.208  1.00 47.87           C  
+ANISOU  412  C3'   C R  21     7382   4852   5955  -1009   -461   -691       C  
+ATOM    413  O3'   C R  21     168.036   1.886 151.576  1.00 55.45           O  
+ANISOU  413  O3'   C R  21     8444   5727   6897  -1175   -653   -648       O  
+ATOM    414  C2'   C R  21     170.335   2.803 151.390  1.00 48.30           C  
+ANISOU  414  C2'   C R  21     7497   4858   5995   -862   -432   -755       C  
+ATOM    415  O2'   C R  21     170.749   1.563 150.850  1.00 46.55           O  
+ANISOU  415  O2'   C R  21     7476   4501   5709   -779   -614   -808       O  
+ATOM    416  C1'   C R  21     170.890   3.894 150.474  1.00 47.51           C  
+ANISOU  416  C1'   C R  21     7306   4849   5897   -684   -266   -790       C  
+ATOM    417  N1    C R  21     171.196   5.134 151.215  1.00 47.79           N  
+ANISOU  417  N1    C R  21     7167   4994   5998   -708    -73   -762       N  
+ATOM    418  C2    C R  21     172.413   5.207 151.885  1.00 48.70           C  
+ANISOU  418  C2    C R  21     7270   5103   6133   -650    -15   -786       C  
+ATOM    419  O2    C R  21     173.178   4.232 151.818  1.00 45.72           O  
+ANISOU  419  O2    C R  21     7021   4635   5715   -572   -121   -831       O  
+ATOM    420  N3    C R  21     172.717   6.329 152.580  1.00 43.58           N  
+ANISOU  420  N3    C R  21     6474   4541   5544   -675    145   -760       N  
+ATOM    421  C4    C R  21     171.846   7.331 152.604  1.00 45.49           C  
+ANISOU  421  C4    C R  21     6595   4871   5819   -743    243   -719       C  
+ATOM    422  N4    C R  21     172.173   8.431 153.296  1.00 44.43           N  
+ANISOU  422  N4    C R  21     6335   4808   5738   -759    385   -699       N  
+ATOM    423  C5    C R  21     170.591   7.269 151.938  1.00 45.98           C  
+ANISOU  423  C5    C R  21     6661   4949   5861   -796    191   -696       C  
+ATOM    424  C6    C R  21     170.304   6.162 151.266  1.00 47.30           C  
+ANISOU  424  C6    C R  21     6966   5032   5975   -783     33   -716       C  
+ATOM    425  P     A R  22     167.423   1.795 153.058  1.00 53.01           P  
+ANISOU  425  P     A R  22     8056   5458   6628  -1405   -652   -562       P  
+ATOM    426  OP1   A R  22     166.406   0.736 153.114  1.00 55.95           O  
+ANISOU  426  OP1   A R  22     8521   5760   6978  -1581   -853   -501       O  
+ATOM    427  OP2   A R  22     167.047   3.144 153.518  1.00 46.68           O  
+ANISOU  427  OP2   A R  22     7044   4817   5877  -1437   -447   -527       O  
+ATOM    428  O5'   A R  22     168.662   1.354 153.943  1.00 53.32           O  
+ANISOU  428  O5'   A R  22     8170   5424   6666  -1366   -660   -596       O  
+ATOM    429  C5'   A R  22     169.359   0.140 153.701  1.00 54.12           C  
+ANISOU  429  C5'   A R  22     8476   5369   6718  -1297   -836   -647       C  
+ATOM    430  C4'   A R  22     170.542   0.036 154.626  1.00 51.93           C  
+ANISOU  430  C4'   A R  22     8219   5060   6452  -1250   -798   -677       C  
+ATOM    431  O4'   A R  22     171.520   1.048 154.276  1.00 50.35           O  
+ANISOU  431  O4'   A R  22     7915   4941   6273  -1065   -614   -732       O  
+ATOM    432  C3'   A R  22     170.248   0.309 156.091  1.00 55.21           C  
+ANISOU  432  C3'   A R  22     8535   5534   6909  -1432   -735   -605       C  
+ATOM    433  O3'   A R  22     169.692  -0.819 156.753  1.00 62.23           O  
+ANISOU  433  O3'   A R  22     9541   6330   7775  -1613   -918   -547       O  
+ATOM    434  C2'   A R  22     171.607   0.738 156.626  1.00 55.00           C  
+ANISOU  434  C2'   A R  22     8476   5517   6904  -1307   -625   -657       C  
+ATOM    435  O2'   A R  22     172.427  -0.399 156.823  1.00 60.09           O  
+ANISOU  435  O2'   A R  22     9298   6020   7513  -1257   -781   -700       O  
+ATOM    436  C1'   A R  22     172.171   1.514 155.439  1.00 50.10           C  
+ANISOU  436  C1'   A R  22     7799   4952   6285  -1098   -508   -720       C  
+ATOM    437  N9    A R  22     171.961   2.973 155.541  1.00 47.09           N  
+ANISOU  437  N9    A R  22     7220   4718   5955  -1098   -298   -695       N  
+ATOM    438  C8    A R  22     170.930   3.713 155.007  1.00 52.16           C  
+ANISOU  438  C8    A R  22     7759   5450   6609  -1139   -227   -661       C  
+ATOM    439  N7    A R  22     171.014   5.010 155.235  1.00 55.55           N  
+ANISOU  439  N7    A R  22     8031   5993   7084  -1115    -46   -650       N  
+ATOM    440  C5    A R  22     172.186   5.121 155.973  1.00 50.69           C  
+ANISOU  440  C5    A R  22     7413   5359   6490  -1065      4   -676       C  
+ATOM    441  C6    A R  22     172.837   6.231 156.534  1.00 44.70           C  
+ANISOU  441  C6    A R  22     6532   4672   5779  -1028    161   -677       C  
+ATOM    442  N6    A R  22     172.390   7.497 156.430  1.00 45.41           N  
+ANISOU  442  N6    A R  22     6484   4865   5902  -1029    302   -655       N  
+ATOM    443  N1    A R  22     173.987   5.998 157.205  1.00 44.34           N  
+ANISOU  443  N1    A R  22     6518   4581   5746   -986    156   -703       N  
+ATOM    444  C2    A R  22     174.436   4.742 157.304  1.00 43.45           C  
+ANISOU  444  C2    A R  22     6551   4361   5597   -974      8   -730       C  
+ATOM    445  N3    A R  22     173.909   3.615 156.838  1.00 44.06           N  
+ANISOU  445  N3    A R  22     6763   4353   5624  -1002   -154   -734       N  
+ATOM    446  C4    A R  22     172.776   3.876 156.171  1.00 45.24           C  
+ANISOU  446  C4    A R  22     6876   4549   5766  -1052   -147   -704       C  
+ATOM    447  P     U R  23     168.687  -0.627 157.991  1.00 52.55           P  
+ANISOU  447  P     U R  23     8201   5194   6571  -1860   -881   -436       P  
+ATOM    448  OP1   U R  23     168.117  -1.983 158.279  1.00 74.95           O  
+ANISOU  448  OP1   U R  23    11196   7910   9370  -2032  -1113   -376       O  
+ATOM    449  OP2   U R  23     167.775   0.507 157.754  1.00 56.78           O  
+ANISOU  449  OP2   U R  23     8542   5895   7139  -1892   -723   -398       O  
+ATOM    450  O5'   U R  23     169.615  -0.138 159.179  1.00 43.33           O  
+ANISOU  450  O5'   U R  23     6973   4061   5431  -1839   -757   -449       O  
+ATOM    451  C5'   U R  23     170.547  -1.007 159.798  1.00 50.27           C  
+ANISOU  451  C5'   U R  23     7998   4813   6290  -1824   -868   -477       C  
+ATOM    452  C4'   U R  23     171.511  -0.242 160.672  1.00 57.47           C  
+ANISOU  452  C4'   U R  23     8821   5779   7236  -1758   -716   -505       C  
+ATOM    453  O4'   U R  23     172.238   0.728 159.876  1.00 57.94           O  
+ANISOU  453  O4'   U R  23     8791   5900   7325  -1557   -568   -577       O  
+ATOM    454  C3'   U R  23     170.913   0.599 161.797  1.00 58.57           C  
+ANISOU  454  C3'   U R  23     8801   6052   7400  -1899   -575   -434       C  
+ATOM    455  O3'   U R  23     170.577  -0.149 162.939  1.00 71.27           O  
+ANISOU  455  O3'   U R  23    10474   7624   8983  -2081   -672   -364       O  
+ATOM    456  C2'   U R  23     172.025   1.579 162.075  1.00 54.53           C  
+ANISOU  456  C2'   U R  23     8203   5587   6930  -1754   -417   -494       C  
+ATOM    457  O2'   U R  23     173.063   0.920 162.779  1.00 53.56           O  
+ANISOU  457  O2'   U R  23     8192   5361   6799  -1728   -497   -523       O  
+ATOM    458  C1'   U R  23     172.514   1.869 160.660  1.00 53.81           C  
+ANISOU  458  C1'   U R  23     8114   5487   6847  -1559   -387   -566       C  
+ATOM    459  N1    U R  23     171.837   3.047 160.058  1.00 51.16           N  
+ANISOU  459  N1    U R  23     7621   5281   6537  -1534   -236   -554       N  
+ATOM    460  C2    U R  23     172.306   4.281 160.430  1.00 42.21           C  
+ANISOU  460  C2    U R  23     6352   4239   5446  -1474    -62   -567       C  
+ATOM    461  O2    U R  23     173.210   4.421 161.232  1.00 42.81           O  
+ANISOU  461  O2    U R  23     6429   4295   5542  -1449    -29   -585       O  
+ATOM    462  N3    U R  23     171.673   5.333 159.836  1.00 54.65           N  
+ANISOU  462  N3    U R  23     7801   5921   7042  -1445     60   -557       N  
+ATOM    463  C4    U R  23     170.641   5.295 158.927  1.00 50.55           C  
+ANISOU  463  C4    U R  23     7267   5435   6506  -1467     32   -536       C  
+ATOM    464  O4    U R  23     170.185   6.355 158.478  1.00 53.31           O  
+ANISOU  464  O4    U R  23     7497   5883   6877  -1428    153   -532       O  
+ATOM    465  C5    U R  23     170.213   3.982 158.587  1.00 42.93           C  
+ANISOU  465  C5    U R  23     6439   4374   5498  -1534   -151   -522       C  
+ATOM    466  C6    U R  23     170.810   2.938 159.153  1.00 45.88           C  
+ANISOU  466  C6    U R  23     6947   4636   5850  -1566   -278   -531       C  
+ATOM    467  P     C R  24     169.214   0.130 163.738  1.00 59.36           P  
+ANISOU  467  P     C R  24     8844   6248   7462  -2299   -620   -250       P  
+ATOM    468  OP1   C R  24     168.997  -1.075 164.590  1.00 64.49           O  
+ANISOU  468  OP1   C R  24     9627   6807   8069  -2478   -790   -179       O  
+ATOM    469  OP2   C R  24     168.147   0.541 162.799  1.00 77.89           O  
+ANISOU  469  OP2   C R  24    11094   8685   9816  -2314   -585   -225       O  
+ATOM    470  O5'   C R  24     169.605   1.332 164.704  1.00 61.07           O  
+ANISOU  470  O5'   C R  24     8916   6583   7706  -2263   -419   -260       O  
+ATOM    471  C5'   C R  24     170.583   1.149 165.718  1.00 48.67           C  
+ANISOU  471  C5'   C R  24     7409   4951   6133  -2251   -427   -281       C  
+ATOM    472  C4'   C R  24     171.059   2.471 166.288  1.00 51.11           C  
+ANISOU  472  C4'   C R  24     7580   5362   6477  -2168   -234   -313       C  
+ATOM    473  O4'   C R  24     171.735   3.240 165.265  1.00 46.22           O  
+ANISOU  473  O4'   C R  24     6910   4747   5904  -1976   -148   -394       O  
+ATOM    474  C3'   C R  24     169.985   3.421 166.784  1.00 53.99           C  
+ANISOU  474  C3'   C R  24     7780   5899   6834  -2253    -93   -255       C  
+ATOM    475  O3'   C R  24     169.396   3.071 168.023  1.00 55.80           O  
+ANISOU  475  O3'   C R  24     8008   6178   7016  -2426   -112   -173       O  
+ATOM    476  C2'   C R  24     170.719   4.755 166.790  1.00 40.51           C  
+ANISOU  476  C2'   C R  24     5973   4246   5175  -2099     71   -322       C  
+ATOM    477  O2'   C R  24     171.617   4.822 167.884  1.00 42.10           O  
+ANISOU  477  O2'   C R  24     6211   4406   5378  -2092     83   -340       O  
+ATOM    478  C1'   C R  24     171.538   4.633 165.513  1.00 46.41           C  
+ANISOU  478  C1'   C R  24     6774   4903   5957  -1939     34   -396       C  
+ATOM    479  N1    C R  24     170.846   5.275 164.360  1.00 39.71           N  
+ANISOU  479  N1    C R  24     5834   4130   5124  -1880    102   -402       N  
+ATOM    480  C2    C R  24     170.970   6.664 164.203  1.00 41.81           C  
+ANISOU  480  C2    C R  24     5970   4487   5427  -1783    264   -431       C  
+ATOM    481  O2    C R  24     171.659   7.306 165.010  1.00 38.56           O  
+ANISOU  481  O2    C R  24     5527   4087   5037  -1750    341   -451       O  
+ATOM    482  N3    C R  24     170.347   7.264 163.170  1.00 38.94           N  
+ANISOU  482  N3    C R  24     5531   4189   5076  -1728    321   -436       N  
+ATOM    483  C4    C R  24     169.603   6.563 162.321  1.00 39.81           C  
+ANISOU  483  C4    C R  24     5681   4282   5163  -1766    228   -414       C  
+ATOM    484  N4    C R  24     169.008   7.197 161.319  1.00 40.72           N  
+ANISOU  484  N4    C R  24     5721   4462   5289  -1707    285   -421       N  
+ATOM    485  C5    C R  24     169.433   5.151 162.462  1.00 40.73           C  
+ANISOU  485  C5    C R  24     5928   4305   5242  -1871     58   -384       C  
+ATOM    486  C6    C R  24     170.066   4.580 163.487  1.00 40.30           C  
+ANISOU  486  C6    C R  24     5952   4185   5177  -1924      3   -378       C  
+ATOM    487  P     C R  25     167.858   3.474 168.256  1.00 53.86           P  
+ANISOU  487  P     C R  25     7617   6112   6736  -2559    -37    -82       P  
+ATOM    488  OP1   C R  25     167.384   2.882 169.535  1.00 69.29           O  
+ANISOU  488  OP1   C R  25     9594   8106   8628  -2743    -79     10       O  
+ATOM    489  OP2   C R  25     167.138   3.319 166.973  1.00 42.24           O  
+ANISOU  489  OP2   C R  25     6121   4650   5279  -2551    -81    -76       O  
+ATOM    490  O5'   C R  25     167.879   5.076 168.369  1.00 46.66           O  
+ANISOU  490  O5'   C R  25     6546   5332   5852  -2433    169   -130       O  
+ATOM    491  C5'   C R  25     168.631   5.735 169.362  1.00 43.48           C  
+ANISOU  491  C5'   C R  25     6132   4938   5451  -2379    256   -164       C  
+ATOM    492  C4'   C R  25     168.495   7.242 169.240  1.00 47.71           C  
+ANISOU  492  C4'   C R  25     6527   5587   6013  -2260    426   -207       C  
+ATOM    493  O4'   C R  25     169.127   7.724 168.024  1.00 48.14           O  
+ANISOU  493  O4'   C R  25     6579   5580   6131  -2105    448   -280       O  
+ATOM    494  C3'   C R  25     167.088   7.798 169.134  1.00 47.36           C  
+ANISOU  494  C3'   C R  25     6340   5717   5938  -2309    510   -155       C  
+ATOM    495  O3'   C R  25     166.361   7.758 170.349  1.00 47.65           O  
+ANISOU  495  O3'   C R  25     6327   5875   5905  -2428    546    -84       O  
+ATOM    496  C2'   C R  25     167.362   9.194 168.594  1.00 45.40           C  
+ANISOU  496  C2'   C R  25     6006   5507   5737  -2140    638   -228       C  
+ATOM    497  O2'   C R  25     167.964   9.988 169.612  1.00 37.58           O  
+ANISOU  497  O2'   C R  25     5006   4529   4742  -2086    720   -262       O  
+ATOM    498  C1'   C R  25     168.444   8.876 167.567  1.00 45.66           C  
+ANISOU  498  C1'   C R  25     6132   5387   5831  -2039    570   -290       C  
+ATOM    499  N1    C R  25     167.880   8.628 166.219  1.00 40.86           N  
+ANISOU  499  N1    C R  25     5510   4778   5238  -2019    529   -287       N  
+ATOM    500  C2    C R  25     167.711   9.750 165.405  1.00 39.42           C  
+ANISOU  500  C2    C R  25     5235   4653   5089  -1899    630   -325       C  
+ATOM    501  O2    C R  25     168.051  10.843 165.860  1.00 41.87           O  
+ANISOU  501  O2    C R  25     5489   5003   5415  -1822    738   -358       O  
+ATOM    502  N3    C R  25     167.212   9.612 164.161  1.00 40.16           N  
+ANISOU  502  N3    C R  25     5317   4749   5195  -1870    598   -326       N  
+ATOM    503  C4    C R  25     166.860   8.410 163.707  1.00 40.28           C  
+ANISOU  503  C4    C R  25     5408   4708   5190  -1956    464   -291       C  
+ATOM    504  N4    C R  25     166.367   8.316 162.467  1.00 39.49           N  
+ANISOU  504  N4    C R  25     5301   4605   5098  -1920    427   -296       N  
+ATOM    505  C5    C R  25     167.013   7.252 164.509  1.00 39.84           C  
+ANISOU  505  C5    C R  25     5451   4585   5101  -2083    351   -251       C  
+ATOM    506  C6    C R  25     167.516   7.413 165.741  1.00 41.48           C  
+ANISOU  506  C6    C R  25     5667   4797   5298  -2110    392   -248       C  
+ATOM    507  P     G R  26     164.766   7.587 170.312  1.00 55.27           P  
+ANISOU  507  P     G R  26     7171   7013   6816  -2557    561     12       P  
+ATOM    508  OP1   G R  26     164.313   7.415 171.712  1.00 59.96           O  
+ANISOU  508  OP1   G R  26     7737   7716   7329  -2677    592     85       O  
+ATOM    509  OP2   G R  26     164.311   6.593 169.309  1.00 45.08           O  
+ANISOU  509  OP2   G R  26     5923   5663   5542  -2641    429     54       O  
+ATOM    510  O5'   G R  26     164.289   8.973 169.699  1.00 51.36           O  
+ANISOU  510  O5'   G R  26     6533   6634   6347  -2413    700    -38       O  
+ATOM    511  C5'   G R  26     164.307  10.157 170.472  1.00 47.46           C  
+ANISOU  511  C5'   G R  26     5963   6240   5831  -2322    838    -74       C  
+ATOM    512  C4'   G R  26     163.866  11.333 169.639  1.00 53.67           C  
+ANISOU  512  C4'   G R  26     6640   7103   6649  -2184    934   -122       C  
+ATOM    513  O4'   G R  26     164.741  11.496 168.484  1.00 42.02           O  
+ANISOU  513  O4'   G R  26     5231   5480   5255  -2074    901   -193       O  
+ATOM    514  C3'   G R  26     162.489  11.207 169.021  1.00 55.14           C  
+ANISOU  514  C3'   G R  26     6706   7429   6814  -2245    935    -61       C  
+ATOM    515  O3'   G R  26     161.455  11.450 169.953  1.00 56.69           O  
+ANISOU  515  O3'   G R  26     6784   7825   6930  -2307   1010      1       O  
+ATOM    516  C2'   G R  26     162.566  12.227 167.892  1.00 51.21           C  
+ANISOU  516  C2'   G R  26     6166   6915   6375  -2082    991   -134       C  
+ATOM    517  O2'   G R  26     162.461  13.541 168.412  1.00 52.23           O  
+ANISOU  517  O2'   G R  26     6220   7137   6486  -1962   1118   -180       O  
+ATOM    518  C1'   G R  26     163.996  12.009 167.400  1.00 46.19           C  
+ANISOU  518  C1'   G R  26     5670   6074   5805  -2014    933   -200       C  
+ATOM    519  N9    G R  26     163.971  11.043 166.293  1.00 47.64           N  
+ANISOU  519  N9    G R  26     5915   6168   6018  -2060    816   -183       N  
+ATOM    520  C8    G R  26     164.085   9.674 166.306  1.00 46.99           C  
+ANISOU  520  C8    G R  26     5931   5998   5923  -2187    681   -137       C  
+ATOM    521  N7    G R  26     163.911   9.143 165.131  1.00 45.56           N  
+ANISOU  521  N7    G R  26     5788   5756   5768  -2186    595   -137       N  
+ATOM    522  C5    G R  26     163.643  10.222 164.301  1.00 38.70           C  
+ANISOU  522  C5    G R  26     4831   4945   4929  -2057    685   -181       C  
+ATOM    523  C6    G R  26     163.376  10.279 162.913  1.00 43.40           C  
+ANISOU  523  C6    G R  26     5423   5514   5554  -1992    652   -201       C  
+ATOM    524  O6    G R  26     163.312   9.331 162.119  1.00 44.45           O  
+ANISOU  524  O6    G R  26     5635   5563   5690  -2036    528   -187       O  
+ATOM    525  N1    G R  26     163.152  11.588 162.472  1.00 43.46           N  
+ANISOU  525  N1    G R  26     5333   5598   5582  -1863    769   -243       N  
+ATOM    526  C2    G R  26     163.188  12.707 163.272  1.00 42.38           C  
+ANISOU  526  C2    G R  26     5120   5543   5438  -1799    894   -265       C  
+ATOM    527  N2    G R  26     162.941  13.883 162.663  1.00 41.22           N  
+ANISOU  527  N2    G R  26     4901   5448   5313  -1673    979   -305       N  
+ATOM    528  N3    G R  26     163.450  12.666 164.575  1.00 37.89           N  
+ANISOU  528  N3    G R  26     4559   4999   4840  -1851    923   -252       N  
+ATOM    529  C4    G R  26     163.664  11.403 165.009  1.00 45.31           C  
+ANISOU  529  C4    G R  26     5584   5872   5759  -1981    819   -208       C  
+ATOM    530  P     C R  27     160.226  10.433 170.123  1.00 61.32           P  
+ANISOU  530  P     C R  27     7295   8545   7461  -2506    950    129       P  
+ATOM    531  OP1   C R  27     159.470  10.893 171.310  1.00 70.35           O  
+ANISOU  531  OP1   C R  27     8320   9899   8512  -2531   1059    177       O  
+ATOM    532  OP2   C R  27     160.720   9.023 170.087  1.00 70.35           O  
+ANISOU  532  OP2   C R  27     8581   9533   8616  -2654    794    177       O  
+ATOM    533  O5'   C R  27     159.329  10.731 168.842  1.00 63.10           O  
+ANISOU  533  O5'   C R  27     7414   8839   7723  -2468    948    133       O  
+ATOM    534  C5'   C R  27     158.731   9.692 168.091  1.00 62.85           C  
+ANISOU  534  C5'   C R  27     7387   8788   7706  -2607    823    207       C  
+ATOM    535  C4'   C R  27     157.576  10.229 167.293  1.00 61.90           C  
+ANISOU  535  C4'   C R  27     7110   8816   7592  -2572    862    224       C  
+ATOM    536  O4'   C R  27     156.765  11.059 168.157  1.00 71.34           O  
+ANISOU  536  O4'   C R  27     8143  10243   8721  -2539    999    248       O  
+ATOM    537  C3'   C R  27     157.951  11.135 166.136  1.00 54.24           C  
+ANISOU  537  C3'   C R  27     6152   7767   6689  -2382    897    120       C  
+ATOM    538  O3'   C R  27     158.206  10.401 164.963  1.00 45.30           O  
+ANISOU  538  O3'   C R  27     5118   6484   5611  -2408    768    113       O  
+ATOM    539  C2'   C R  27     156.745  12.053 165.997  1.00 58.23           C  
+ANISOU  539  C2'   C R  27     6468   8488   7169  -2320    996    134       C  
+ATOM    540  O2'   C R  27     155.730  11.442 165.227  1.00 60.98           O  
+ANISOU  540  O2'   C R  27     6742   8903   7525  -2427    911    208       O  
+ATOM    541  C1'   C R  27     156.256  12.157 167.434  1.00 65.74           C  
+ANISOU  541  C1'   C R  27     7325   9619   8033  -2383   1080    192       C  
+ATOM    542  N1    C R  27     156.682  13.409 168.097  1.00 55.89           N  
+ANISOU  542  N1    C R  27     6063   8409   6762  -2209   1215    106       N  
+ATOM    543  C2    C R  27     156.043  14.588 167.722  1.00 60.12           C  
+ANISOU  543  C2    C R  27     6479   9068   7294  -2055   1309     58       C  
+ATOM    544  O2    C R  27     155.173  14.534 166.826  1.00 62.63           O  
+ANISOU  544  O2    C R  27     6703   9460   7633  -2069   1279     89       O  
+ATOM    545  N3    C R  27     156.405  15.747 168.336  1.00 59.55           N  
+ANISOU  545  N3    C R  27     6409   9021   7197  -1892   1417    -22       N  
+ATOM    546  C4    C R  27     157.344  15.744 169.296  1.00 58.90           C  
+ANISOU  546  C4    C R  27     6434   8852   7095  -1888   1435    -51       C  
+ATOM    547  N4    C R  27     157.675  16.902 169.886  1.00 58.71           N  
+ANISOU  547  N4    C R  27     6419   8844   7044  -1728   1527   -130       N  
+ATOM    548  C5    C R  27     157.993  14.540 169.700  1.00 56.32           C  
+ANISOU  548  C5    C R  27     6218   8408   6772  -2046   1345     -1       C  
+ATOM    549  C6    C R  27     157.631  13.411 169.074  1.00 54.29           C  
+ANISOU  549  C6    C R  27     5965   8123   6538  -2199   1238     75       C  
+ATOM    550  P     G R  28     159.596  10.558 164.218  1.00 54.55           P  
+ANISOU  550  P     G R  28     6445   7437   6845  -2268    743      8       P  
+ATOM    551  OP1   G R  28     159.676   9.500 163.185  1.00 46.71           O  
+ANISOU  551  OP1   G R  28     5556   6312   5879  -2330    589     24       O  
+ATOM    552  OP2   G R  28     160.661  10.769 165.223  1.00 62.70           O  
+ANISOU  552  OP2   G R  28     7552   8403   7870  -2229    794    -33       O  
+ATOM    553  O5'   G R  28     159.422  11.935 163.438  1.00 52.14           O  
+ANISOU  553  O5'   G R  28     6055   7185   6570  -2084    851    -63       O  
+ATOM    554  C5'   G R  28     158.286  12.143 162.613  1.00 44.07           C  
+ANISOU  554  C5'   G R  28     4923   6272   5551  -2083    843    -35       C  
+ATOM    555  C4'   G R  28     157.962  13.606 162.505  1.00 46.50           C  
+ANISOU  555  C4'   G R  28     5122   6685   5860  -1922    975    -90       C  
+ATOM    556  O4'   G R  28     157.695  14.145 163.825  1.00 47.14           O  
+ANISOU  556  O4'   G R  28     5120   6905   5888  -1922   1078    -77       O  
+ATOM    557  C3'   G R  28     159.090  14.463 161.963  1.00 44.86           C  
+ANISOU  557  C3'   G R  28     5004   6340   5701  -1751   1023   -188       C  
+ATOM    558  O3'   G R  28     159.083  14.449 160.553  1.00 48.67           O  
+ANISOU  558  O3'   G R  28     5521   6748   6224  -1692    969   -212       O  
+ATOM    559  C2'   G R  28     158.783  15.835 162.559  1.00 52.04           C  
+ANISOU  559  C2'   G R  28     5814   7370   6588  -1632   1155   -225       C  
+ATOM    560  O2'   G R  28     157.742  16.447 161.809  1.00 54.81           O  
+ANISOU  560  O2'   G R  28     6054   7834   6939  -1568   1179   -224       O  
+ATOM    561  C1'   G R  28     158.190  15.465 163.914  1.00 48.64           C  
+ANISOU  561  C1'   G R  28     5309   7082   6090  -1744   1184   -162       C  
+ATOM    562  N9    G R  28     159.103  15.541 165.081  1.00 52.04           N  
+ANISOU  562  N9    G R  28     5814   7457   6501  -1742   1222   -186       N  
+ATOM    563  C8    G R  28     159.887  14.520 165.551  1.00 56.42           C  
+ANISOU  563  C8    G R  28     6481   7897   7058  -1851   1150   -162       C  
+ATOM    564  N7    G R  28     160.537  14.805 166.652  1.00 52.66           N  
+ANISOU  564  N7    G R  28     6048   7404   6557  -1831   1199   -186       N  
+ATOM    565  C5    G R  28     160.155  16.099 166.958  1.00 54.77           C  
+ANISOU  565  C5    G R  28     6231   7779   6801  -1701   1309   -229       C  
+ATOM    566  C6    G R  28     160.542  16.943 168.050  1.00 52.48           C  
+ANISOU  566  C6    G R  28     5951   7514   6473  -1618   1390   -273       C  
+ATOM    567  O6    G R  28     161.321  16.715 168.997  1.00 50.15           O  
+ANISOU  567  O6    G R  28     5739   7154   6161  -1650   1385   -280       O  
+ATOM    568  N1    G R  28     159.905  18.176 167.994  1.00 49.14           N  
+ANISOU  568  N1    G R  28     5440   7204   6028  -1479   1477   -315       N  
+ATOM    569  C2    G R  28     159.032  18.566 167.022  1.00 42.89           C  
+ANISOU  569  C2    G R  28     4554   6491   5250  -1425   1487   -314       C  
+ATOM    570  N2    G R  28     158.543  19.803 167.178  1.00 45.09           N  
+ANISOU  570  N2    G R  28     4766   6868   5499  -1276   1568   -363       N  
+ATOM    571  N3    G R  28     158.664  17.798 165.999  1.00 51.78           N  
+ANISOU  571  N3    G R  28     5663   7599   6414  -1505   1415   -270       N  
+ATOM    572  C4    G R  28     159.249  16.567 166.014  1.00 56.42           C  
+ANISOU  572  C4    G R  28     6341   8075   7021  -1643   1326   -229       C  
+ATOM    573  P     A R  29     160.438  14.396 159.720  1.00 46.31           P  
+ANISOU  573  P     A R  29     5370   6252   5972  -1600    936   -277       P  
+ATOM    574  OP1   A R  29     160.148  13.867 158.361  1.00 47.92           O  
+ANISOU  574  OP1   A R  29     5613   6402   6192  -1597    843   -272       O  
+ATOM    575  OP2   A R  29     161.449  13.791 160.617  1.00 55.04           O  
+ANISOU  575  OP2   A R  29     6571   7266   7075  -1654    915   -280       O  
+ATOM    576  O5'   A R  29     160.819  15.942 159.495  1.00 54.03           O  
+ANISOU  576  O5'   A R  29     6318   7238   6975  -1425   1054   -344       O  
+ATOM    577  C5'   A R  29     159.906  16.850 158.886  1.00 54.00           C  
+ANISOU  577  C5'   A R  29     6216   7333   6969  -1343   1099   -353       C  
+ATOM    578  C4'   A R  29     160.314  18.283 159.167  1.00 46.78           C  
+ANISOU  578  C4'   A R  29     5285   6423   6066  -1203   1205   -409       C  
+ATOM    579  O4'   A R  29     160.080  18.574 160.569  1.00 41.27           O  
+ANISOU  579  O4'   A R  29     4531   5821   5329  -1230   1266   -401       O  
+ATOM    580  C3'   A R  29     161.786  18.582 158.935  1.00 43.19           C  
+ANISOU  580  C3'   A R  29     4945   5811   5653  -1132   1218   -455       C  
+ATOM    581  O3'   A R  29     162.077  18.939 157.589  1.00 45.09           O  
+ANISOU  581  O3'   A R  29     5226   5982   5925  -1042   1206   -478       O  
+ATOM    582  C2'   A R  29     162.086  19.696 159.936  1.00 46.34           C  
+ANISOU  582  C2'   A R  29     5324   6236   6047  -1063   1305   -488       C  
+ATOM    583  O2'   A R  29     161.745  20.956 159.382  1.00 43.85           O  
+ANISOU  583  O2'   A R  29     4972   5948   5740   -937   1355   -521       O  
+ATOM    584  C1'   A R  29     161.112  19.385 161.073  1.00 48.16           C  
+ANISOU  584  C1'   A R  29     5466   6612   6220  -1145   1322   -452       C  
+ATOM    585  N9    A R  29     161.744  18.725 162.240  1.00 46.41           N  
+ANISOU  585  N9    A R  29     5295   6357   5982  -1235   1312   -438       N  
+ATOM    586  C8    A R  29     162.464  17.557 162.276  1.00 57.34           C  
+ANISOU  586  C8    A R  29     6766   7640   7380  -1332   1237   -416       C  
+ATOM    587  N7    A R  29     162.904  17.235 163.472  1.00 50.53           N  
+ANISOU  587  N7    A R  29     5936   6769   6495  -1393   1242   -407       N  
+ATOM    588  C5    A R  29     162.445  18.257 164.290  1.00 41.38           C  
+ANISOU  588  C5    A R  29     4707   5716   5299  -1330   1329   -426       C  
+ATOM    589  C6    A R  29     162.588  18.504 165.673  1.00 45.85           C  
+ANISOU  589  C6    A R  29     5275   6326   5821  -1342   1373   -431       C  
+ATOM    590  N6    A R  29     163.256  17.713 166.508  1.00 47.41           N  
+ANISOU  590  N6    A R  29     5544   6463   6007  -1432   1336   -412       N  
+ATOM    591  N1    A R  29     162.009  19.613 166.192  1.00 54.31           N  
+ANISOU  591  N1    A R  29     6278   7505   6852  -1246   1453   -459       N  
+ATOM    592  C2    A R  29     161.353  20.419 165.336  1.00 54.07           C  
+ANISOU  592  C2    A R  29     6183   7527   6833  -1146   1481   -481       C  
+ATOM    593  N3    A R  29     161.160  20.304 164.020  1.00 56.17           N  
+ANISOU  593  N3    A R  29     6441   7759   7144  -1131   1446   -475       N  
+ATOM    594  C4    A R  29     161.732  19.179 163.545  1.00 52.31           C  
+ANISOU  594  C4    A R  29     6020   7168   6689  -1229   1370   -447       C  
+ATOM    595  P     G R  30     163.269  18.202 156.803  1.00 54.97           P  
+ANISOU  595  P     G R  30     6597   7086   7203  -1037   1149   -489       P  
+ATOM    596  OP1   G R  30     163.877  19.070 155.768  1.00 69.33           O  
+ANISOU  596  OP1   G R  30     8449   8843   9049   -914   1185   -519       O  
+ATOM    597  OP2   G R  30     162.784  16.855 156.482  1.00 69.68           O  
+ANISOU  597  OP2   G R  30     8485   8945   9045  -1138   1047   -455       O  
+ATOM    598  O5'   G R  30     164.328  17.856 157.934  1.00 74.93           O  
+ANISOU  598  O5'   G R  30     9180   9551   9739  -1084   1157   -495       O  
+ATOM    599  C5'   G R  30     165.498  18.621 158.167  1.00 48.31           C  
+ANISOU  599  C5'   G R  30     5848   6107   6401  -1011   1210   -527       C  
+ATOM    600  C4'   G R  30     165.959  18.434 159.602  1.00 46.45           C  
+ANISOU  600  C4'   G R  30     5624   5864   6159  -1073   1221   -526       C  
+ATOM    601  O4'   G R  30     165.014  17.610 160.338  1.00 49.77           O  
+ANISOU  601  O4'   G R  30     6008   6368   6535  -1186   1186   -490       O  
+ATOM    602  C3'   G R  30     167.286  17.737 159.837  1.00 38.17           C  
+ANISOU  602  C3'   G R  30     4664   4705   5134  -1095   1183   -534       C  
+ATOM    603  O3'   G R  30     168.408  18.569 159.605  1.00 44.13           O  
+ANISOU  603  O3'   G R  30     5444   5391   5931  -1009   1226   -559       O  
+ATOM    604  C2'   G R  30     167.158  17.286 161.290  1.00 38.39           C  
+ANISOU  604  C2'   G R  30     4691   4762   5133  -1190   1173   -519       C  
+ATOM    605  O2'   G R  30     167.331  18.382 162.176  1.00 48.08           O  
+ANISOU  605  O2'   G R  30     5890   6013   6364  -1148   1244   -540       O  
+ATOM    606  C1'   G R  30     165.699  16.864 161.331  1.00 42.71           C  
+ANISOU  606  C1'   G R  30     5171   5423   5634  -1264   1154   -482       C  
+ATOM    607  N9    G R  30     165.570  15.436 161.009  1.00 56.28           N  
+ANISOU  607  N9    G R  30     6942   7104   7337  -1359   1051   -450       N  
+ATOM    608  C8    G R  30     165.029  14.886 159.871  1.00 50.36           C  
+ANISOU  608  C8    G R  30     6200   6349   6585  -1366    989   -436       C  
+ATOM    609  N7    G R  30     165.070  13.572 159.863  1.00 45.55           N  
+ANISOU  609  N7    G R  30     5662   5686   5959  -1460    882   -410       N  
+ATOM    610  C5    G R  30     165.689  13.252 161.073  1.00 39.95           C  
+ANISOU  610  C5    G R  30     4991   4947   5243  -1517    881   -405       C  
+ATOM    611  C6    G R  30     166.013  11.978 161.620  1.00 42.85           C  
+ANISOU  611  C6    G R  30     5447   5244   5590  -1623    779   -380       C  
+ATOM    612  O6    G R  30     165.790  10.844 161.133  1.00 38.65           O  
+ANISOU  612  O6    G R  30     4984   4658   5042  -1691    662   -356       O  
+ATOM    613  N1    G R  30     166.637  12.122 162.856  1.00 39.96           N  
+ANISOU  613  N1    G R  30     5096   4866   5219  -1646    814   -385       N  
+ATOM    614  C2    G R  30     166.895  13.312 163.491  1.00 37.16           C  
+ANISOU  614  C2    G R  30     4683   4558   4877  -1579    925   -412       C  
+ATOM    615  N2    G R  30     167.493  13.212 164.675  1.00 35.91           N  
+ANISOU  615  N2    G R  30     4562   4374   4709  -1616    930   -414       N  
+ATOM    616  N3    G R  30     166.609  14.502 162.987  1.00 36.56           N  
+ANISOU  616  N3    G R  30     4533   4538   4820  -1479   1012   -437       N  
+ATOM    617  C4    G R  30     166.012  14.390 161.784  1.00 43.02           C  
+ANISOU  617  C4    G R  30     5330   5372   5643  -1455    986   -431       C  
+ATOM    618  P     G R  31     169.823  17.904 159.235  1.00 50.40           P  
+ANISOU  618  P     G R  31     6315   6081   6755   -991   1187   -567       P  
+ATOM    619  OP1   G R  31     170.795  18.970 158.924  1.00 48.99           O  
+ANISOU  619  OP1   G R  31     6131   5862   6621   -908   1243   -578       O  
+ATOM    620  OP2   G R  31     169.552  16.868 158.196  1.00 48.41           O  
+ANISOU  620  OP2   G R  31     6100   5814   6480   -995   1119   -561       O  
+ATOM    621  O5'   G R  31     170.269  17.212 160.609  1.00 40.13           O  
+ANISOU  621  O5'   G R  31     5050   4752   5447  -1076   1152   -566       O  
+ATOM    622  C5'   G R  31     170.753  17.982 161.711  1.00 44.27           C  
+ANISOU  622  C5'   G R  31     5564   5268   5988  -1076   1194   -577       C  
+ATOM    623  C4'   G R  31     171.271  17.085 162.813  1.00 41.79           C  
+ANISOU  623  C4'   G R  31     5302   4913   5663  -1154   1143   -574       C  
+ATOM    624  O4'   G R  31     170.225  16.158 163.210  1.00 51.77           O  
+ANISOU  624  O4'   G R  31     6565   6231   6872  -1250   1098   -548       O  
+ATOM    625  C3'   G R  31     172.413  16.173 162.414  1.00 38.76           C  
+ANISOU  625  C3'   G R  31     4985   4439   5301  -1142   1080   -582       C  
+ATOM    626  O3'   G R  31     173.673  16.807 162.407  1.00 38.55           O  
+ANISOU  626  O3'   G R  31     4962   4361   5326  -1078   1108   -597       O  
+ATOM    627  C2'   G R  31     172.298  15.027 163.419  1.00 41.73           C  
+ANISOU  627  C2'   G R  31     5416   4797   5641  -1244   1007   -570       C  
+ATOM    628  O2'   G R  31     172.879  15.373 164.654  1.00 36.88           O  
+ANISOU  628  O2'   G R  31     4814   4162   5037  -1267   1022   -578       O  
+ATOM    629  C1'   G R  31     170.794  14.919 163.590  1.00 44.30           C  
+ANISOU  629  C1'   G R  31     5697   5217   5918  -1315   1014   -540       C  
+ATOM    630  N9    G R  31     170.272  13.844 162.730  1.00 46.70           N  
+ANISOU  630  N9    G R  31     6035   5512   6199  -1351    936   -522       N  
+ATOM    631  C8    G R  31     169.701  13.927 161.474  1.00 45.73           C  
+ANISOU  631  C8    G R  31     5887   5413   6075  -1305    936   -521       C  
+ATOM    632  N7    G R  31     169.386  12.751 160.979  1.00 43.33           N  
+ANISOU  632  N7    G R  31     5642   5076   5745  -1355    837   -506       N  
+ATOM    633  C5    G R  31     169.817  11.861 161.956  1.00 39.74           C  
+ANISOU  633  C5    G R  31     5256   4568   5275  -1437    769   -495       C  
+ATOM    634  C6    G R  31     169.749  10.450 161.972  1.00 44.70           C  
+ANISOU  634  C6    G R  31     5980   5131   5874  -1518    640   -476       C  
+ATOM    635  O6    G R  31     169.261   9.778 161.074  1.00 41.35           O  
+ANISOU  635  O6    G R  31     5594   4686   5432  -1528    562   -467       O  
+ATOM    636  N1    G R  31     170.289   9.892 163.142  1.00 38.88           N  
+ANISOU  636  N1    G R  31     5300   4346   5125  -1587    597   -468       N  
+ATOM    637  C2    G R  31     170.832  10.620 164.171  1.00 45.65           C  
+ANISOU  637  C2    G R  31     6125   5221   5999  -1576    673   -479       C  
+ATOM    638  N2    G R  31     171.308   9.923 165.213  1.00 40.54           N  
+ANISOU  638  N2    G R  31     5550   4520   5335  -1647    612   -470       N  
+ATOM    639  N3    G R  31     170.900  11.962 164.170  1.00 38.63           N  
+ANISOU  639  N3    G R  31     5148   4390   5138  -1499    790   -500       N  
+ATOM    640  C4    G R  31     170.375  12.501 163.038  1.00 39.59           C  
+ANISOU  640  C4    G R  31     5215   4556   5271  -1435    831   -505       C  
+ATOM    641  P     A R  32     174.827  16.290 161.423  1.00 50.56           P  
+ANISOU  641  P     A R  32     6513   5824   6873  -1009   1079   -605       P  
+ATOM    642  OP1   A R  32     175.904  17.310 161.470  1.00 46.98           O  
+ANISOU  642  OP1   A R  32     6026   5349   6475   -955   1130   -604       O  
+ATOM    643  OP2   A R  32     174.156  15.926 160.141  1.00 47.05           O  
+ANISOU  643  OP2   A R  32     6070   5406   6400   -972   1068   -601       O  
+ATOM    644  O5'   A R  32     175.309  14.908 162.077  1.00 45.77           O  
+ANISOU  644  O5'   A R  32     5984   5159   6246  -1061    986   -613       O  
+ATOM    645  C5'   A R  32     175.757  14.859 163.422  1.00 43.18           C  
+ANISOU  645  C5'   A R  32     5678   4802   5928  -1118    967   -616       C  
+ATOM    646  C4'   A R  32     175.939  13.443 163.902  1.00 34.96           C  
+ANISOU  646  C4'   A R  32     4722   3706   4854  -1174    865   -620       C  
+ATOM    647  O4'   A R  32     174.665  12.742 163.994  1.00 36.02           O  
+ANISOU  647  O4'   A R  32     4881   3873   4934  -1261    823   -597       O  
+ATOM    648  C3'   A R  32     176.769  12.548 163.011  1.00 35.96           C  
+ANISOU  648  C3'   A R  32     4902   3779   4984  -1101    802   -639       C  
+ATOM    649  O3'   A R  32     178.146  12.811 163.128  1.00 36.95           O  
+ANISOU  649  O3'   A R  32     5014   3871   5155  -1034    812   -655       O  
+ATOM    650  C2'   A R  32     176.353  11.156 163.488  1.00 36.53           C  
+ANISOU  650  C2'   A R  32     5071   3803   5006  -1184    687   -635       C  
+ATOM    651  O2'   A R  32     176.933  10.881 164.758  1.00 37.83           O  
+ANISOU  651  O2'   A R  32     5275   3922   5175  -1237    649   -637       O  
+ATOM    652  C1'   A R  32     174.862  11.370 163.716  1.00 37.21           C  
+ANISOU  652  C1'   A R  32     5122   3958   5057  -1278    712   -601       C  
+ATOM    653  N9    A R  32     174.061  11.005 162.538  1.00 42.15           N  
+ANISOU  653  N9    A R  32     5753   4605   5658  -1263    688   -594       N  
+ATOM    654  C8    A R  32     173.537  11.832 161.592  1.00 36.16           C  
+ANISOU  654  C8    A R  32     4923   3907   4909  -1206    761   -593       C  
+ATOM    655  N7    A R  32     172.855  11.253 160.661  1.00 36.80           N  
+ANISOU  655  N7    A R  32     5031   3990   4960  -1205    710   -587       N  
+ATOM    656  C5    A R  32     172.945   9.925 161.012  1.00 42.09           C  
+ANISOU  656  C5    A R  32     5805   4590   5600  -1268    587   -584       C  
+ATOM    657  C6    A R  32     172.426   8.788 160.407  1.00 39.85           C  
+ANISOU  657  C6    A R  32     5606   4260   5275  -1301    468   -577       C  
+ATOM    658  N6    A R  32     171.699   8.842 159.295  1.00 39.97           N  
+ANISOU  658  N6    A R  32     5607   4303   5275  -1271    461   -574       N  
+ATOM    659  N1    A R  32     172.684   7.615 161.004  1.00 45.09           N  
+ANISOU  659  N1    A R  32     6379   4842   5914  -1367    346   -573       N  
+ATOM    660  C2    A R  32     173.416   7.588 162.119  1.00 38.49           C  
+ANISOU  660  C2    A R  32     5557   3976   5090  -1394    351   -577       C  
+ATOM    661  N3    A R  32     173.964   8.590 162.782  1.00 43.98           N  
+ANISOU  661  N3    A R  32     6175   4711   5824  -1366    458   -585       N  
+ATOM    662  C4    A R  32     173.676   9.744 162.171  1.00 45.31           C  
+ANISOU  662  C4    A R  32     6241   4958   6017  -1305    572   -588       C  
+ATOM    663  P     U R  33     179.070  12.787 161.818  1.00 45.96           P  
+ANISOU  663  P     U R  33     6134   5015   6312   -904    828   -669       P  
+ATOM    664  OP1   U R  33     180.369  13.342 162.228  1.00 38.98           O  
+ANISOU  664  OP1   U R  33     5204   4123   5484   -865    856   -668       O  
+ATOM    665  OP2   U R  33     178.324  13.316 160.649  1.00 41.23           O  
+ANISOU  665  OP2   U R  33     5493   4471   5700   -863    887   -657       O  
+ATOM    666  O5'   U R  33     179.231  11.236 161.515  1.00 41.65           O  
+ANISOU  666  O5'   U R  33     5694   4412   5719   -879    711   -695       O  
+ATOM    667  C5'   U R  33     179.931  10.398 162.408  1.00 48.53           C  
+ANISOU  667  C5'   U R  33     6634   5217   6588   -900    624   -713       C  
+ATOM    668  C4'   U R  33     179.836   8.954 161.971  1.00 43.74           C  
+ANISOU  668  C4'   U R  33     6145   4547   5926   -875    501   -738       C  
+ATOM    669  O4'   U R  33     178.473   8.482 162.150  1.00 41.41           O  
+ANISOU  669  O4'   U R  33     5903   4242   5588   -990    451   -715       O  
+ATOM    670  C3'   U R  33     180.126   8.674 160.503  1.00 43.17           C  
+ANISOU  670  C3'   U R  33     6084   4491   5828   -738    498   -764       C  
+ATOM    671  O3'   U R  33     181.507   8.650 160.185  1.00 46.15           O  
+ANISOU  671  O3'   U R  33     6435   4876   6224   -608    510   -789       O  
+ATOM    672  C2'   U R  33     179.409   7.348 160.303  1.00 44.29           C  
+ANISOU  672  C2'   U R  33     6361   4561   5907   -772    361   -778       C  
+ATOM    673  O2'   U R  33     180.128   6.303 160.934  1.00 45.72           O  
+ANISOU  673  O2'   U R  33     6644   4656   6072   -762    244   -806       O  
+ATOM    674  C1'   U R  33     178.136   7.590 161.117  1.00 43.35           C  
+ANISOU  674  C1'   U R  33     6229   4456   5787   -941    370   -733       C  
+ATOM    675  N1    U R  33     177.084   8.194 160.270  1.00 45.23           N  
+ANISOU  675  N1    U R  33     6408   4761   6016   -951    434   -712       N  
+ATOM    676  C2    U R  33     176.334   7.288 159.569  1.00 47.62           C  
+ANISOU  676  C2    U R  33     6798   5028   6268   -964    336   -714       C  
+ATOM    677  O2    U R  33     176.467   6.080 159.687  1.00 49.72           O  
+ANISOU  677  O2    U R  33     7188   5206   6497   -977    200   -730       O  
+ATOM    678  N3    U R  33     175.389   7.835 158.759  1.00 46.99           N  
+ANISOU  678  N3    U R  33     6663   5010   6181   -968    389   -696       N  
+ATOM    679  C4    U R  33     175.135   9.162 158.537  1.00 42.53           C  
+ANISOU  679  C4    U R  33     5975   4534   5652   -949    526   -679       C  
+ATOM    680  O4    U R  33     174.239   9.447 157.749  1.00 44.73           O  
+ANISOU  680  O4    U R  33     6225   4854   5914   -949    546   -666       O  
+ATOM    681  C5    U R  33     175.967  10.062 159.265  1.00 43.88           C  
+ANISOU  681  C5    U R  33     6069   4730   5872   -933    619   -678       C  
+ATOM    682  C6    U R  33     176.897   9.551 160.087  1.00 47.68           C  
+ANISOU  682  C6    U R  33     6596   5156   6364   -937    570   -693       C  
+ATOM    683  P     G R  34     182.026   9.032 158.705  1.00 51.04           P  
+ANISOU  683  P     G R  34     6995   5568   6832   -452    583   -798       P  
+ATOM    684  OP1   G R  34     183.508   9.025 158.659  1.00 55.96           O  
+ANISOU  684  OP1   G R  34     7568   6216   7476   -338    598   -812       O  
+ATOM    685  OP2   G R  34     181.254  10.171 158.169  1.00 65.92           O  
+ANISOU  685  OP2   G R  34     8793   7520   8733   -485    692   -760       O  
+ATOM    686  O5'   G R  34     181.613   7.784 157.839  1.00 45.43           O  
+ANISOU  686  O5'   G R  34     6414   4807   6042   -383    472   -838       O  
+ATOM    687  C5'   G R  34     182.284   6.554 158.009  1.00 43.90           C  
+ANISOU  687  C5'   G R  34     6331   4539   5810   -313    346   -885       C  
+ATOM    688  C4'   G R  34     181.609   5.497 157.205  1.00 44.74           C  
+ANISOU  688  C4'   G R  34     6576   4584   5840   -274    230   -918       C  
+ATOM    689  O4'   G R  34     180.231   5.371 157.638  1.00 45.57           O  
+ANISOU  689  O4'   G R  34     6725   4648   5941   -444    185   -884       O  
+ATOM    690  C3'   G R  34     181.478   5.776 155.721  1.00 51.35           C  
+ANISOU  690  C3'   G R  34     7390   5484   6635   -147    287   -929       C  
+ATOM    691  O3'   G R  34     182.669   5.598 154.977  1.00 57.67           O  
+ANISOU  691  O3'   G R  34     8177   6331   7405     47    307   -967       O  
+ATOM    692  C2'   G R  34     180.356   4.839 155.330  1.00 46.58           C  
+ANISOU  692  C2'   G R  34     6930   4797   5971   -195    154   -944       C  
+ATOM    693  O2'   G R  34     180.833   3.499 155.295  1.00 62.62           O  
+ANISOU  693  O2'   G R  34     9118   6730   7945   -111     -5  -1000       O  
+ATOM    694  C1'   G R  34     179.426   4.998 156.535  1.00 44.83           C  
+ANISOU  694  C1'   G R  34     6697   4544   5794   -409    138   -894       C  
+ATOM    695  N9    G R  34     178.441   6.053 156.267  1.00 44.80           N  
+ANISOU  695  N9    G R  34     6588   4618   5817   -489    249   -848       N  
+ATOM    696  C8    G R  34     178.481   7.370 156.674  1.00 46.60           C  
+ANISOU  696  C8    G R  34     6670   4930   6107   -534    396   -810       C  
+ATOM    697  N7    G R  34     177.479   8.070 156.219  1.00 46.24           N  
+ANISOU  697  N7    G R  34     6568   4938   6065   -581    459   -780       N  
+ATOM    698  C5    G R  34     176.755   7.166 155.452  1.00 43.65           C  
+ANISOU  698  C5    G R  34     6345   4562   5677   -571    350   -796       C  
+ATOM    699  C6    G R  34     175.577   7.346 154.699  1.00 42.79           C  
+ANISOU  699  C6    G R  34     6233   4480   5547   -605    347   -777       C  
+ATOM    700  O6    G R  34     174.901   8.368 154.562  1.00 42.64           O  
+ANISOU  700  O6    G R  34     6111   4535   5555   -646    447   -744       O  
+ATOM    701  N1    G R  34     175.185   6.172 154.063  1.00 47.86           N  
+ANISOU  701  N1    G R  34     7013   5044   6127   -584    199   -803       N  
+ATOM    702  C2    G R  34     175.857   4.981 154.131  1.00 48.55           C  
+ANISOU  702  C2    G R  34     7236   5035   6174   -527     67   -846       C  
+ATOM    703  N2    G R  34     175.322   3.973 153.440  1.00 48.24           N  
+ANISOU  703  N2    G R  34     7336   4918   6074   -512    -81   -868       N  
+ATOM    704  N3    G R  34     176.962   4.800 154.822  1.00 45.22           N  
+ANISOU  704  N3    G R  34     6820   4593   5770   -484     71   -867       N  
+ATOM    705  C4    G R  34     177.346   5.925 155.455  1.00 45.44           C  
+ANISOU  705  C4    G R  34     6703   4700   5861   -513    217   -838       C  
+ATOM    706  P     G R  35     182.876   6.457 153.633  1.00 68.68           P  
+ANISOU  706  P     G R  35     9471   7846   8779    172    441   -953       P  
+ATOM    707  OP1   G R  35     184.176   6.053 153.029  1.00 77.29           O  
+ANISOU  707  OP1   G R  35    10554   8989   9824    375    445   -993       O  
+ATOM    708  OP2   G R  35     182.564   7.877 153.950  1.00 57.40           O  
+ANISOU  708  OP2   G R  35     7895   6489   7426     58    582   -886       O  
+ATOM    709  O5'   G R  35     181.726   5.935 152.667  1.00 55.73           O  
+ANISOU  709  O5'   G R  35     7946   6162   7068    182    367   -973       O  
+ATOM    710  C5'   G R  35     181.897   4.737 151.936  1.00 53.91           C  
+ANISOU  710  C5'   G R  35     7867   5871   6746    323    238  -1038       C  
+ATOM    711  C4'   G R  35     180.637   4.350 151.218  1.00 53.07           C  
+ANISOU  711  C4'   G R  35     7867   5709   6589    284    157  -1045       C  
+ATOM    712  O4'   G R  35     179.489   4.631 152.049  1.00 49.54           O  
+ANISOU  712  O4'   G R  35     7400   5223   6199     64    143   -993       O  
+ATOM    713  C3'   G R  35     180.326   5.090 149.930  1.00 49.83           C  
+ANISOU  713  C3'   G R  35     7399   5389   6146    368    258  -1031       C  
+ATOM    714  O3'   G R  35     181.079   4.632 148.820  1.00 55.27           O  
+ANISOU  714  O3'   G R  35     8145   6111   6744    591    246  -1084       O  
+ATOM    715  C2'   G R  35     178.840   4.839 149.776  1.00 48.05           C  
+ANISOU  715  C2'   G R  35     7253   5093   5910    238    170  -1016       C  
+ATOM    716  O2'   G R  35     178.616   3.519 149.286  1.00 67.58           O  
+ANISOU  716  O2'   G R  35     9919   7458   8300    307    -13  -1075       O  
+ATOM    717  C1'   G R  35     178.375   4.922 151.232  1.00 46.69           C  
+ANISOU  717  C1'   G R  35     7046   4878   5817     29    151   -974       C  
+ATOM    718  N9    G R  35     177.874   6.269 151.549  1.00 50.34           N  
+ANISOU  718  N9    G R  35     7348   5428   6350    -82    300   -912       N  
+ATOM    719  C8    G R  35     178.457   7.245 152.306  1.00 54.26           C  
+ANISOU  719  C8    G R  35     7709   5990   6919   -123    428   -878       C  
+ATOM    720  N7    G R  35     177.738   8.327 152.359  1.00 49.74           N  
+ANISOU  720  N7    G R  35     7033   5477   6390   -210    527   -831       N  
+ATOM    721  C5    G R  35     176.624   8.031 151.578  1.00 46.61           C  
+ANISOU  721  C5    G R  35     6699   5061   5950   -226    467   -833       C  
+ATOM    722  C6    G R  35     175.483   8.804 151.263  1.00 45.31           C  
+ANISOU  722  C6    G R  35     6472   4941   5800   -300    519   -796       C  
+ATOM    723  O6    G R  35     175.237   9.966 151.616  1.00 42.86           O  
+ANISOU  723  O6    G R  35     6044   4697   5545   -359    635   -757       O  
+ATOM    724  N1    G R  35     174.603   8.117 150.431  1.00 46.38           N  
+ANISOU  724  N1    G R  35     6706   5038   5880   -292    415   -811       N  
+ATOM    725  C2    G R  35     174.791   6.840 149.983  1.00 45.80           C  
+ANISOU  725  C2    G R  35     6784   4879   5741   -224    269   -858       C  
+ATOM    726  N2    G R  35     173.832   6.335 149.197  1.00 52.96           N  
+ANISOU  726  N2    G R  35     7776   5746   6599   -233    168   -864       N  
+ATOM    727  N3    G R  35     175.840   6.114 150.282  1.00 46.53           N  
+ANISOU  727  N3    G R  35     6944   4923   5813   -147    217   -897       N  
+ATOM    728  C4    G R  35     176.705   6.771 151.070  1.00 44.88           C  
+ANISOU  728  C4    G R  35     6628   4764   5661   -153    326   -881       C  
+ATOM    729  P     G R  36     181.549   5.692 147.709  1.00 61.96           P  
+ANISOU  729  P     G R  36     8863   7110   7568    718    420  -1056       P  
+ATOM    730  OP1   G R  36     182.214   4.902 146.628  1.00 62.76           O  
+ANISOU  730  OP1   G R  36     9063   7232   7551    956    370  -1123       O  
+ATOM    731  OP2   G R  36     182.300   6.790 148.393  1.00 55.34           O  
+ANISOU  731  OP2   G R  36     7839   6368   6819    660    573   -996       O  
+ATOM    732  O5'   G R  36     180.176   6.321 147.194  1.00 55.20           O  
+ANISOU  732  O5'   G R  36     8000   6252   6722    608    446  -1017       O  
+ATOM    733  C5'   G R  36     179.255   5.575 146.401  1.00 52.54           C  
+ANISOU  733  C5'   G R  36     7814   5839   6311    636    318  -1055       C  
+ATOM    734  C4'   G R  36     178.028   6.404 146.121  1.00 51.21           C  
+ANISOU  734  C4'   G R  36     7591   5691   6177    511    368  -1003       C  
+ATOM    735  O4'   G R  36     177.489   6.823 147.394  1.00 52.04           O  
+ANISOU  735  O4'   G R  36     7618   5774   6382    304    385   -956       O  
+ATOM    736  C3'   G R  36     178.300   7.696 145.359  1.00 55.18           C  
+ANISOU  736  C3'   G R  36     7956   6324   6684    574    547   -958       C  
+ATOM    737  O3'   G R  36     178.251   7.520 143.951  1.00 66.91           O  
+ANISOU  737  O3'   G R  36     9514   7839   8069    733    538   -987       O  
+ATOM    738  C2'   G R  36     177.256   8.682 145.909  1.00 53.58           C  
+ANISOU  738  C2'   G R  36     7656   6133   6570    385    607   -896       C  
+ATOM    739  O2'   G R  36     176.041   8.632 145.179  1.00 49.70           O  
+ANISOU  739  O2'   G R  36     7225   5614   6046    355    548   -897       O  
+ATOM    740  C1'   G R  36     177.005   8.148 147.318  1.00 46.58           C  
+ANISOU  740  C1'   G R  36     6788   5165   5744    230    523   -897       C  
+ATOM    741  N9    G R  36     177.670   8.939 148.365  1.00 44.99           N  
+ANISOU  741  N9    G R  36     6456   5009   5627    160    631   -859       N  
+ATOM    742  C8    G R  36     178.870   8.653 148.964  1.00 51.66           C  
+ANISOU  742  C8    G R  36     7284   5857   6487    211    639   -874       C  
+ATOM    743  N7    G R  36     179.209   9.530 149.872  1.00 53.36           N  
+ANISOU  743  N7    G R  36     7379   6110   6784    121    733   -831       N  
+ATOM    744  C5    G R  36     178.162  10.421 149.874  1.00 43.51           C  
+ANISOU  744  C5    G R  36     6074   4884   5573     15    787   -790       C  
+ATOM    745  C6    G R  36     177.975  11.569 150.677  1.00 45.76           C  
+ANISOU  745  C6    G R  36     6245   5204   5938    -99    881   -741       C  
+ATOM    746  O6    G R  36     178.750  12.013 151.551  1.00 52.21           O  
+ANISOU  746  O6    G R  36     6992   6034   6813   -134    931   -723       O  
+ATOM    747  N1    G R  36     176.767  12.193 150.365  1.00 44.47           N  
+ANISOU  747  N1    G R  36     6059   5057   5781   -165    905   -717       N  
+ATOM    748  C2    G R  36     175.872  11.777 149.423  1.00 42.94           C  
+ANISOU  748  C2    G R  36     5935   4850   5530   -136    846   -733       C  
+ATOM    749  N2    G R  36     174.777  12.532 149.288  1.00 41.82           N  
+ANISOU  749  N2    G R  36     5746   4735   5407   -205    881   -704       N  
+ATOM    750  N3    G R  36     176.037  10.700 148.678  1.00 42.73           N  
+ANISOU  750  N3    G R  36     6021   4784   5431    -39    752   -776       N  
+ATOM    751  C4    G R  36     177.204  10.087 148.949  1.00 43.80           C  
+ANISOU  751  C4    G R  36     6186   4902   5553     37    730   -804       C  
+ATOM    752  P     G R  37     179.309   8.259 142.989  1.00 64.34           P  
+ANISOU  752  P     G R  37     9096   7658   7693    908    695   -967       P  
+ATOM    753  OP1   G R  37     179.252   7.613 141.659  1.00 67.29           O  
+ANISOU  753  OP1   G R  37     9601   8032   7936   1091    632  -1020       O  
+ATOM    754  OP2   G R  37     180.612   8.358 143.710  1.00 64.48           O  
+ANISOU  754  OP2   G R  37     9017   7733   7749    942    766   -956       O  
+ATOM    755  O5'   G R  37     178.742   9.742 142.864  1.00 68.72           O  
+ANISOU  755  O5'   G R  37     9513   8284   8314    798    834   -886       O  
+ATOM    756  C5'   G R  37     177.398   9.994 142.481  1.00 59.27           C  
+ANISOU  756  C5'   G R  37     8355   7046   7120    714    793   -875       C  
+ATOM    757  C4'   G R  37     177.016  11.431 142.760  1.00 63.97           C  
+ANISOU  757  C4'   G R  37     8806   7699   7799    595    921   -800       C  
+ATOM    758  O4'   G R  37     177.006  11.683 144.205  1.00 65.43           O  
+ANISOU  758  O4'   G R  37     8916   7854   8090    438    931   -777       O  
+ATOM    759  C3'   G R  37     177.948  12.489 142.149  1.00 63.12           C  
+ANISOU  759  C3'   G R  37     8586   7713   7682    681   1083   -745       C  
+ATOM    760  O3'   G R  37     177.171  13.621 141.755  1.00 63.69           O  
+ANISOU  760  O3'   G R  37     8602   7814   7782    617   1151   -693       O  
+ATOM    761  C2'   G R  37     178.807  12.888 143.344  1.00 60.93           C  
+ANISOU  761  C2'   G R  37     8198   7457   7496    602   1146   -713       C  
+ATOM    762  O2'   G R  37     179.440  14.145 143.243  1.00 66.86           O  
+ANISOU  762  O2'   G R  37     8816   8301   8288    592   1289   -638       O  
+ATOM    763  C1'   G R  37     177.772  12.847 144.464  1.00 58.72           C  
+ANISOU  763  C1'   G R  37     7927   7086   7296    424   1075   -719       C  
+ATOM    764  N9    G R  37     178.339  12.868 145.828  1.00 56.43           N  
+ANISOU  764  N9    G R  37     7577   6775   7088    331   1082   -710       N  
+ATOM    765  C8    G R  37     177.974  13.710 146.863  1.00 54.70           C  
+ANISOU  765  C8    G R  37     7276   6546   6963    183   1124   -672       C  
+ATOM    766  N7    G R  37     178.674  13.575 147.964  1.00 41.05           N  
+ANISOU  766  N7    G R  37     5511   4799   5288    131   1122   -672       N  
+ATOM    767  C5    G R  37     179.592  12.607 147.621  1.00 40.03           C  
+ANISOU  767  C5    G R  37     5435   4673   5101    255   1079   -711       C  
+ATOM    768  C6    G R  37     180.614  12.040 148.413  1.00 43.83           C  
+ANISOU  768  C6    G R  37     5910   5140   5603    273   1051   -731       C  
+ATOM    769  O6    G R  37     180.900  12.326 149.591  1.00 50.54           O  
+ANISOU  769  O6    G R  37     6705   5969   6529    171   1061   -713       O  
+ATOM    770  N1    G R  37     181.315  11.074 147.692  1.00 44.78           N  
+ANISOU  770  N1    G R  37     6100   5274   5638    436   1004   -778       N  
+ATOM    771  C2    G R  37     181.050  10.718 146.384  1.00 51.35           C  
+ANISOU  771  C2    G R  37     7006   6129   6374    565    987   -804       C  
+ATOM    772  N2    G R  37     181.819   9.769 145.830  1.00 66.90           N  
+ANISOU  772  N2    G R  37     9047   8113   8259    735    937   -857       N  
+ATOM    773  N3    G R  37     180.099  11.234 145.643  1.00 47.92           N  
+ANISOU  773  N3    G R  37     6583   5703   5921    543   1010   -784       N  
+ATOM    774  C4    G R  37     179.409  12.164 146.323  1.00 42.63           C  
+ANISOU  774  C4    G R  37     5839   5022   5337    384   1056   -737       C  
+ATOM    775  P     C R  38     177.547  14.457 140.435  1.00 69.42           P  
+ANISOU  775  P     C R  38     9292   8643   8441    734   1264   -646       P  
+ATOM    776  OP1   C R  38     177.397  13.536 139.283  1.00 63.54           O  
+ANISOU  776  OP1   C R  38     8680   7891   7572    887   1189   -702       O  
+ATOM    777  OP2   C R  38     178.809  15.202 140.633  1.00 66.12           O  
+ANISOU  777  OP2   C R  38     8749   8321   8054    752   1393   -584       O  
+ATOM    778  O5'   C R  38     176.414  15.564 140.370  1.00 64.26           O  
+ANISOU  778  O5'   C R  38     8599   7977   7842    622   1293   -601       O  
+ATOM    779  C5'   C R  38     175.075  15.206 140.078  1.00 61.15           C  
+ANISOU  779  C5'   C R  38     8288   7516   7429    587   1191   -636       C  
+ATOM    780  C4'   C R  38     174.126  16.150 140.755  1.00 53.40           C  
+ANISOU  780  C4'   C R  38     7234   6515   6540    439   1211   -601       C  
+ATOM    781  O4'   C R  38     174.075  15.838 142.167  1.00 51.99           O  
+ANISOU  781  O4'   C R  38     7022   6291   6442    318   1174   -615       O  
+ATOM    782  C3'   C R  38     174.548  17.607 140.730  1.00 53.47           C  
+ANISOU  782  C3'   C R  38     7136   6586   6595    417   1343   -528       C  
+ATOM    783  O3'   C R  38     174.293  18.251 139.493  1.00 66.78           O  
+ANISOU  783  O3'   C R  38     8838   8313   8221    493   1385   -497       O  
+ATOM    784  C2'   C R  38     173.803  18.186 141.923  1.00 47.99           C  
+ANISOU  784  C2'   C R  38     6379   5853   6001    268   1335   -519       C  
+ATOM    785  O2'   C R  38     172.441  18.392 141.609  1.00 52.78           O  
+ANISOU  785  O2'   C R  38     7011   6438   6605    233   1284   -529       O  
+ATOM    786  C1'   C R  38     173.881  17.022 142.911  1.00 54.04           C  
+ANISOU  786  C1'   C R  38     7178   6567   6788    216   1250   -568       C  
+ATOM    787  N1    C R  38     174.990  17.172 143.878  1.00 54.54           N  
+ANISOU  787  N1    C R  38     7175   6640   6906    183   1304   -551       N  
+ATOM    788  C2    C R  38     174.706  17.985 144.967  1.00 50.64           C  
+ANISOU  788  C2    C R  38     6607   6133   6499     64   1336   -526       C  
+ATOM    789  O2    C R  38     173.584  18.510 145.039  1.00 50.87           O  
+ANISOU  789  O2    C R  38     6626   6153   6549      7   1323   -522       O  
+ATOM    790  N3    C R  38     175.650  18.158 145.901  1.00 41.98           N  
+ANISOU  790  N3    C R  38     5456   5038   5458     24   1373   -511       N  
+ATOM    791  C4    C R  38     176.827  17.560 145.780  1.00 44.03           C  
+ANISOU  791  C4    C R  38     5720   5317   5692     96   1382   -517       C  
+ATOM    792  N4    C R  38     177.702  17.793 146.761  1.00 47.37           N  
+ANISOU  792  N4    C R  38     6081   5740   6178     46   1412   -498       N  
+ATOM    793  C5    C R  38     177.155  16.707 144.667  1.00 45.52           C  
+ANISOU  793  C5    C R  38     5977   5529   5787    229   1355   -544       C  
+ATOM    794  C6    C R  38     176.199  16.537 143.749  1.00 50.65           C  
+ANISOU  794  C6    C R  38     6695   6170   6379    268   1314   -562       C  
+ATOM    795  P     G R  39     175.338  19.343 138.969  1.00 64.29           P  
+ANISOU  795  P     G R  39     8448   8084   7896    539   1521   -416       P  
+ATOM    796  OP1   G R  39     174.884  19.923 137.671  1.00 80.28           O  
+ANISOU  796  OP1   G R  39    10512  10142   9851    610   1546   -386       O  
+ATOM    797  OP2   G R  39     176.706  18.753 139.056  1.00 53.44           O  
+ANISOU  797  OP2   G R  39     7050   6762   6493    612   1560   -415       O  
+ATOM    798  O5'   G R  39     175.185  20.478 140.062  1.00 46.21           O  
+ANISOU  798  O5'   G R  39     6063   5771   5724    398   1564   -371       O  
+ATOM    799  C5'   G R  39     176.309  21.087 140.662  1.00 53.98           C  
+ANISOU  799  C5'   G R  39     6958   6789   6764    359   1644   -316       C  
+ATOM    800  C4'   G R  39     175.952  21.602 142.030  1.00 57.49           C  
+ANISOU  800  C4'   G R  39     7353   7175   7315    225   1628   -318       C  
+ATOM    801  O4'   G R  39     176.005  20.502 142.980  1.00 52.82           O  
+ANISOU  801  O4'   G R  39     6779   6545   6745    193   1561   -380       O  
+ATOM    802  C3'   G R  39     176.889  22.646 142.611  1.00 56.19           C  
+ANISOU  802  C3'   G R  39     7100   7029   7221    162   1702   -247       C  
+ATOM    803  O3'   G R  39     176.606  23.950 142.144  1.00 58.70           O  
+ANISOU  803  O3'   G R  39     7401   7349   7551    140   1745   -184       O  
+ATOM    804  C2'   G R  39     176.687  22.468 144.106  1.00 49.12           C  
+ANISOU  804  C2'   G R  39     6185   6072   6408     60   1657   -285       C  
+ATOM    805  O2'   G R  39     175.452  23.037 144.510  1.00 47.94           O  
+ANISOU  805  O2'   G R  39     6050   5875   6292     -2   1623   -305       O  
+ATOM    806  C1'   G R  39     176.550  20.947 144.198  1.00 46.63           C  
+ANISOU  806  C1'   G R  39     5927   5743   6048    102   1585   -360       C  
+ATOM    807  N9    G R  39     177.856  20.297 144.368  1.00 41.11           N  
+ANISOU  807  N9    G R  39     5204   5078   5339    146   1603   -358       N  
+ATOM    808  C8    G R  39     178.529  19.521 143.460  1.00 41.01           C  
+ANISOU  808  C8    G R  39     5220   5120   5244    270   1611   -368       C  
+ATOM    809  N7    G R  39     179.672  19.093 143.915  1.00 42.42           N  
+ANISOU  809  N7    G R  39     5356   5327   5435    292   1626   -366       N  
+ATOM    810  C5    G R  39     179.751  19.625 145.198  1.00 41.09           C  
+ANISOU  810  C5    G R  39     5133   5113   5366    167   1624   -350       C  
+ATOM    811  C6    G R  39     180.744  19.513 146.197  1.00 39.95           C  
+ANISOU  811  C6    G R  39     4930   4969   5281    125   1628   -342       C  
+ATOM    812  O6    G R  39     181.815  18.917 146.180  1.00 43.59           O  
+ANISOU  812  O6    G R  39     5363   5477   5723    191   1637   -343       O  
+ATOM    813  N1    G R  39     180.396  20.201 147.339  1.00 39.72           N  
+ANISOU  813  N1    G R  39     4874   4878   5340     -3   1617   -332       N  
+ATOM    814  C2    G R  39     179.252  20.940 147.525  1.00 41.41           C  
+ANISOU  814  C2    G R  39     5108   5046   5580    -73   1608   -332       C  
+ATOM    815  N2    G R  39     179.119  21.538 148.718  1.00 41.98           N  
+ANISOU  815  N2    G R  39     5154   5068   5728   -177   1596   -328       N  
+ATOM    816  N3    G R  39     178.309  21.049 146.616  1.00 42.64           N  
+ANISOU  816  N3    G R  39     5308   5207   5684    -34   1604   -340       N  
+ATOM    817  C4    G R  39     178.633  20.374 145.491  1.00 41.75           C  
+ANISOU  817  C4    G R  39     5228   5145   5489     80   1611   -347       C  
+ATOM    818  P     G R  40     177.809  24.981 141.876  1.00 47.27           P  
+ANISOU  818  P     G R  40     5884   5954   6124    123   1831    -77       P  
+ATOM    819  OP1   G R  40     177.198  26.267 141.406  1.00 60.20           O  
+ANISOU  819  OP1   G R  40     7537   7566   7771     95   1845    -25       O  
+ATOM    820  OP2   G R  40     178.906  24.331 141.098  1.00 49.59           O  
+ANISOU  820  OP2   G R  40     6154   6343   6346    217   1883    -50       O  
+ATOM    821  O5'   G R  40     178.400  25.267 143.334  1.00 43.92           O  
+ANISOU  821  O5'   G R  40     5398   5488   5802     17   1823    -70       O  
+ATOM    822  C5'   G R  40     177.614  25.904 144.333  1.00 50.95           C  
+ANISOU  822  C5'   G R  40     6299   6296   6764    -71   1781    -95       C  
+ATOM    823  C4'   G R  40     178.338  25.948 145.661  1.00 53.33           C  
+ANISOU  823  C4'   G R  40     6552   6565   7145   -153   1770    -95       C  
+ATOM    824  O4'   G R  40     178.624  24.602 146.134  1.00 53.19           O  
+ANISOU  824  O4'   G R  40     6537   6559   7114   -130   1741   -158       O  
+ATOM    825  C3'   G R  40     179.696  26.641 145.646  1.00 47.77           C  
+ANISOU  825  C3'   G R  40     5776   5896   6478   -189   1821      0       C  
+ATOM    826  O3'   G R  40     179.553  28.057 145.732  1.00 51.95           O  
+ANISOU  826  O3'   G R  40     6306   6378   7054   -256   1822     62       O  
+ATOM    827  C2'   G R  40     180.402  26.020 146.853  1.00 45.91           C  
+ANISOU  827  C2'   G R  40     5504   5644   6297   -234   1795    -31       C  
+ATOM    828  O2'   G R  40     180.044  26.656 148.070  1.00 40.04           O  
+ANISOU  828  O2'   G R  40     4771   4815   5627   -326   1751    -50       O  
+ATOM    829  C1'   G R  40     179.828  24.590 146.864  1.00 49.70           C  
+ANISOU  829  C1'   G R  40     6034   6127   6724   -170   1755   -127       C  
+ATOM    830  N9    G R  40     180.768  23.677 146.219  1.00 49.24           N  
+ANISOU  830  N9    G R  40     5950   6148   6609    -83   1783   -121       N  
+ATOM    831  C8    G R  40     180.731  23.225 144.931  1.00 55.89           C  
+ANISOU  831  C8    G R  40     6818   7056   7360     27   1811   -119       C  
+ATOM    832  N7    G R  40     181.754  22.467 144.650  1.00 56.18           N  
+ANISOU  832  N7    G R  40     6822   7165   7358    103   1834   -116       N  
+ATOM    833  C5    G R  40     182.507  22.441 145.809  1.00 51.95           C  
+ANISOU  833  C5    G R  40     6230   6609   6900     33   1820   -112       C  
+ATOM    834  C6    G R  40     183.727  21.788 146.074  1.00 49.42           C  
+ANISOU  834  C6    G R  40     5850   6347   6581     75   1830   -107       C  
+ATOM    835  O6    G R  40     184.386  21.079 145.288  1.00 48.39           O  
+ANISOU  835  O6    G R  40     5705   6308   6374    196   1859   -109       O  
+ATOM    836  N1    G R  40     184.155  22.042 147.386  1.00 44.47           N  
+ANISOU  836  N1    G R  40     5181   5667   6049    -30   1800   -103       N  
+ATOM    837  C2    G R  40     183.479  22.807 148.313  1.00 38.91           C  
+ANISOU  837  C2    G R  40     4499   4866   5419   -149   1765   -106       C  
+ATOM    838  N2    G R  40     184.044  22.919 149.528  1.00 38.31           N  
+ANISOU  838  N2    G R  40     4388   4748   5421   -230   1733   -105       N  
+ATOM    839  N3    G R  40     182.335  23.424 148.065  1.00 43.83           N  
+ANISOU  839  N3    G R  40     5176   5441   6035   -177   1759   -113       N  
+ATOM    840  C4    G R  40     181.919  23.197 146.796  1.00 50.07           C  
+ANISOU  840  C4    G R  40     5999   6281   6742    -86   1787   -114       C  
+ATOM    841  P     A R  41     180.108  29.076 144.614  1.00 50.74           P  
+ANISOU  841  P     A R  41     6130   6269   6878   -255   1877    181       P  
+ATOM    842  OP1   A R  41     179.054  30.099 144.397  1.00 58.00           O  
+ANISOU  842  OP1   A R  41     7117   7118   7801   -270   1846    183       O  
+ATOM    843  OP2   A R  41     180.734  28.395 143.449  1.00 47.33           O  
+ANISOU  843  OP2   A R  41     5668   5952   6363   -165   1940    215       O  
+ATOM    844  O5'   A R  41     181.278  29.819 145.382  1.00 50.83           O  
+ANISOU  844  O5'   A R  41     6074   6264   6974   -359   1878    263       O  
+ATOM    845  C5'   A R  41     182.554  29.217 145.519  1.00 40.42           C  
+ANISOU  845  C5'   A R  41     4668   5025   5665   -360   1913    299       C  
+ATOM    846  C4'   A R  41     183.470  30.052 146.377  1.00 40.69           C  
+ANISOU  846  C4'   A R  41     4646   5022   5792   -478   1891    373       C  
+ATOM    847  O4'   A R  41     184.672  29.278 146.636  1.00 44.51           O  
+ANISOU  847  O4'   A R  41     5035   5589   6286   -469   1919    391       O  
+ATOM    848  C3'   A R  41     183.942  31.341 145.719  1.00 49.09           C  
+ANISOU  848  C3'   A R  41     5687   6095   6870   -545   1912    510       C  
+ATOM    849  O3'   A R  41     184.387  32.240 146.723  1.00 55.02           O  
+ANISOU  849  O3'   A R  41     6430   6758   7718   -667   1852    554       O  
+ATOM    850  C2'   A R  41     185.179  30.868 144.979  1.00 53.35           C  
+ANISOU  850  C2'   A R  41     6113   6787   7370   -513   1992    595       C  
+ATOM    851  O2'   A R  41     186.083  31.898 144.648  1.00 62.23           O  
+ANISOU  851  O2'   A R  41     7170   7949   8527   -607   2013    746       O  
+ATOM    852  C1'   A R  41     185.774  29.882 145.995  1.00 49.10           C  
+ANISOU  852  C1'   A R  41     5524   6261   6871   -506   1972    527       C  
+ATOM    853  N9    A R  41     186.579  28.822 145.373  1.00 55.04           N  
+ANISOU  853  N9    A R  41     6196   7160   7557   -405   2039    532       N  
+ATOM    854  C8    A R  41     186.449  28.393 144.078  1.00 44.99           C  
+ANISOU  854  C8    A R  41     4927   5990   6176   -289   2107    542       C  
+ATOM    855  N7    A R  41     187.310  27.452 143.763  1.00 58.58           N  
+ANISOU  855  N7    A R  41     6572   7838   7847   -196   2156    539       N  
+ATOM    856  C5    A R  41     188.058  27.254 144.918  1.00 53.86           C  
+ANISOU  856  C5    A R  41     5911   7219   7335   -261   2117    531       C  
+ATOM    857  C6    A R  41     189.124  26.384 145.231  1.00 58.44           C  
+ANISOU  857  C6    A R  41     6397   7893   7915   -207   2132    521       C  
+ATOM    858  N6    A R  41     189.663  25.511 144.372  1.00 65.20           N  
+ANISOU  858  N6    A R  41     7206   8895   8673    -62   2196    516       N  
+ATOM    859  N1    A R  41     189.643  26.441 146.478  1.00 59.25           N  
+ANISOU  859  N1    A R  41     6460   7936   8118   -299   2074    514       N  
+ATOM    860  C2    A R  41     189.108  27.312 147.339  1.00 52.28           C  
+ANISOU  860  C2    A R  41     5635   6909   7322   -430   2007    514       C  
+ATOM    861  N3    A R  41     188.108  28.157 147.161  1.00 50.98           N  
+ANISOU  861  N3    A R  41     5561   6649   7162   -479   1987    517       N  
+ATOM    862  C4    A R  41     187.615  28.086 145.921  1.00 54.03           C  
+ANISOU  862  C4    A R  41     5978   7096   7454   -392   2045    527       C  
+ATOM    863  P     A R  42     183.476  33.400 147.356  1.00 55.37           P  
+ANISOU  863  P     A R  42     6582   6646   7812   -729   1766    531       P  
+ATOM    864  OP1   A R  42     182.044  33.226 147.104  1.00 59.35           O  
+ANISOU  864  OP1   A R  42     7177   7110   8262   -646   1755    432       O  
+ATOM    865  OP2   A R  42     184.094  34.675 146.917  1.00 61.36           O  
+ANISOU  865  OP2   A R  42     7329   7383   8601   -824   1753    673       O  
+ATOM    866  O5'   A R  42     183.918  33.309 148.888  1.00 74.01           O  
+ANISOU  866  O5'   A R  42     8931   8934  10257   -801   1701    487       O  
+ATOM    867  C5'   A R  42     183.115  32.753 149.911  1.00 56.95           C  
+ANISOU  867  C5'   A R  42     6827   6709   8104   -770   1658    356       C  
+ATOM    868  C4'   A R  42     183.256  31.254 150.057  1.00 56.96           C  
+ANISOU  868  C4'   A R  42     6782   6789   8070   -703   1695    282       C  
+ATOM    869  O4'   A R  42     184.537  30.882 150.684  1.00 54.49           O  
+ANISOU  869  O4'   A R  42     6386   6509   7810   -753   1690    317       O  
+ATOM    870  C3'   A R  42     182.169  30.675 150.967  1.00 51.22           C  
+ANISOU  870  C3'   A R  42     6125   6002   7335   -672   1653    152       C  
+ATOM    871  O3'   A R  42     181.766  29.398 150.512  1.00 42.91           O  
+ANISOU  871  O3'   A R  42     5068   5019   6216   -587   1687     87       O  
+ATOM    872  C2'   A R  42     182.891  30.553 152.296  1.00 47.93           C  
+ANISOU  872  C2'   A R  42     5688   5540   6986   -741   1604    137       C  
+ATOM    873  O2'   A R  42     182.296  29.709 153.249  1.00 65.36           O  
+ANISOU  873  O2'   A R  42     7931   7719   9183   -722   1575     31       O  
+ATOM    874  C1'   A R  42     184.262  30.085 151.834  1.00 47.22           C  
+ANISOU  874  C1'   A R  42     5493   5544   6905   -747   1648    213       C  
+ATOM    875  N9    A R  42     185.262  30.248 152.895  1.00 43.79           N  
+ANISOU  875  N9    A R  42     5017   5074   6549   -830   1600    239       N  
+ATOM    876  C8    A R  42     185.558  31.389 153.628  1.00 46.49           C  
+ANISOU  876  C8    A R  42     5382   5319   6962   -929   1533    285       C  
+ATOM    877  N7    A R  42     186.449  31.200 154.580  1.00 50.68           N  
+ANISOU  877  N7    A R  42     5872   5830   7553   -987   1489    292       N  
+ATOM    878  C5    A R  42     186.725  29.826 154.492  1.00 46.50           C  
+ANISOU  878  C5    A R  42     5291   5389   6986   -915   1531    242       C  
+ATOM    879  C6    A R  42     187.578  28.960 155.212  1.00 40.76           C  
+ANISOU  879  C6    A R  42     4510   4690   6287   -919   1511    218       C  
+ATOM    880  N6    A R  42     188.369  29.286 156.227  1.00 41.55           N  
+ANISOU  880  N6    A R  42     4587   4736   6462  -1002   1445    242       N  
+ATOM    881  N1    A R  42     187.604  27.671 154.850  1.00 49.98           N  
+ANISOU  881  N1    A R  42     5653   5939   7397   -825   1552    165       N  
+ATOM    882  C2    A R  42     186.824  27.260 153.849  1.00 56.66           C  
+ANISOU  882  C2    A R  42     6530   6834   8166   -739   1606    136       C  
+ATOM    883  N3    A R  42     186.000  27.972 153.101  1.00 49.84           N  
+ANISOU  883  N3    A R  42     5710   5957   7271   -730   1632    155       N  
+ATOM    884  C4    A R  42     185.990  29.249 153.471  1.00 43.86           C  
+ANISOU  884  C4    A R  42     4973   5121   6570   -819   1595    208       C  
+ATOM    885  P     A R  43     180.230  29.207 150.158  1.00 43.57           P  
+ANISOU  885  P     A R  43     5225   5087   6242   -524   1680      9       P  
+ATOM    886  OP1   A R  43     180.093  29.069 148.675  1.00 38.46           O  
+ANISOU  886  OP1   A R  43     4574   4512   5527   -452   1732     46       O  
+ATOM    887  OP2   A R  43     179.476  30.267 150.888  1.00 48.08           O  
+ANISOU  887  OP2   A R  43     5853   5565   6848   -566   1631    -11       O  
+ATOM    888  O5'   A R  43     179.841  27.855 150.898  1.00 46.43           O  
+ANISOU  888  O5'   A R  43     5600   5456   6586   -502   1656    -89       O  
+ATOM    889  C5'   A R  43     179.917  27.727 152.317  1.00 46.92           C  
+ANISOU  889  C5'   A R  43     5670   5462   6694   -560   1610   -133       C  
+ATOM    890  C4'   A R  43     179.821  26.273 152.724  1.00 47.48           C  
+ANISOU  890  C4'   A R  43     5747   5558   6737   -537   1593   -202       C  
+ATOM    891  O4'   A R  43     178.509  25.788 152.358  1.00 40.61           O  
+ANISOU  891  O4'   A R  43     4921   4700   5810   -496   1585   -259       O  
+ATOM    892  C3'   A R  43     180.814  25.371 152.014  1.00 51.74           C  
+ANISOU  892  C3'   A R  43     6242   6167   7251   -486   1622   -179       C  
+ATOM    893  O3'   A R  43     181.141  24.248 152.835  1.00 54.56           O  
+ANISOU  893  O3'   A R  43     6604   6515   7610   -492   1584   -232       O  
+ATOM    894  C2'   A R  43     180.042  24.920 150.769  1.00 51.57           C  
+ANISOU  894  C2'   A R  43     6251   6191   7151   -404   1645   -196       C  
+ATOM    895  O2'   A R  43     180.409  23.656 150.283  1.00 52.41           O  
+ANISOU  895  O2'   A R  43     6360   6347   7206   -334   1644   -225       O  
+ATOM    896  C1'   A R  43     178.592  24.913 151.241  1.00 43.49           C  
+ANISOU  896  C1'   A R  43     5285   5124   6116   -423   1606   -260       C  
+ATOM    897  N9    A R  43     177.648  25.420 150.231  1.00 49.69           N  
+ANISOU  897  N9    A R  43     6096   5924   6860   -380   1624   -252       N  
+ATOM    898  C8    A R  43     177.148  26.709 150.180  1.00 47.79           C  
+ANISOU  898  C8    A R  43     5865   5652   6642   -399   1631   -225       C  
+ATOM    899  N7    A R  43     176.302  26.942 149.204  1.00 43.49           N  
+ANISOU  899  N7    A R  43     5346   5126   6052   -348   1640   -225       N  
+ATOM    900  C5    A R  43     176.205  25.717 148.558  1.00 45.24           C  
+ANISOU  900  C5    A R  43     5580   5394   6217   -294   1637   -255       C  
+ATOM    901  C6    A R  43     175.449  25.287 147.436  1.00 52.69           C  
+ANISOU  901  C6    A R  43     6557   6370   7093   -225   1633   -272       C  
+ATOM    902  N6    A R  43     174.619  26.090 146.753  1.00 45.24           N  
+ANISOU  902  N6    A R  43     5635   5424   6130   -199   1638   -258       N  
+ATOM    903  N1    A R  43     175.569  23.983 147.031  1.00 40.85           N  
+ANISOU  903  N1    A R  43     5080   4899   5543   -178   1613   -307       N  
+ATOM    904  C2    A R  43     176.404  23.211 147.729  1.00 40.86           C  
+ANISOU  904  C2    A R  43     5066   4897   5562   -197   1601   -323       C  
+ATOM    905  N3    A R  43     177.160  23.482 148.794  1.00 41.45           N  
+ANISOU  905  N3    A R  43     5102   4948   5698   -260   1607   -309       N  
+ATOM    906  C4    A R  43     177.011  24.765 149.185  1.00 49.90           C  
+ANISOU  906  C4    A R  43     6152   5988   6818   -310   1625   -275       C  
+ATOM    907  P     G R  44     182.674  23.952 153.209  1.00 48.02           P  
+ANISOU  907  P     G R  44     5711   5712   6822   -502   1584   -197       P  
+ATOM    908  OP1   G R  44     183.539  24.284 152.048  1.00 53.08           O  
+ANISOU  908  OP1   G R  44     6283   6435   7448   -454   1646   -118       O  
+ATOM    909  OP2   G R  44     182.676  22.585 153.809  1.00 59.77           O  
+ANISOU  909  OP2   G R  44     7234   7189   8287   -482   1536   -269       O  
+ATOM    910  O5'   G R  44     183.031  25.002 154.353  1.00 59.51           O  
+ANISOU  910  O5'   G R  44     7153   7099   8360   -603   1555   -168       O  
+ATOM    911  C5'   G R  44     182.523  24.855 155.666  1.00 50.75           C  
+ANISOU  911  C5'   G R  44     6095   5917   7272   -656   1500   -229       C  
+ATOM    912  C4'   G R  44     183.623  24.962 156.687  1.00 45.53           C  
+ANISOU  912  C4'   G R  44     5401   5222   6675   -715   1462   -210       C  
+ATOM    913  O4'   G R  44     184.641  25.873 156.206  1.00 47.20           O  
+ANISOU  913  O4'   G R  44     5540   5458   6934   -740   1487   -116       O  
+ATOM    914  C3'   G R  44     183.176  25.526 158.035  1.00 40.51           C  
+ANISOU  914  C3'   G R  44     4820   4498   6073   -785   1409   -244       C  
+ATOM    915  O3'   G R  44     182.730  24.493 158.905  1.00 53.89           O  
+ANISOU  915  O3'   G R  44     6562   6174   7738   -789   1372   -318       O  
+ATOM    916  C2'   G R  44     184.410  26.270 158.536  1.00 42.68           C  
+ANISOU  916  C2'   G R  44     5049   4742   6425   -848   1381   -182       C  
+ATOM    917  O2'   G R  44     185.319  25.342 159.101  1.00 48.63           O  
+ANISOU  917  O2'   G R  44     5772   5509   7196   -851   1352   -196       O  
+ATOM    918  C1'   G R  44     185.023  26.774 157.226  1.00 49.07           C  
+ANISOU  918  C1'   G R  44     5785   5618   7241   -827   1436    -93       C  
+ATOM    919  N9    G R  44     184.573  28.129 156.830  1.00 42.19           N  
+ANISOU  919  N9    G R  44     4938   4708   6384   -856   1443    -45       N  
+ATOM    920  C8    G R  44     183.872  28.400 155.678  1.00 36.17           C  
+ANISOU  920  C8    G R  44     4185   3983   5574   -806   1493    -29       C  
+ATOM    921  N7    G R  44     183.603  29.673 155.499  1.00 45.83           N  
+ANISOU  921  N7    G R  44     5439   5155   6819   -841   1480     16       N  
+ATOM    922  C5    G R  44     184.148  30.297 156.616  1.00 46.65           C  
+ANISOU  922  C5    G R  44     5558   5177   6989   -920   1412     28       C  
+ATOM    923  C6    G R  44     184.150  31.686 156.975  1.00 48.50           C  
+ANISOU  923  C6    G R  44     5843   5316   7270   -982   1354     69       C  
+ATOM    924  O6    G R  44     183.663  32.658 156.359  1.00 39.35           O  
+ANISOU  924  O6    G R  44     4725   4125   6103   -980   1352    105       O  
+ATOM    925  N1    G R  44     184.812  31.897 158.191  1.00 46.49           N  
+ANISOU  925  N1    G R  44     5601   4988   7074  -1051   1280     65       N  
+ATOM    926  C2    G R  44     185.383  30.901 158.957  1.00 51.74           C  
+ANISOU  926  C2    G R  44     6231   5676   7753  -1058   1268     27       C  
+ATOM    927  N2    G R  44     185.967  31.336 160.085  1.00 41.40           N  
+ANISOU  927  N2    G R  44     4948   4282   6500  -1127   1186     29       N  
+ATOM    928  N3    G R  44     185.386  29.596 158.634  1.00 47.40           N  
+ANISOU  928  N3    G R  44     5635   5214   7160   -998   1322    -11       N  
+ATOM    929  C4    G R  44     184.753  29.362 157.455  1.00 46.00           C  
+ANISOU  929  C4    G R  44     5449   5105   6925   -931   1390     -9       C  
+ATOM    930  P     C R  45     181.300  24.574 159.638  1.00 51.64           P  
+ANISOU  930  P     C R  45     6350   5856   7416   -806   1354   -381       P  
+ATOM    931  OP1   C R  45     180.986  23.272 160.290  1.00 65.35           O  
+ANISOU  931  OP1   C R  45     8121   7594   9113   -814   1321   -437       O  
+ATOM    932  OP2   C R  45     180.282  25.168 158.740  1.00 53.05           O  
+ANISOU  932  OP2   C R  45     6536   6059   7561   -769   1394   -375       O  
+ATOM    933  O5'   C R  45     181.586  25.609 160.811  1.00 44.77           O  
+ANISOU  933  O5'   C R  45     5504   4911   6596   -866   1313   -376       O  
+ATOM    934  C5'   C R  45     182.554  25.306 161.804  1.00 38.70           C  
+ANISOU  934  C5'   C R  45     4734   4103   5867   -910   1264   -378       C  
+ATOM    935  C4'   C R  45     182.897  26.532 162.598  1.00 37.50           C  
+ANISOU  935  C4'   C R  45     4606   3876   5765   -959   1222   -359       C  
+ATOM    936  O4'   C R  45     183.575  27.475 161.739  1.00 48.09           O  
+ANISOU  936  O4'   C R  45     5899   5218   7156   -968   1237   -281       O  
+ATOM    937  C3'   C R  45     181.713  27.316 163.124  1.00 35.82           C  
+ANISOU  937  C3'   C R  45     4465   3628   5519   -951   1214   -401       C  
+ATOM    938  O3'   C R  45     181.167  26.749 164.296  1.00 45.39           O  
+ANISOU  938  O3'   C R  45     5729   4828   6690   -963   1188   -465       O  
+ATOM    939  C2'   C R  45     182.309  28.701 163.323  1.00 37.35           C  
+ANISOU  939  C2'   C R  45     4674   3744   5771   -986   1172   -356       C  
+ATOM    940  O2'   C R  45     183.133  28.714 164.482  1.00 38.50           O  
+ANISOU  940  O2'   C R  45     4844   3827   5958  -1038   1103   -362       O  
+ATOM    941  C1'   C R  45     183.224  28.795 162.105  1.00 41.85           C  
+ANISOU  941  C1'   C R  45     5162   4354   6385   -992   1204   -273       C  
+ATOM    942  N1    C R  45     182.590  29.457 160.943  1.00 39.61           N  
+ANISOU  942  N1    C R  45     4873   4096   6080   -954   1250   -242       N  
+ATOM    943  C2    C R  45     182.507  30.847 160.968  1.00 42.22           C  
+ANISOU  943  C2    C R  45     5250   4354   6439   -975   1213   -210       C  
+ATOM    944  O2    C R  45     182.935  31.439 161.960  1.00 42.24           O  
+ANISOU  944  O2    C R  45     5297   4273   6481  -1022   1141   -213       O  
+ATOM    945  N3    C R  45     181.967  31.495 159.927  1.00 39.74           N  
+ANISOU  945  N3    C R  45     4940   4054   6106   -942   1246   -179       N  
+ATOM    946  C4    C R  45     181.499  30.831 158.887  1.00 45.45           C  
+ANISOU  946  C4    C R  45     5622   4863   6783   -889   1316   -181       C  
+ATOM    947  N4    C R  45     180.978  31.543 157.894  1.00 40.56           N  
+ANISOU  947  N4    C R  45     5015   4251   6145   -857   1341   -149       N  
+ATOM    948  C5    C R  45     181.552  29.404 158.816  1.00 40.06           C  
+ANISOU  948  C5    C R  45     4897   4255   6069   -864   1352   -216       C  
+ATOM    949  C6    C R  45     182.104  28.778 159.867  1.00 37.79           C  
+ANISOU  949  C6    C R  45     4609   3948   5803   -898   1316   -245       C  
+ATOM    950  P     C R  46     179.612  26.900 164.617  1.00 36.27           P  
+ANISOU  950  P     C R  46     4619   3701   5459   -928   1211   -520       P  
+ATOM    951  OP1   C R  46     179.407  26.354 165.979  1.00 44.21           O  
+ANISOU  951  OP1   C R  46     5672   4695   6430   -957   1177   -568       O  
+ATOM    952  OP2   C R  46     178.780  26.577 163.438  1.00 35.33           O  
+ANISOU  952  OP2   C R  46     4465   3654   5304   -885   1267   -516       O  
+ATOM    953  O5'   C R  46     179.453  28.492 164.809  1.00 47.65           O  
+ANISOU  953  O5'   C R  46     6106   5078   6921   -912   1187   -515       O  
+ATOM    954  C5'   C R  46     179.900  29.109 165.999  1.00 36.34           C  
+ANISOU  954  C5'   C R  46     4734   3565   5509   -938   1121   -532       C  
+ATOM    955  C4'   C R  46     179.714  30.620 165.955  1.00 40.94           C  
+ANISOU  955  C4'   C R  46     5371   4077   6107   -912   1087   -526       C  
+ATOM    956  O4'   C R  46     180.439  31.195 164.829  1.00 39.07           O  
+ANISOU  956  O4'   C R  46     5092   3818   5933   -933   1088   -448       O  
+ATOM    957  C3'   C R  46     178.294  31.123 165.772  1.00 38.62           C  
+ANISOU  957  C3'   C R  46     5107   3822   5744   -833   1120   -571       C  
+ATOM    958  O3'   C R  46     177.521  31.060 166.960  1.00 42.84           O  
+ANISOU  958  O3'   C R  46     5696   4372   6210   -800   1110   -642       O  
+ATOM    959  C2'   C R  46     178.546  32.540 165.265  1.00 40.34           C  
+ANISOU  959  C2'   C R  46     5367   3956   6004   -820   1077   -535       C  
+ATOM    960  O2'   C R  46     179.042  33.337 166.323  1.00 40.92           O  
+ANISOU  960  O2'   C R  46     5526   3922   6098   -837    989   -551       O  
+ATOM    961  C1'   C R  46     179.709  32.294 164.322  1.00 43.02           C  
+ANISOU  961  C1'   C R  46     5634   4294   6418   -884   1087   -448       C  
+ATOM    962  N1    C R  46     179.270  32.000 162.938  1.00 37.98           N  
+ANISOU  962  N1    C R  46     4933   3734   5763   -852   1160   -418       N  
+ATOM    963  C2    C R  46     178.921  33.130 162.207  1.00 43.56           C  
+ANISOU  963  C2    C R  46     5672   4405   6475   -821   1151   -390       C  
+ATOM    964  O2    C R  46     178.992  34.239 162.759  1.00 40.80           O  
+ANISOU  964  O2    C R  46     5402   3958   6142   -821   1079   -395       O  
+ATOM    965  N3    C R  46     178.517  32.981 160.933  1.00 40.25           N  
+ANISOU  965  N3    C R  46     5207   4049   6038   -788   1210   -361       N  
+ATOM    966  C4    C R  46     178.447  31.776 160.392  1.00 42.19           C  
+ANISOU  966  C4    C R  46     5382   4386   6260   -783   1272   -362       C  
+ATOM    967  N4    C R  46     178.041  31.717 159.125  1.00 48.30           N  
+ANISOU  967  N4    C R  46     6124   5214   7013   -745   1321   -335       N  
+ATOM    968  C5    C R  46     178.786  30.594 161.113  1.00 40.67           C  
+ANISOU  968  C5    C R  46     5162   4227   6063   -813   1277   -392       C  
+ATOM    969  C6    C R  46     179.187  30.764 162.377  1.00 39.40           C  
+ANISOU  969  C6    C R  46     5044   4006   5921   -849   1222   -417       C  
+ATOM    970  P     U R  47     175.927  30.839 166.898  1.00 44.02           P  
+ANISOU  970  P     U R  47     5829   4629   6266   -726   1172   -693       P  
+ATOM    971  OP1   U R  47     175.381  30.683 168.275  1.00 57.35           O  
+ANISOU  971  OP1   U R  47     7564   6345   7883   -706   1162   -753       O  
+ATOM    972  OP2   U R  47     175.681  29.796 165.884  1.00 42.06           O  
+ANISOU  972  OP2   U R  47     5497   4466   6016   -747   1232   -664       O  
+ATOM    973  O5'   U R  47     175.349  32.187 166.244  1.00 43.91           O  
+ANISOU  973  O5'   U R  47     5850   4584   6249   -647   1162   -697       O  
+ATOM    974  C5'   U R  47     175.435  33.448 166.883  1.00 43.60           C  
+ANISOU  974  C5'   U R  47     5909   4449   6208   -604   1092   -724       C  
+ATOM    975  C4'   U R  47     174.828  34.514 166.002  1.00 48.68           C  
+ANISOU  975  C4'   U R  47     6577   5072   6848   -529   1086   -721       C  
+ATOM    976  O4'   U R  47     175.611  34.660 164.791  1.00 44.52           O  
+ANISOU  976  O4'   U R  47     6013   4504   6397   -586   1086   -639       O  
+ATOM    977  C3'   U R  47     173.424  34.218 165.505  1.00 47.67           C  
+ANISOU  977  C3'   U R  47     6393   5071   6648   -450   1159   -755       C  
+ATOM    978  O3'   U R  47     172.439  34.612 166.442  1.00 54.41           O  
+ANISOU  978  O3'   U R  47     7290   5967   7417   -355   1155   -831       O  
+ATOM    979  C2'   U R  47     173.344  35.031 164.222  1.00 43.52           C  
+ANISOU  979  C2'   U R  47     5873   4507   6157   -420   1151   -715       C  
+ATOM    980  O2'   U R  47     173.047  36.393 164.513  1.00 44.62           O  
+ANISOU  980  O2'   U R  47     6116   4560   6278   -337   1081   -749       O  
+ATOM    981  C1'   U R  47     174.772  34.948 163.704  1.00 42.25           C  
+ANISOU  981  C1'   U R  47     5700   4266   6087   -525   1126   -633       C  
+ATOM    982  N1    U R  47     174.926  33.901 162.681  1.00 43.27           N  
+ANISOU  982  N1    U R  47     5730   4477   6233   -569   1196   -585       N  
+ATOM    983  C2    U R  47     174.621  34.240 161.376  1.00 45.08           C  
+ANISOU  983  C2    U R  47     5937   4724   6468   -540   1222   -547       C  
+ATOM    984  O2    U R  47     174.237  35.356 161.092  1.00 45.65           O  
+ANISOU  984  O2    U R  47     6068   4742   6534   -485   1186   -550       O  
+ATOM    985  N3    U R  47     174.778  33.239 160.439  1.00 42.13           N  
+ANISOU  985  N3    U R  47     5483   4425   6101   -571   1282   -509       N  
+ATOM    986  C4    U R  47     175.199  31.946 160.716  1.00 41.20           C  
+ANISOU  986  C4    U R  47     5311   4360   5986   -624   1311   -510       C  
+ATOM    987  O4    U R  47     175.304  31.109 159.827  1.00 39.80           O  
+ANISOU  987  O4    U R  47     5077   4241   5807   -635   1354   -482       O  
+ATOM    988  C5    U R  47     175.484  31.686 162.092  1.00 37.85           C  
+ANISOU  988  C5    U R  47     4913   3909   5558   -656   1279   -547       C  
+ATOM    989  C6    U R  47     175.334  32.636 163.012  1.00 39.44           C  
+ANISOU  989  C6    U R  47     5189   4046   5752   -629   1228   -583       C  
+ATOM    990  P     A R  48     171.607  33.560 167.310  1.00 51.77           P  
+ANISOU  990  P     A R  48     6897   5773   6998   -348   1217   -874       P  
+ATOM    991  OP1   A R  48     171.038  34.375 168.391  1.00 55.66           O  
+ANISOU  991  OP1   A R  48     7468   6264   7414   -245   1186   -946       O  
+ATOM    992  OP2   A R  48     172.363  32.311 167.568  1.00 47.38           O  
+ANISOU  992  OP2   A R  48     6298   5230   6474   -465   1234   -838       O  
+ATOM    993  O5'   A R  48     170.424  33.110 166.361  1.00 68.27           O  
+ANISOU  993  O5'   A R  48     8889   7998   9051   -310   1290   -869       O  
+ATOM    994  C5'   A R  48     169.500  34.063 165.889  1.00 57.98           C  
+ANISOU  994  C5'   A R  48     7598   6718   7712   -194   1289   -900       C  
+ATOM    995  C4'   A R  48     168.318  33.421 165.215  1.00 53.56           C  
+ANISOU  995  C4'   A R  48     6931   6310   7110   -170   1358   -897       C  
+ATOM    996  O4'   A R  48     168.779  32.455 164.232  1.00 47.32           O  
+ANISOU  996  O4'   A R  48     6079   5524   6376   -270   1383   -835       O  
+ATOM    997  C3'   A R  48     167.341  32.692 166.141  1.00 53.02           C  
+ANISOU  997  C3'   A R  48     6797   6398   6951   -156   1409   -930       C  
+ATOM    998  O3'   A R  48     165.998  33.104 165.871  1.00 50.99           O  
+ANISOU  998  O3'   A R  48     6486   6259   6628    -45   1440   -963       O  
+ATOM    999  C2'   A R  48     167.517  31.219 165.770  1.00 53.81           C  
+ANISOU  999  C2'   A R  48     6816   6555   7076   -283   1446   -877       C  
+ATOM   1000  O2'   A R  48     166.318  30.488 165.862  1.00 62.31           O  
+ANISOU 1000  O2'   A R  48     7794   7796   8084   -283   1497   -878       O  
+ATOM   1001  C1'   A R  48     167.992  31.297 164.319  1.00 47.46           C  
+ANISOU 1001  C1'   A R  48     6006   5680   6348   -307   1434   -831       C  
+ATOM   1002  N9    A R  48     168.755  30.130 163.850  1.00 40.11           N  
+ANISOU 1002  N9    A R  48     5045   4729   5466   -421   1440   -780       N  
+ATOM   1003  C8    A R  48     169.415  29.171 164.586  1.00 39.62           C  
+ANISOU 1003  C8    A R  48     4986   4656   5410   -512   1434   -768       C  
+ATOM   1004  N7    A R  48     169.955  28.202 163.869  1.00 42.34           N  
+ANISOU 1004  N7    A R  48     5305   4988   5796   -585   1435   -726       N  
+ATOM   1005  C5    A R  48     169.630  28.549 162.565  1.00 39.53           C  
+ANISOU 1005  C5    A R  48     4925   4638   5458   -542   1447   -708       C  
+ATOM   1006  C6    A R  48     169.898  27.943 161.316  1.00 40.56           C  
+ANISOU 1006  C6    A R  48     5028   4763   5618   -567   1452   -670       C  
+ATOM   1007  N6    A R  48     170.608  26.825 161.156  1.00 36.52           N  
+ANISOU 1007  N6    A R  48     4511   4236   5128   -638   1443   -644       N  
+ATOM   1008  N1    A R  48     169.431  28.564 160.202  1.00 44.94           N  
+ANISOU 1008  N1    A R  48     5572   5326   6177   -505   1462   -660       N  
+ATOM   1009  C2    A R  48     168.731  29.702 160.340  1.00 36.32           C  
+ANISOU 1009  C2    A R  48     4495   4243   5063   -422   1462   -689       C  
+ATOM   1010  N3    A R  48     168.411  30.351 161.458  1.00 37.36           N  
+ANISOU 1010  N3    A R  48     4653   4380   5163   -382   1454   -732       N  
+ATOM   1011  C4    A R  48     168.899  29.735 162.545  1.00 37.94           C  
+ANISOU 1011  C4    A R  48     4737   4449   5231   -446   1449   -739       C  
+ATOM   1012  P     A R  49     165.164  33.876 167.016  1.00 56.01           P  
+ANISOU 1012  P     A R  49     7149   6970   7161     94   1443  -1039       P  
+ATOM   1013  OP1   A R  49     165.439  33.219 168.306  1.00 49.13           O  
+ANISOU 1013  OP1   A R  49     6285   6137   6245     37   1459  -1046       O  
+ATOM   1014  OP2   A R  49     163.771  34.053 166.528  1.00 69.43           O  
+ANISOU 1014  OP2   A R  49     8758   8821   8802    195   1485  -1058       O  
+ATOM   1015  O5'   A R  49     165.884  35.294 167.146  1.00 60.26           O  
+ANISOU 1015  O5'   A R  49     7839   7329   7730    175   1357  -1076       O  
+ATOM   1016  C5'   A R  49     165.999  36.192 166.048  1.00 53.88           C  
+ANISOU 1016  C5'   A R  49     7077   6421   6975    222   1312  -1065       C  
+ATOM   1017  C4'   A R  49     166.713  37.470 166.447  1.00 59.84           C  
+ANISOU 1017  C4'   A R  49     7989   6999   7749    281   1214  -1096       C  
+ATOM   1018  O4'   A R  49     166.013  38.111 167.559  1.00 69.27           O  
+ANISOU 1018  O4'   A R  49     9239   8241   8840    428   1197  -1183       O  
+ATOM   1019  C3'   A R  49     168.159  37.283 166.907  1.00 65.56           C  
+ANISOU 1019  C3'   A R  49     8782   7584   8545    155   1165  -1058       C  
+ATOM   1020  O3'   A R  49     168.955  38.389 166.491  1.00 59.28           O  
+ANISOU 1020  O3'   A R  49     8104   6607   7815    157   1069  -1039       O  
+ATOM   1021  C2'   A R  49     168.038  37.286 168.426  1.00 73.42           C  
+ANISOU 1021  C2'   A R  49     9826   8608   9461    204   1155  -1122       C  
+ATOM   1022  O2'   A R  49     169.202  37.684 169.116  1.00 76.23           O  
+ANISOU 1022  O2'   A R  49    10299   8805   9860    153   1071  -1121       O  
+ATOM   1023  C1'   A R  49     166.898  38.270 168.655  1.00 75.91           C  
+ANISOU 1023  C1'   A R  49    10182   8977   9681    395   1142  -1202       C  
+ATOM   1024  N9    A R  49     166.181  37.981 169.901  1.00 85.67           N  
+ANISOU 1024  N9    A R  49    11398  10352  10802    474   1187  -1264       N  
+ATOM   1025  C8    A R  49     164.946  37.399 170.084  1.00 84.54           C  
+ANISOU 1025  C8    A R  49    11127  10428  10567    533   1283  -1283       C  
+ATOM   1026  N7    A R  49     164.627  37.256 171.350  1.00 83.83           N  
+ANISOU 1026  N7    A R  49    11048  10428  10375    589   1307  -1331       N  
+ATOM   1027  C5    A R  49     165.717  37.769 172.050  1.00 85.48           C  
+ANISOU 1027  C5    A R  49    11410  10456  10612    571   1216  -1352       C  
+ATOM   1028  C6    A R  49     166.002  37.915 173.429  1.00 94.80           C  
+ANISOU 1028  C6    A R  49    12686  11616  11719    613   1186  -1404       C  
+ATOM   1029  N6    A R  49     165.169  37.539 174.410  1.00 91.60           N  
+ANISOU 1029  N6    A R  49    12229  11392  11182    689   1257  -1443       N  
+ATOM   1030  N1    A R  49     167.195  38.470 173.775  1.00102.04           N  
+ANISOU 1030  N1    A R  49    13753  12319  12697    571   1074  -1408       N  
+ATOM   1031  C2    A R  49     168.039  38.850 172.802  1.00 96.39           C  
+ANISOU 1031  C2    A R  49    13078  11437  12110    486   1006  -1356       C  
+ATOM   1032  N3    A R  49     167.879  38.763 171.482  1.00 94.04           N  
+ANISOU 1032  N3    A R  49    12699  11149  11884    443   1035  -1302       N  
+ATOM   1033  C4    A R  49     166.686  38.214 171.166  1.00 86.98           C  
+ANISOU 1033  C4    A R  49    11668  10455  10925    494   1139  -1308       C  
+ATOM   1034  P     G R  50     169.951  38.222 165.247  1.00 60.70           P  
+ANISOU 1034  P     G R  50     8259   6699   8107     28   1060   -941       P  
+ATOM   1035  OP1   G R  50     170.028  36.776 164.929  1.00 61.86           O  
+ANISOU 1035  OP1   G R  50     8275   6958   8269    -74   1150   -898       O  
+ATOM   1036  OP2   G R  50     171.199  38.978 165.510  1.00 57.08           O  
+ANISOU 1036  OP2   G R  50     7912   6058   7716    -34    959   -908       O  
+ATOM   1037  O5'   G R  50     169.149  38.892 164.056  1.00 48.07           O  
+ANISOU 1037  O5'   G R  50     6653   5112   6498    115   1061   -937       O  
+ATOM   1038  C5'   G R  50     168.694  40.229 164.169  1.00 54.42           C  
+ANISOU 1038  C5'   G R  50     7573   5837   7266    247    980   -988       C  
+ATOM   1039  C4'   G R  50     168.501  40.829 162.813  1.00 48.42           C  
+ANISOU 1039  C4'   G R  50     6825   5034   6539    269    960   -945       C  
+ATOM   1040  O4'   G R  50     169.696  40.621 162.012  1.00 46.42           O  
+ANISOU 1040  O4'   G R  50     6561   4695   6382    120    953   -843       O  
+ATOM   1041  C3'   G R  50     167.406  40.196 161.987  1.00 45.73           C  
+ANISOU 1041  C3'   G R  50     6359   4853   6162    314   1049   -949       C  
+ATOM   1042  O3'   G R  50     166.125  40.668 162.328  1.00 48.29           O  
+ANISOU 1042  O3'   G R  50     6686   5264   6397    480   1050  -1034       O  
+ATOM   1043  C2'   G R  50     167.829  40.543 160.578  1.00 46.88           C  
+ANISOU 1043  C2'   G R  50     6520   4922   6371    264   1029   -871       C  
+ATOM   1044  O2'   G R  50     167.604  41.927 160.343  1.00 60.26           O  
+ANISOU 1044  O2'   G R  50     8341   6499   8054    365    933   -891       O  
+ATOM   1045  C1'   G R  50     169.328  40.320 160.683  1.00 43.60           C  
+ANISOU 1045  C1'   G R  50     6129   4400   6038    111   1007   -796       C  
+ATOM   1046  N9    G R  50     169.646  38.908 160.424  1.00 43.11           N  
+ANISOU 1046  N9    G R  50     5939   4443   5999      5   1099   -754       N  
+ATOM   1047  C8    G R  50     170.028  37.966 161.349  1.00 45.00           C  
+ANISOU 1047  C8    G R  50     6131   4730   6237    -62   1134   -767       C  
+ATOM   1048  N7    G R  50     170.238  36.784 160.830  1.00 42.22           N  
+ANISOU 1048  N7    G R  50     5679   4459   5905   -143   1204   -725       N  
+ATOM   1049  C5    G R  50     169.951  36.955 159.477  1.00 41.29           C  
+ANISOU 1049  C5    G R  50     5537   4353   5797   -125   1221   -685       C  
+ATOM   1050  C6    G R  50     169.991  36.026 158.399  1.00 42.64           C  
+ANISOU 1050  C6    G R  50     5624   4596   5982   -174   1281   -636       C  
+ATOM   1051  O6    G R  50     170.289  34.815 158.442  1.00 51.11           O  
+ANISOU 1051  O6    G R  50     6625   5732   7061   -244   1328   -621       O  
+ATOM   1052  N1    G R  50     169.627  36.617 157.190  1.00 46.15           N  
+ANISOU 1052  N1    G R  50     6084   5027   6426   -127   1274   -607       N  
+ATOM   1053  C2    G R  50     169.283  37.947 157.035  1.00 43.01           C  
+ANISOU 1053  C2    G R  50     5775   4549   6019    -46   1211   -621       C  
+ATOM   1054  N2    G R  50     168.965  38.324 155.791  1.00 42.39           N  
+ANISOU 1054  N2    G R  50     5703   4466   5937    -12   1210   -585       N  
+ATOM   1055  N3    G R  50     169.248  38.819 158.028  1.00 42.55           N  
+ANISOU 1055  N3    G R  50     5802   4417   5949      4   1148   -668       N  
+ATOM   1056  C4    G R  50     169.588  38.267 159.211  1.00 45.03           C  
+ANISOU 1056  C4    G R  50     6101   4749   6261    -37   1158   -699       C  
+ATOM   1057  P     G R  51     164.904  39.635 162.427  1.00 57.60           P  
+ANISOU 1057  P     G R  51     7706   6670   7508    519   1156  -1065       P  
+ATOM   1058  OP1   G R  51     163.806  40.364 163.126  1.00 58.43           O  
+ANISOU 1058  OP1   G R  51     7837   6849   7516    705   1140  -1159       O  
+ATOM   1059  OP2   G R  51     165.447  38.367 162.999  1.00 48.32           O  
+ANISOU 1059  OP2   G R  51     6453   5554   6351    382   1218  -1033       O  
+ATOM   1060  O5'   G R  51     164.514  39.334 160.911  1.00 48.67           O  
+ANISOU 1060  O5'   G R  51     6498   5583   6410    495   1189  -1011       O  
+ATOM   1061  C5'   G R  51     164.241  40.395 160.010  1.00 59.94           C  
+ANISOU 1061  C5'   G R  51     7999   6931   7845    583   1128  -1011       C  
+ATOM   1062  C4'   G R  51     164.217  39.923 158.579  1.00 51.55           C  
+ANISOU 1062  C4'   G R  51     6871   5890   6824    518   1161   -942       C  
+ATOM   1063  O4'   G R  51     165.542  39.502 158.162  1.00 47.14           O  
+ANISOU 1063  O4'   G R  51     6329   5238   6344    363   1165   -858       O  
+ATOM   1064  C3'   G R  51     163.361  38.707 158.292  1.00 50.70           C  
+ANISOU 1064  C3'   G R  51     6609   5967   6689    496   1248   -940       C  
+ATOM   1065  O3'   G R  51     161.972  38.970 158.256  1.00 60.19           O  
+ANISOU 1065  O3'   G R  51     7754   7294   7823    634   1256   -997       O  
+ATOM   1066  C2'   G R  51     163.951  38.201 156.979  1.00 49.37           C  
+ANISOU 1066  C2'   G R  51     6419   5758   6580    391   1264   -857       C  
+ATOM   1067  O2'   G R  51     163.560  38.985 155.870  1.00 48.15           O  
+ANISOU 1067  O2'   G R  51     6308   5561   6427    465   1225   -845       O  
+ATOM   1068  C1'   G R  51     165.431  38.434 157.229  1.00 54.39           C  
+ANISOU 1068  C1'   G R  51     7142   6246   7279    290   1232   -809       C  
+ATOM   1069  N9    G R  51     166.002  37.196 157.793  1.00 51.20           N  
+ANISOU 1069  N9    G R  51     6668   5894   6893    173   1286   -790       N  
+ATOM   1070  C8    G R  51     166.261  36.879 159.107  1.00 52.38           C  
+ANISOU 1070  C8    G R  51     6816   6056   7028    146   1293   -824       C  
+ATOM   1071  N7    G R  51     166.721  35.664 159.248  1.00 40.98           N  
+ANISOU 1071  N7    G R  51     5306   4661   5604     37   1339   -793       N  
+ATOM   1072  C5    G R  51     166.739  35.163 157.971  1.00 41.24           C  
+ANISOU 1072  C5    G R  51     5293   4715   5660      0   1364   -742       C  
+ATOM   1073  C6    G R  51     167.150  33.884 157.540  1.00 43.02           C  
+ANISOU 1073  C6    G R  51     5453   4984   5906    -99   1405   -700       C  
+ATOM   1074  O6    G R  51     167.564  32.998 158.281  1.00 46.37           O  
+ANISOU 1074  O6    G R  51     5850   5433   6335   -173   1423   -701       O  
+ATOM   1075  N1    G R  51     167.035  33.735 156.157  1.00 44.84           N  
+ANISOU 1075  N1    G R  51     5666   5224   6148    -95   1414   -660       N  
+ATOM   1076  C2    G R  51     166.561  34.728 155.309  1.00 46.39           C  
+ANISOU 1076  C2    G R  51     5900   5389   6335    -12   1389   -657       C  
+ATOM   1077  N2    G R  51     166.496  34.440 154.003  1.00 41.53           N  
+ANISOU 1077  N2    G R  51     5267   4788   5723    -16   1401   -616       N  
+ATOM   1078  N3    G R  51     166.166  35.935 155.721  1.00 44.15           N  
+ANISOU 1078  N3    G R  51     5678   5060   6036     78   1347   -695       N  
+ATOM   1079  C4    G R  51     166.293  36.073 157.052  1.00 41.34           C  
+ANISOU 1079  C4    G R  51     5344   4696   5670     80   1336   -738       C  
+ATOM   1080  P     G R  52     160.960  37.935 158.952  1.00 59.87           P  
+ANISOU 1080  P     G R  52     7560   7467   7720    638   1333  -1027       P  
+ATOM   1081  OP1   G R  52     159.580  38.344 158.584  1.00 64.26           O  
+ANISOU 1081  OP1   G R  52     8051   8145   8218    783   1332  -1071       O  
+ATOM   1082  OP2   G R  52     161.365  37.824 160.374  1.00 62.07           O  
+ANISOU 1082  OP2   G R  52     7864   7747   7971    622   1344  -1060       O  
+ATOM   1083  O5'   G R  52     161.239  36.567 158.168  1.00 62.25           O  
+ANISOU 1083  O5'   G R  52     7769   7814   8068    481   1382   -953       O  
+ATOM   1084  C5'   G R  52     160.929  36.483 156.787  1.00 51.17           C  
+ANISOU 1084  C5'   G R  52     6342   6411   6688    481   1374   -917       C  
+ATOM   1085  C4'   G R  52     161.581  35.306 156.102  1.00 55.44           C  
+ANISOU 1085  C4'   G R  52     6845   6942   7276    334   1402   -849       C  
+ATOM   1086  O4'   G R  52     162.937  35.121 156.568  1.00 54.71           O  
+ANISOU 1086  O4'   G R  52     6819   6739   7231    236   1402   -820       O  
+ATOM   1087  C3'   G R  52     160.925  33.960 156.337  1.00 56.72           C  
+ANISOU 1087  C3'   G R  52     6880   7256   7413    263   1447   -840       C  
+ATOM   1088  O3'   G R  52     159.777  33.790 155.534  1.00 58.75           O  
+ANISOU 1088  O3'   G R  52     7058   7620   7645    311   1444   -841       O  
+ATOM   1089  C2'   G R  52     162.049  32.986 156.007  1.00 54.91           C  
+ANISOU 1089  C2'   G R  52     6672   6957   7236    123   1458   -784       C  
+ATOM   1090  O2'   G R  52     162.168  32.854 154.603  1.00 53.29           O  
+ANISOU 1090  O2'   G R  52     6480   6713   7056    113   1444   -745       O  
+ATOM   1091  C1'   G R  52     163.268  33.741 156.538  1.00 48.24           C  
+ANISOU 1091  C1'   G R  52     5934   5968   6427    114   1439   -784       C  
+ATOM   1092  N9    G R  52     163.640  33.316 157.909  1.00 43.92           N  
+ANISOU 1092  N9    G R  52     5381   5438   5869     61   1456   -803       N  
+ATOM   1093  C8    G R  52     163.487  34.047 159.074  1.00 45.85           C  
+ANISOU 1093  C8    G R  52     5661   5682   6079    129   1446   -854       C  
+ATOM   1094  N7    G R  52     163.908  33.449 160.153  1.00 43.01           N  
+ANISOU 1094  N7    G R  52     5294   5336   5710     61   1463   -860       N  
+ATOM   1095  C5    G R  52     164.345  32.226 159.664  1.00 43.53           C  
+ANISOU 1095  C5    G R  52     5315   5413   5810    -59   1483   -808       C  
+ATOM   1096  C6    G R  52     164.915  31.139 160.362  1.00 40.47           C  
+ANISOU 1096  C6    G R  52     4910   5037   5430   -170   1498   -790       C  
+ATOM   1097  O6    G R  52     165.128  31.062 161.575  1.00 40.56           O  
+ANISOU 1097  O6    G R  52     4938   5054   5418   -188   1502   -812       O  
+ATOM   1098  N1    G R  52     165.254  30.091 159.499  1.00 40.89           N  
+ANISOU 1098  N1    G R  52     4934   5086   5515   -257   1502   -743       N  
+ATOM   1099  C2    G R  52     165.052  30.081 158.139  1.00 40.15           C  
+ANISOU 1099  C2    G R  52     4829   4986   5439   -238   1496   -717       C  
+ATOM   1100  N2    G R  52     165.423  28.963 157.502  1.00 40.89           N  
+ANISOU 1100  N2    G R  52     4906   5079   5552   -317   1495   -680       N  
+ATOM   1101  N3    G R  52     164.518  31.091 157.462  1.00 43.34           N  
+ANISOU 1101  N3    G R  52     5247   5384   5838   -141   1486   -730       N  
+ATOM   1102  C4    G R  52     164.195  32.122 158.289  1.00 45.18           C  
+ANISOU 1102  C4    G R  52     5509   5615   6044    -57   1478   -775       C  
+ATOM   1103  P     U R  53     158.496  33.022 156.113  1.00 53.25           P  
+ANISOU 1103  P     U R  53     6214   7125   6893    308   1476   -854       P  
+ATOM   1104  OP1   U R  53     157.329  33.474 155.308  1.00 60.74           O  
+ANISOU 1104  OP1   U R  53     7106   8157   7817    413   1455   -870       O  
+ATOM   1105  OP2   U R  53     158.410  33.089 157.591  1.00 56.45           O  
+ANISOU 1105  OP2   U R  53     6597   7596   7255    322   1507   -889       O  
+ATOM   1106  O5'   U R  53     158.838  31.510 155.782  1.00 49.92           O  
+ANISOU 1106  O5'   U R  53     5749   6719   6499    147   1485   -797       O  
+ATOM   1107  C5'   U R  53     159.130  31.105 154.467  1.00 42.93           C  
+ANISOU 1107  C5'   U R  53     4892   5770   5649    106   1459   -758       C  
+ATOM   1108  C4'   U R  53     159.850  29.787 154.483  1.00 48.78           C  
+ANISOU 1108  C4'   U R  53     5636   6484   6415    -36   1462   -717       C  
+ATOM   1109  O4'   U R  53     161.128  29.934 155.151  1.00 60.31           O  
+ANISOU 1109  O4'   U R  53     7176   7834   7903    -74   1477   -717       O  
+ATOM   1110  C3'   U R  53     159.165  28.673 155.258  1.00 53.50           C  
+ANISOU 1110  C3'   U R  53     6133   7213   6981   -124   1471   -704       C  
+ATOM   1111  O3'   U R  53     158.131  28.058 154.518  1.00 59.80           O  
+ANISOU 1111  O3'   U R  53     6849   8107   7763   -144   1443   -682       O  
+ATOM   1112  C2'   U R  53     160.325  27.741 155.561  1.00 54.72           C  
+ANISOU 1112  C2'   U R  53     6345   7282   7165   -241   1470   -678       C  
+ATOM   1113  O2'   U R  53     160.681  27.030 154.379  1.00 53.31           O  
+ANISOU 1113  O2'   U R  53     6201   7044   7011   -285   1436   -646       O  
+ATOM   1114  C1'   U R  53     161.436  28.748 155.857  1.00 56.14           C  
+ANISOU 1114  C1'   U R  53     6621   7335   7374   -190   1486   -698       C  
+ATOM   1115  N1    U R  53     161.546  29.067 157.296  1.00 46.50           N  
+ANISOU 1115  N1    U R  53     5398   6137   6132   -185   1511   -727       N  
+ATOM   1116  C2    U R  53     162.131  28.140 158.137  1.00 49.02           C  
+ANISOU 1116  C2    U R  53     5722   6450   6454   -291   1518   -711       C  
+ATOM   1117  O2    U R  53     162.559  27.049 157.790  1.00 56.43           O  
+ANISOU 1117  O2    U R  53     6665   7363   7411   -386   1500   -677       O  
+ATOM   1118  N3    U R  53     162.220  28.533 159.432  1.00 40.34           N  
+ANISOU 1118  N3    U R  53     4631   5369   5328   -274   1539   -740       N  
+ATOM   1119  C4    U R  53     161.766  29.705 159.984  1.00 41.53           C  
+ANISOU 1119  C4    U R  53     4788   5547   5444   -158   1552   -787       C  
+ATOM   1120  O4    U R  53     161.896  29.884 161.188  1.00 43.64           O  
+ANISOU 1120  O4    U R  53     5070   5833   5680   -150   1568   -812       O  
+ATOM   1121  C5    U R  53     161.172  30.613 159.056  1.00 42.62           C  
+ANISOU 1121  C5    U R  53     4924   5686   5582    -48   1539   -803       C  
+ATOM   1122  C6    U R  53     161.091  30.258 157.775  1.00 45.73           C  
+ANISOU 1122  C6    U R  53     5308   6062   6007    -71   1521   -771       C  
+ATOM   1123  P     C R  54     156.861  27.405 155.254  1.00 59.55           P  
+ANISOU 1123  P     C R  54     6674   8265   7685   -193   1449   -668       P  
+ATOM   1124  OP1   C R  54     156.010  26.924 154.119  1.00 72.72           O  
+ANISOU 1124  OP1   C R  54     8288   9987   9356   -208   1399   -640       O  
+ATOM   1125  OP2   C R  54     156.333  28.297 156.316  1.00 45.93           O  
+ANISOU 1125  OP2   C R  54     4897   6638   5916    -99   1497   -708       O  
+ATOM   1126  O5'   C R  54     157.453  26.159 156.057  1.00 57.92           O  
+ANISOU 1126  O5'   C R  54     6478   8049   7482   -346   1450   -633       O  
+ATOM   1127  C5'   C R  54     157.982  25.037 155.378  1.00 57.47           C  
+ANISOU 1127  C5'   C R  54     6471   7912   7453   -451   1400   -596       C  
+ATOM   1128  C4'   C R  54     158.655  24.093 156.347  1.00 62.56           C  
+ANISOU 1128  C4'   C R  54     7142   8531   8097   -570   1401   -575       C  
+ATOM   1129  O4'   C R  54     159.765  24.768 157.004  1.00 61.60           O  
+ANISOU 1129  O4'   C R  54     7101   8312   7993   -528   1442   -607       O  
+ATOM   1130  C3'   C R  54     157.817  23.576 157.511  1.00 51.97           C  
+ANISOU 1130  C3'   C R  54     5697   7341   6709   -647   1418   -549       C  
+ATOM   1131  O3'   C R  54     156.914  22.540 157.163  1.00 52.42           O  
+ANISOU 1131  O3'   C R  54     5678   7488   6752   -750   1363   -497       O  
+ATOM   1132  C2'   C R  54     158.895  23.139 158.487  1.00 48.40           C  
+ANISOU 1132  C2'   C R  54     5319   6809   6262   -717   1430   -549       C  
+ATOM   1133  O2'   C R  54     159.502  21.946 158.022  1.00 59.31           O  
+ANISOU 1133  O2'   C R  54     6767   8099   7671   -823   1367   -518       O  
+ATOM   1134  C1'   C R  54     159.915  24.266 158.316  1.00 56.38           C  
+ANISOU 1134  C1'   C R  54     6423   7692   7308   -605   1461   -599       C  
+ATOM   1135  N1    C R  54     159.671  25.354 159.283  1.00 45.85           N  
+ANISOU 1135  N1    C R  54     5066   6415   5942   -514   1516   -638       N  
+ATOM   1136  C2    C R  54     160.143  25.158 160.572  1.00 51.44           C  
+ANISOU 1136  C2    C R  54     5793   7123   6627   -560   1540   -642       C  
+ATOM   1137  O2    C R  54     160.742  24.094 160.813  1.00 71.40           O  
+ANISOU 1137  O2    C R  54     8357   9602   9170   -677   1512   -611       O  
+ATOM   1138  N3    C R  54     159.919  26.103 161.511  1.00 46.32           N  
+ANISOU 1138  N3    C R  54     5134   6527   5938   -471   1584   -683       N  
+ATOM   1139  C4    C R  54     159.279  27.226 161.175  1.00 44.74           C  
+ANISOU 1139  C4    C R  54     4907   6369   5721   -334   1600   -721       C  
+ATOM   1140  N4    C R  54     159.085  28.160 162.111  1.00 39.99           N  
+ANISOU 1140  N4    C R  54     4311   5811   5072   -230   1634   -768       N  
+ATOM   1141  C5    C R  54     158.784  27.440 159.865  1.00 41.31           C  
+ANISOU 1141  C5    C R  54     4449   5934   5313   -288   1575   -715       C  
+ATOM   1142  C6    C R  54     158.984  26.489 158.959  1.00 43.77           C  
+ANISOU 1142  C6    C R  54     4767   6201   5662   -383   1536   -672       C  
+ATOM   1143  P     U R  55     155.629  22.222 158.091  1.00 60.05           P  
+ANISOU 1143  P     U R  55     6488   8666   7660   -815   1383   -454       P  
+ATOM   1144  OP1   U R  55     154.860  21.213 157.312  1.00 76.18           O  
+ANISOU 1144  OP1   U R  55     8480  10755   9710   -921   1300   -396       O  
+ATOM   1145  OP2   U R  55     154.965  23.463 158.572  1.00 56.02           O  
+ANISOU 1145  OP2   U R  55     5896   8278   7113   -675   1456   -494       O  
+ATOM   1146  O5'   U R  55     156.220  21.551 159.415  1.00 65.47           O  
+ANISOU 1146  O5'   U R  55     7205   9346   8324   -923   1402   -432       O  
+ATOM   1147  C5'   U R  55     156.994  20.357 159.371  1.00 63.08           C  
+ANISOU 1147  C5'   U R  55     6995   8928   8046  -1053   1337   -399       C  
+ATOM   1148  C4'   U R  55     157.383  19.921 160.760  1.00 60.83           C  
+ANISOU 1148  C4'   U R  55     6722   8663   7728  -1136   1364   -381       C  
+ATOM   1149  O4'   U R  55     158.221  20.934 161.378  1.00 53.90           O  
+ANISOU 1149  O4'   U R  55     5905   7721   6853  -1026   1432   -443       O  
+ATOM   1150  C3'   U R  55     156.237  19.751 161.731  1.00 58.52           C  
+ANISOU 1150  C3'   U R  55     6288   8580   7367  -1198   1400   -330       C  
+ATOM   1151  O3'   U R  55     155.576  18.507 161.577  1.00 71.68           O  
+ANISOU 1151  O3'   U R  55     7904  10307   9024  -1364   1324   -246       O  
+ATOM   1152  C2'   U R  55     156.905  19.941 163.089  1.00 51.44           C  
+ANISOU 1152  C2'   U R  55     5436   7674   6436  -1197   1457   -349       C  
+ATOM   1153  O2'   U R  55     157.586  18.766 163.496  1.00 41.48           O  
+ANISOU 1153  O2'   U R  55     4258   6321   5182  -1343   1398   -308       O  
+ATOM   1154  C1'   U R  55     157.970  20.981 162.766  1.00 49.51           C  
+ANISOU 1154  C1'   U R  55     5301   7273   6237  -1053   1484   -432       C  
+ATOM   1155  N1    U R  55     157.623  22.362 163.177  1.00 51.09           N  
+ANISOU 1155  N1    U R  55     5457   7549   6404   -894   1561   -489       N  
+ATOM   1156  C2    U R  55     157.715  22.652 164.523  1.00 56.93           C  
+ANISOU 1156  C2    U R  55     6194   8351   7086   -877   1616   -503       C  
+ATOM   1157  O2    U R  55     158.017  21.832 165.366  1.00 58.50           O  
+ANISOU 1157  O2    U R  55     6415   8554   7260   -992   1607   -466       O  
+ATOM   1158  N3    U R  55     157.434  23.949 164.870  1.00 59.94           N  
+ANISOU 1158  N3    U R  55     6556   8788   7432   -714   1675   -564       N  
+ATOM   1159  C4    U R  55     157.096  24.975 164.009  1.00 52.42           C  
+ANISOU 1159  C4    U R  55     5590   7825   6500   -573   1679   -611       C  
+ATOM   1160  O4    U R  55     156.872  26.099 164.472  1.00 56.58           O  
+ANISOU 1160  O4    U R  55     6116   8396   6987   -425   1722   -668       O  
+ATOM   1161  C5    U R  55     157.026  24.597 162.634  1.00 48.51           C  
+ANISOU 1161  C5    U R  55     5096   7268   6068   -608   1625   -587       C  
+ATOM   1162  C6    U R  55     157.301  23.338 162.268  1.00 51.44           C  
+ANISOU 1162  C6    U R  55     5487   7588   6471   -761   1570   -530       C  
+ATOM   1163  P     C R  56     154.009  18.365 161.905  1.00 72.46           P  
+ANISOU 1163  P     C R  56     7810  10655   9065  -1425   1341   -174       P  
+ATOM   1164  OP1   C R  56     153.659  16.996 161.462  1.00 87.94           O  
+ANISOU 1164  OP1   C R  56     9771  12600  11041  -1611   1225    -89       O  
+ATOM   1165  OP2   C R  56     153.218  19.510 161.388  1.00 78.94           O  
+ANISOU 1165  OP2   C R  56     8528  11586   9880  -1268   1394   -216       O  
+ATOM   1166  O5'   C R  56     153.940  18.451 163.487  1.00 64.68           O  
+ANISOU 1166  O5'   C R  56     6773   9796   8006  -1453   1423   -154       O  
+ATOM   1167  C5'   C R  56     154.190  17.304 164.273  1.00 62.49           C  
+ANISOU 1167  C5'   C R  56     6532   9507   7704  -1631   1381    -84       C  
+ATOM   1168  C4'   C R  56     154.451  17.674 165.708  1.00 64.67           C  
+ANISOU 1168  C4'   C R  56     6804   9854   7912  -1604   1471    -96       C  
+ATOM   1169  O4'   C R  56     155.317  18.835 165.765  1.00 62.18           O  
+ANISOU 1169  O4'   C R  56     6580   9429   7618  -1421   1530   -204       O  
+ATOM   1170  C3'   C R  56     153.245  18.078 166.531  1.00 62.80           C  
+ANISOU 1170  C3'   C R  56     6384   9893   7583  -1583   1560    -55       C  
+ATOM   1171  O3'   C R  56     152.488  16.962 166.961  1.00 58.72           O  
+ANISOU 1171  O3'   C R  56     5773   9515   7023  -1783   1523     68       O  
+ATOM   1172  C2'   C R  56     153.885  18.866 167.674  1.00 64.32           C  
+ANISOU 1172  C2'   C R  56     6636  10078   7724  -1468   1650   -122       C  
+ATOM   1173  O2'   C R  56     154.402  17.984 168.663  1.00 72.27           O  
+ANISOU 1173  O2'   C R  56     7711  11052   8697  -1611   1631    -70       O  
+ATOM   1174  C1'   C R  56     155.059  19.551 166.960  1.00 60.17           C  
+ANISOU 1174  C1'   C R  56     6269   9311   7283  -1341   1628   -225       C  
+ATOM   1175  N1    C R  56     154.785  20.973 166.631  1.00 52.36           N  
+ANISOU 1175  N1    C R  56     5245   8359   6290  -1129   1690   -309       N  
+ATOM   1176  C2    C R  56     154.895  21.924 167.652  1.00 53.54           C  
+ANISOU 1176  C2    C R  56     5403   8567   6375   -997   1772   -368       C  
+ATOM   1177  O2    C R  56     155.225  21.543 168.779  1.00 60.20           O  
+ANISOU 1177  O2    C R  56     6278   9432   7165  -1061   1794   -347       O  
+ATOM   1178  N3    C R  56     154.644  23.232 167.395  1.00 45.89           N  
+ANISOU 1178  N3    C R  56     4419   7621   5397   -798   1815   -448       N  
+ATOM   1179  C4    C R  56     154.316  23.610 166.155  1.00 57.00           C  
+ANISOU 1179  C4    C R  56     5801   8995   6861   -734   1784   -467       C  
+ATOM   1180  N4    C R  56     154.095  24.913 165.926  1.00 65.85           N  
+ANISOU 1180  N4    C R  56     6921  10127   7971   -537   1817   -546       N  
+ATOM   1181  C5    C R  56     154.198  22.655 165.094  1.00 56.04           C  
+ANISOU 1181  C5    C R  56     5666   8822   6806   -868   1707   -407       C  
+ATOM   1182  C6    C R  56     154.441  21.362 165.369  1.00 52.00           C  
+ANISOU 1182  C6    C R  56     5174   8285   6300  -1060   1660   -332       C  
+ATOM   1183  P     C R  57     150.887  17.047 167.085  1.00 73.10           P  
+ANISOU 1183  P     C R  57     7354  11642   8778  -1810   1569    149       P  
+ATOM   1184  OP1   C R  57     150.364  15.659 167.190  1.00 83.12           O  
+ANISOU 1184  OP1   C R  57     8571  12974  10038  -2063   1481    288       O  
+ATOM   1185  OP2   C R  57     150.407  17.885 165.948  1.00 85.24           O  
+ANISOU 1185  OP2   C R  57     8833  13192  10363  -1660   1571     89       O  
+ATOM   1186  O5'   C R  57     150.645  17.715 168.510  1.00 81.44           O  
+ANISOU 1186  O5'   C R  57     8333  12889   9721  -1721   1703    137       O  
+ATOM   1187  C5'   C R  57     151.214  17.099 169.657  1.00 75.98           C  
+ANISOU 1187  C5'   C R  57     7717  12173   8978  -1831   1712    177       C  
+ATOM   1188  C4'   C R  57     150.944  17.822 170.956  1.00 74.67           C  
+ANISOU 1188  C4'   C R  57     7482  12197   8694  -1721   1842    157       C  
+ATOM   1189  O4'   C R  57     151.615  17.067 172.003  1.00 76.76           O  
+ANISOU 1189  O4'   C R  57     7848  12402   8916  -1854   1830    203       O  
+ATOM   1190  C3'   C R  57     151.488  19.252 171.053  1.00 73.15           C  
+ANISOU 1190  C3'   C R  57     7366  11931   8498  -1459   1914     10       C  
+ATOM   1191  O3'   C R  57     150.678  20.040 171.942  1.00 75.87           O  
+ANISOU 1191  O3'   C R  57     7576  12531   8721  -1323   2033     -4       O  
+ATOM   1192  C2'   C R  57     152.871  19.037 171.668  1.00 73.64           C  
+ANISOU 1192  C2'   C R  57     7633  11768   8580  -1488   1886    -33       C  
+ATOM   1193  O2'   C R  57     153.401  20.153 172.356  1.00 88.11           O  
+ANISOU 1193  O2'   C R  57     9542  13567  10370  -1296   1957   -140       O  
+ATOM   1194  C1'   C R  57     152.615  17.866 172.617  1.00 76.60           C  
+ANISOU 1194  C1'   C R  57     7969  12254   8882  -1700   1878     91       C  
+ATOM   1195  N1    C R  57     153.815  17.043 172.882  1.00 75.26           N  
+ANISOU 1195  N1    C R  57     7987  11852   8758  -1825   1796     97       N  
+ATOM   1196  C2    C R  57     154.222  15.974 172.051  1.00 77.45           C  
+ANISOU 1196  C2    C R  57     8344  11955   9127  -1986   1669    144       C  
+ATOM   1197  O2    C R  57     153.585  15.662 171.036  1.00 78.47           O  
+ANISOU 1197  O2    C R  57     8397  12111   9306  -2039   1616    185       O  
+ATOM   1198  N3    C R  57     155.340  15.273 172.361  1.00 75.39           N  
+ANISOU 1198  N3    C R  57     8255  11490   8899  -2076   1596    141       N  
+ATOM   1199  C4    C R  57     156.055  15.586 173.440  1.00 75.95           C  
+ANISOU 1199  C4    C R  57     8415  11523   8921  -2023   1642     99       C  
+ATOM   1200  N4    C R  57     157.150  14.863 173.702  1.00 83.54           N  
+ANISOU 1200  N4    C R  57     9541  12283   9919  -2111   1562     97       N  
+ATOM   1201  C5    C R  57     155.675  16.658 174.301  1.00 74.62           C  
+ANISOU 1201  C5    C R  57     8175  11518   8658  -1867   1766     52       C  
+ATOM   1202  C6    C R  57     154.571  17.347 173.981  1.00 70.59           C  
+ANISOU 1202  C6    C R  57     7499  11210   8112  -1769   1838     50       C  
+ATOM   1203  P     C R  58     149.326  20.749 171.414  1.00 95.98           P  
+ANISOU 1203  P     C R  58     9916  15316  11235  -1191   2085     -5       P  
+ATOM   1204  OP1   C R  58     148.315  20.619 172.495  1.00 95.30           O  
+ANISOU 1204  OP1   C R  58     9713  15452  11044  -1175   2128     76       O  
+ATOM   1205  OP2   C R  58     149.047  20.254 170.034  1.00 90.61           O  
+ANISOU 1205  OP2   C R  58     9201  14563  10663  -1289   1991     34       O  
+ATOM   1206  O5'   C R  58     149.665  22.306 171.322  1.00 78.96           O  
+ANISOU 1206  O5'   C R  58     7835  13092   9074   -901   2137   -162       O  
+ATOM   1207  C5'   C R  58     151.012  22.776 171.276  1.00 67.89           C  
+ANISOU 1207  C5'   C R  58     6657  11404   7736   -827   2101   -262       C  
+ATOM   1208  C4'   C R  58     151.083  24.218 170.836  1.00 68.91           C  
+ANISOU 1208  C4'   C R  58     6833  11472   7879   -573   2120   -389       C  
+ATOM   1209  O4'   C R  58     151.617  24.276 169.477  1.00 68.80           O  
+ANISOU 1209  O4'   C R  58     6909  11234   7997   -584   2035   -419       O  
+ATOM   1210  C3'   C R  58     149.739  24.956 170.798  1.00 74.51           C  
+ANISOU 1210  C3'   C R  58     7354  12450   8507   -411   2189   -402       C  
+ATOM   1211  O3'   C R  58     149.906  26.330 171.155  1.00 83.52           O  
+ANISOU 1211  O3'   C R  58     8569  13566   9597   -154   2229   -528       O  
+ATOM   1212  C2'   C R  58     149.376  24.892 169.320  1.00 72.66           C  
+ANISOU 1212  C2'   C R  58     7073  12159   8377   -433   2120   -390       C  
+ATOM   1213  O2'   C R  58     148.482  25.896 168.890  1.00 81.71           O  
+ANISOU 1213  O2'   C R  58     8113  13440   9492   -232   2151   -446       O  
+ATOM   1214  C1'   C R  58     150.750  25.041 168.677  1.00 70.84           C  
+ANISOU 1214  C1'   C R  58     7065  11589   8260   -441   2044   -453       C  
+ATOM   1215  N1    C R  58     150.811  24.581 167.285  1.00 68.01           N  
+ANISOU 1215  N1    C R  58     6720  11106   8015   -531   1959   -424       N  
+ATOM   1216  C2    C R  58     150.804  25.579 166.309  1.00 71.99           C  
+ANISOU 1216  C2    C R  58     7263  11519   8569   -367   1936   -502       C  
+ATOM   1217  O2    C R  58     150.788  26.774 166.671  1.00 79.31           O  
+ANISOU 1217  O2    C R  58     8224  12461   9451   -163   1978   -592       O  
+ATOM   1218  N3    C R  58     150.813  25.219 165.003  1.00 68.49           N  
+ANISOU 1218  N3    C R  58     6832  10972   8217   -432   1860   -479       N  
+ATOM   1219  C4    C R  58     150.825  23.922 164.669  1.00 70.49           C  
+ANISOU 1219  C4    C R  58     7065  11205   8511   -645   1803   -388       C  
+ATOM   1220  N4    C R  58     150.843  23.611 163.364  1.00 73.41           N  
+ANISOU 1220  N4    C R  58     7462  11467   8964   -690   1724   -374       N  
+ATOM   1221  C5    C R  58     150.819  22.886 165.657  1.00 65.74           C  
+ANISOU 1221  C5    C R  58     6428  10688   7863   -817   1816   -306       C  
+ATOM   1222  C6    C R  58     150.807  23.259 166.944  1.00 62.43           C  
+ANISOU 1222  C6    C R  58     5990  10379   7352   -756   1898   -324       C  
+ATOM   1223  P     U R  59     150.307  26.782 172.649  1.00111.91           P  
+ANISOU 1223  P     U R  59    12246  17200  13074    -53   2294   -581       P  
+ATOM   1224  OP1   U R  59     151.773  26.939 172.607  1.00111.04           O  
+ANISOU 1224  OP1   U R  59    12370  16769  13050    -75   2227   -641       O  
+ATOM   1225  OP2   U R  59     149.723  25.923 173.708  1.00 92.51           O  
+ANISOU 1225  OP2   U R  59     9659  14986  10505   -176   2364   -480       O  
+ATOM   1226  O5'   U R  59     149.649  28.227 172.785  1.00 98.91           O  
+ANISOU 1226  O5'   U R  59    10565  15673  11343    250   2343   -692       O  
+ATOM   1227  C5'   U R  59     150.102  29.333 172.004  1.00 94.49           C  
+ANISOU 1227  C5'   U R  59    10138  14908  10856    419   2283   -802       C  
+ATOM   1228  C4'   U R  59     150.076  30.611 172.807  1.00 93.29           C  
+ANISOU 1228  C4'   U R  59    10066  14784  10598    686   2315   -921       C  
+ATOM   1229  O4'   U R  59     148.768  30.741 173.422  1.00 91.31           O  
+ANISOU 1229  O4'   U R  59     9639  14834  10220    795   2388   -895       O  
+ATOM   1230  C3'   U R  59     151.085  30.662 173.947  1.00 91.34           C  
+ANISOU 1230  C3'   U R  59     9989  14410  10306    679   2316   -959       C  
+ATOM   1231  O3'   U R  59     151.500  32.008 174.183  1.00 92.56           O  
+ANISOU 1231  O3'   U R  59    10307  14430  10432    915   2281  -1091       O  
+ATOM   1232  C2'   U R  59     150.288  30.149 175.138  1.00 85.34           C  
+ANISOU 1232  C2'   U R  59     9081  13955   9389    666   2420   -902       C  
+ATOM   1233  O2'   U R  59     150.757  30.603 176.388  1.00 87.95           O  
+ANISOU 1233  O2'   U R  59     9535  14271   9612    775   2445   -967       O  
+ATOM   1234  C1'   U R  59     148.880  30.670 174.835  1.00 91.66           C  
+ANISOU 1234  C1'   U R  59     9729  14947  10151    818   2434   -892       C  
+ATOM   1235  N1    U R  59     147.757  29.830 175.321  1.00 99.51           N  
+ANISOU 1235  N1    U R  59    10536  16182  11091    708   2476   -760       N  
+ATOM   1236  C2    U R  59     147.855  28.515 175.826  1.00103.30           C  
+ANISOU 1236  C2    U R  59    10960  16723  11565    458   2496   -633       C  
+ATOM   1237  O2    U R  59     148.858  27.824 175.953  1.00105.12           O  
+ANISOU 1237  O2    U R  59    11283  16824  11834    289   2483   -610       O  
+ATOM   1238  N3    U R  59     146.657  27.955 176.207  1.00106.08           N  
+ANISOU 1238  N3    U R  59    11135  17308  11863    397   2525   -520       N  
+ATOM   1239  C4    U R  59     145.394  28.515 176.165  1.00106.09           C  
+ANISOU 1239  C4    U R  59    10997  17499  11812    550   2543   -521       C  
+ATOM   1240  O4    U R  59     144.417  27.865 176.558  1.00111.67           O  
+ANISOU 1240  O4    U R  59    11543  18416  12471    460   2569   -408       O  
+ATOM   1241  C5    U R  59     145.368  29.847 175.648  1.00 98.47           C  
+ANISOU 1241  C5    U R  59    10099  16461  10854    806   2522   -657       C  
+ATOM   1242  C6    U R  59     146.510  30.425 175.262  1.00 97.34           C  
+ANISOU 1242  C6    U R  59    10137  16081  10765    870   2488   -764       C  
+ATOM   1243  P     G R  60     152.800  32.589 173.433  1.00 92.75           P  
+ANISOU 1243  P     G R  60    10557  14083  10600    908   2167  -1150       P  
+ATOM   1244  OP1   G R  60     153.182  33.877 174.081  1.00 90.05           O  
+ANISOU 1244  OP1   G R  60    10385  13636  10193   1136   2133  -1274       O  
+ATOM   1245  OP2   G R  60     152.516  32.528 171.972  1.00 87.64           O  
+ANISOU 1245  OP2   G R  60     9846  13387  10067    864   2127  -1120       O  
+ATOM   1246  O5'   G R  60     153.947  31.512 173.731  1.00 87.82           O  
+ANISOU 1246  O5'   G R  60    10020  13299  10051    659   2141  -1080       O  
+ATOM   1247  C5'   G R  60     154.267  31.118 175.063  1.00 79.92           C  
+ANISOU 1247  C5'   G R  60     9060  12349   8958    617   2179  -1070       C  
+ATOM   1248  C4'   G R  60     154.631  29.647 175.151  1.00 79.37           C  
+ANISOU 1248  C4'   G R  60     8945  12275   8935    345   2184   -955       C  
+ATOM   1249  O4'   G R  60     153.717  28.837 174.358  1.00 82.24           O  
+ANISOU 1249  O4'   G R  60     9120  12800   9328    226   2210   -861       O  
+ATOM   1250  C3'   G R  60     156.004  29.251 174.630  1.00 79.16           C  
+ANISOU 1250  C3'   G R  60     9070  11951   9055    195   2095   -942       C  
+ATOM   1251  O3'   G R  60     157.039  29.534 175.555  1.00 82.56           O  
+ANISOU 1251  O3'   G R  60     9671  12230   9469    215   2063   -992       O  
+ATOM   1252  C2'   G R  60     155.829  27.762 174.355  1.00 78.29           C  
+ANISOU 1252  C2'   G R  60     8852  11910   8983    -47   2103   -820       C  
+ATOM   1253  O2'   G R  60     155.855  27.036 175.577  1.00 86.90           O  
+ANISOU 1253  O2'   G R  60     9933  13103   9980   -141   2143   -772       O  
+ATOM   1254  C1'   G R  60     154.406  27.722 173.821  1.00 71.26           C  
+ANISOU 1254  C1'   G R  60     7760  11265   8051     -9   2156   -781       C  
+ATOM   1255  N9    G R  60     154.360  27.789 172.347  1.00 69.74           N  
+ANISOU 1255  N9    G R  60     7549  10971   7979    -27   2102   -777       N  
+ATOM   1256  C8    G R  60     154.102  28.909 171.595  1.00 75.16           C  
+ANISOU 1256  C8    G R  60     8249  11616   8691    153   2085   -853       C  
+ATOM   1257  N7    G R  60     154.110  28.703 170.301  1.00 75.79           N  
+ANISOU 1257  N7    G R  60     8311  11608   8877     92   2036   -827       N  
+ATOM   1258  C5    G R  60     154.388  27.351 170.185  1.00 71.66           C  
+ANISOU 1258  C5    G R  60     7762  11065   8402   -137   2016   -732       C  
+ATOM   1259  C6    G R  60     154.501  26.567 169.015  1.00 68.26           C  
+ANISOU 1259  C6    G R  60     7312  10549   8073   -279   1959   -673       C  
+ATOM   1260  O6    G R  60     154.392  26.927 167.826  1.00 79.11           O  
+ANISOU 1260  O6    G R  60     8687  11852   9518   -231   1921   -691       O  
+ATOM   1261  N1    G R  60     154.785  25.241 169.334  1.00 69.46           N  
+ANISOU 1261  N1    G R  60     7459  10698   8236   -489   1941   -587       N  
+ATOM   1262  C2    G R  60     154.922  24.735 170.602  1.00 72.24           C  
+ANISOU 1262  C2    G R  60     7816  11122   8511   -562   1976   -556       C  
+ATOM   1263  N2    G R  60     155.194  23.424 170.662  1.00 75.15           N  
+ANISOU 1263  N2    G R  60     8189  11458   8906   -773   1936   -469       N  
+ATOM   1264  N3    G R  60     154.808  25.458 171.714  1.00 73.84           N  
+ANISOU 1264  N3    G R  60     8030  11414   8613   -433   2037   -607       N  
+ATOM   1265  C4    G R  60     154.539  26.760 171.434  1.00 76.76           C  
+ANISOU 1265  C4    G R  60     8410  11787   8970   -219   2054   -697       C  
+ATOM   1266  P     A R  61     158.553  29.109 175.234  1.00 83.99           P  
+ANISOU 1266  P     A R  61    10004  12121   9788     65   1976   -978       P  
+ATOM   1267  OP1   A R  61     159.419  29.657 176.312  1.00 86.04           O  
+ANISOU 1267  OP1   A R  61    10426  12259  10006    133   1944  -1043       O  
+ATOM   1268  OP2   A R  61     158.790  29.505 173.813  1.00 70.54           O  
+ANISOU 1268  OP2   A R  61     8316  10276   8211     78   1923   -989       O  
+ATOM   1269  O5'   A R  61     158.545  27.515 175.404  1.00 83.90           O  
+ANISOU 1269  O5'   A R  61     9913  12180   9784   -173   1992   -865       O  
+ATOM   1270  C5'   A R  61     159.723  26.742 175.216  1.00 72.04           C  
+ANISOU 1270  C5'   A R  61     8510  10478   8386   -336   1925   -830       C  
+ATOM   1271  C4'   A R  61     159.448  25.383 174.614  1.00 63.30           C  
+ANISOU 1271  C4'   A R  61     7307   9421   7325   -534   1918   -727       C  
+ATOM   1272  O4'   A R  61     158.216  25.385 173.847  1.00 70.36           O  
+ANISOU 1272  O4'   A R  61     8041  10488   8203   -509   1957   -695       O  
+ATOM   1273  C3'   A R  61     160.498  24.936 173.619  1.00 65.92           C  
+ANISOU 1273  C3'   A R  61     7719   9527   7800   -635   1838   -713       C  
+ATOM   1274  O3'   A R  61     161.634  24.397 174.250  1.00 75.92           O  
+ANISOU 1274  O3'   A R  61     9103  10649   9093   -729   1791   -706       O  
+ATOM   1275  C2'   A R  61     159.754  23.952 172.728  1.00 59.36           C  
+ANISOU 1275  C2'   A R  61     6766   8789   6998   -760   1834   -631       C  
+ATOM   1276  O2'   A R  61     159.670  22.679 173.345  1.00 60.08           O  
+ANISOU 1276  O2'   A R  61     6833   8944   7051   -934   1827   -549       O  
+ATOM   1277  C1'   A R  61     158.362  24.572 172.692  1.00 68.78           C  
+ANISOU 1277  C1'   A R  61     7817  10208   8109   -644   1905   -638       C  
+ATOM   1278  N9    A R  61     158.164  25.406 171.492  1.00 65.27           N  
+ANISOU 1278  N9    A R  61     7358   9710   7731   -529   1890   -684       N  
+ATOM   1279  C8    A R  61     158.054  26.774 171.444  1.00 62.08           C  
+ANISOU 1279  C8    A R  61     6988   9290   7309   -330   1905   -771       C  
+ATOM   1280  N7    A R  61     157.870  27.249 170.235  1.00 63.07           N  
+ANISOU 1280  N7    A R  61     7097   9364   7504   -270   1880   -789       N  
+ATOM   1281  C5    A R  61     157.851  26.119 169.428  1.00 58.68           C  
+ANISOU 1281  C5    A R  61     6492   8792   7013   -435   1849   -713       C  
+ATOM   1282  C6    A R  61     157.677  25.942 168.046  1.00 62.57           C  
+ANISOU 1282  C6    A R  61     6952   9236   7585   -462   1811   -691       C  
+ATOM   1283  N6    A R  61     157.492  26.956 167.191  1.00 56.89           N  
+ANISOU 1283  N6    A R  61     6243   8475   6898   -324   1802   -742       N  
+ATOM   1284  N1    A R  61     157.712  24.673 167.559  1.00 63.19           N  
+ANISOU 1284  N1    A R  61     7002   9303   7706   -635   1772   -615       N  
+ATOM   1285  C2    A R  61     157.895  23.663 168.427  1.00 57.41           C  
+ANISOU 1285  C2    A R  61     6272   8604   6939   -776   1771   -561       C  
+ATOM   1286  N3    A R  61     158.064  23.714 169.748  1.00 55.92           N  
+ANISOU 1286  N3    A R  61     6106   8464   6675   -772   1808   -570       N  
+ATOM   1287  C4    A R  61     158.033  24.975 170.192  1.00 61.54           C  
+ANISOU 1287  C4    A R  61     6846   9190   7345   -595   1849   -649       C  
+ATOM   1288  P     G R  62     163.061  24.823 173.691  1.00 83.30           P  
+ANISOU 1288  P     G R  62    10175  11325  10151   -712   1718   -753       P  
+ATOM   1289  OP1   G R  62     164.093  23.945 174.293  1.00 88.95           O  
+ANISOU 1289  OP1   G R  62    10979  11926  10891   -838   1669   -726       O  
+ATOM   1290  OP2   G R  62     163.155  26.294 173.873  1.00 86.64           O  
+ANISOU 1290  OP2   G R  62    10658  11704  10558   -532   1724   -838       O  
+ATOM   1291  O5'   G R  62     162.877  24.583 172.123  1.00 76.87           O  
+ANISOU 1291  O5'   G R  62     9301  10475   9429   -743   1697   -725       O  
+ATOM   1292  C5'   G R  62     163.855  23.939 171.326  1.00 54.38           C  
+ANISOU 1292  C5'   G R  62     6510   7465   6687   -837   1635   -701       C  
+ATOM   1293  C4'   G R  62     163.227  22.925 170.396  1.00 50.95           C  
+ANISOU 1293  C4'   G R  62     5990   7095   6275   -939   1624   -637       C  
+ATOM   1294  O4'   G R  62     161.856  23.281 170.087  1.00 47.32           O  
+ANISOU 1294  O4'   G R  62     5407   6813   5762   -880   1675   -628       O  
+ATOM   1295  C3'   G R  62     163.886  22.788 169.037  1.00 53.09           C  
+ANISOU 1295  C3'   G R  62     6296   7226   6652   -950   1575   -636       C  
+ATOM   1296  O3'   G R  62     165.039  21.984 169.089  1.00 44.75           O  
+ANISOU 1296  O3'   G R  62     5324   6030   5647  -1041   1518   -620       O  
+ATOM   1297  C2'   G R  62     162.770  22.207 168.182  1.00 53.83           C  
+ANISOU 1297  C2'   G R  62     6282   7436   6734   -996   1578   -588       C  
+ATOM   1298  O2'   G R  62     162.607  20.817 168.457  1.00 58.79           O  
+ANISOU 1298  O2'   G R  62     6897   8099   7342  -1152   1541   -521       O  
+ATOM   1299  C1'   G R  62     161.565  22.949 168.745  1.00 52.75           C  
+ANISOU 1299  C1'   G R  62     6049   7484   6511   -909   1647   -602       C  
+ATOM   1300  N9    G R  62     161.280  24.200 168.019  1.00 54.63           N  
+ANISOU 1300  N9    G R  62     6272   7715   6769   -754   1669   -656       N  
+ATOM   1301  C8    G R  62     161.206  25.440 168.604  1.00 48.50           C  
+ANISOU 1301  C8    G R  62     5520   6955   5952   -609   1704   -720       C  
+ATOM   1302  N7    G R  62     160.922  26.397 167.768  1.00 47.81           N  
+ANISOU 1302  N7    G R  62     5425   6850   5891   -489   1706   -757       N  
+ATOM   1303  C5    G R  62     160.790  25.742 166.553  1.00 49.93           C  
+ANISOU 1303  C5    G R  62     5655   7097   6220   -561   1676   -714       C  
+ATOM   1304  C6    G R  62     160.481  26.263 165.270  1.00 49.27           C  
+ANISOU 1304  C6    G R  62     5551   6988   6181   -491   1662   -725       C  
+ATOM   1305  O6    G R  62     160.234  27.429 164.947  1.00 47.28           O  
+ANISOU 1305  O6    G R  62     5310   6726   5927   -352   1672   -773       O  
+ATOM   1306  N1    G R  62     160.436  25.256 164.312  1.00 47.79           N  
+ANISOU 1306  N1    G R  62     5336   6783   6038   -597   1626   -672       N  
+ATOM   1307  C2    G R  62     160.660  23.909 164.553  1.00 42.51           C  
+ANISOU 1307  C2    G R  62     4666   6113   5372   -751   1598   -618       C  
+ATOM   1308  N2    G R  62     160.583  23.108 163.472  1.00 39.88           N  
+ANISOU 1308  N2    G R  62     4323   5748   5081   -823   1550   -580       N  
+ATOM   1309  N3    G R  62     160.960  23.419 165.743  1.00 44.65           N  
+ANISOU 1309  N3    G R  62     4958   6402   5605   -822   1607   -605       N  
+ATOM   1310  C4    G R  62     160.997  24.379 166.689  1.00 48.54           C  
+ANISOU 1310  C4    G R  62     5470   6922   6052   -722   1651   -653       C  
+ATOM   1311  P     A R  63     166.329  22.414 168.274  1.00 51.93           P  
+ANISOU 1311  P     A R  63     6315   6759   6658   -996   1481   -650       P  
+ATOM   1312  OP1   A R  63     167.472  21.543 168.670  1.00 61.71           O  
+ANISOU 1312  OP1   A R  63     7632   7886   7930  -1083   1427   -636       O  
+ATOM   1313  OP2   A R  63     166.436  23.883 168.450  1.00 52.18           O  
+ANISOU 1313  OP2   A R  63     6370   6766   6692   -867   1511   -704       O  
+ATOM   1314  O5'   A R  63     165.947  22.100 166.757  1.00 41.04           O  
+ANISOU 1314  O5'   A R  63     4890   5383   5321   -998   1468   -626       O  
+ATOM   1315  C5'   A R  63     165.622  20.790 166.331  1.00 45.12           C  
+ANISOU 1315  C5'   A R  63     5384   5925   5833  -1106   1427   -577       C  
+ATOM   1316  C4'   A R  63     165.476  20.758 164.830  1.00 50.61           C  
+ANISOU 1316  C4'   A R  63     6062   6594   6575  -1075   1409   -571       C  
+ATOM   1317  O4'   A R  63     164.227  21.380 164.451  1.00 48.82           O  
+ANISOU 1317  O4'   A R  63     5744   6490   6315  -1017   1449   -572       O  
+ATOM   1318  C3'   A R  63     166.520  21.543 164.061  1.00 46.60           C  
+ANISOU 1318  C3'   A R  63     5608   5961   6135   -988   1411   -604       C  
+ATOM   1319  O3'   A R  63     167.723  20.832 163.902  1.00 40.61           O  
+ANISOU 1319  O3'   A R  63     4921   5088   5420  -1031   1365   -597       O  
+ATOM   1320  C2'   A R  63     165.808  21.851 162.750  1.00 44.36           C  
+ANISOU 1320  C2'   A R  63     5278   5715   5862   -933   1418   -599       C  
+ATOM   1321  O2'   A R  63     165.788  20.706 161.910  1.00 42.32           O  
+ANISOU 1321  O2'   A R  63     5030   5436   5614   -997   1365   -569       O  
+ATOM   1322  C1'   A R  63     164.396  22.090 163.237  1.00 47.95           C  
+ANISOU 1322  C1'   A R  63     5642   6324   6253   -927   1452   -594       C  
+ATOM   1323  N9    A R  63     164.105  23.504 163.505  1.00 50.12           N  
+ANISOU 1323  N9    A R  63     5900   6630   6514   -807   1503   -635       N  
+ATOM   1324  C8    A R  63     163.969  24.089 164.746  1.00 45.16           C  
+ANISOU 1324  C8    A R  63     5270   6049   5839   -772   1538   -662       C  
+ATOM   1325  N7    A R  63     163.644  25.356 164.689  1.00 43.04           N  
+ANISOU 1325  N7    A R  63     4997   5797   5561   -648   1566   -703       N  
+ATOM   1326  C5    A R  63     163.536  25.602 163.319  1.00 47.18           C  
+ANISOU 1326  C5    A R  63     5513   6285   6130   -609   1553   -698       C  
+ATOM   1327  C6    A R  63     163.221  26.766 162.577  1.00 39.13           C  
+ANISOU 1327  C6    A R  63     4493   5252   5122   -488   1561   -727       C  
+ATOM   1328  N6    A R  63     162.919  27.922 163.167  1.00 37.57           N  
+ANISOU 1328  N6    A R  63     4308   5076   4891   -377   1582   -773       N  
+ATOM   1329  N1    A R  63     163.207  26.681 161.215  1.00 37.53           N  
+ANISOU 1329  N1    A R  63     4287   5012   4961   -481   1541   -707       N  
+ATOM   1330  C2    A R  63     163.491  25.495 160.658  1.00 39.77           C  
+ANISOU 1330  C2    A R  63     4570   5274   5268   -579   1513   -668       C  
+ATOM   1331  N3    A R  63     163.806  24.332 161.242  1.00 39.35           N  
+ANISOU 1331  N3    A R  63     4523   5221   5207   -691   1494   -642       N  
+ATOM   1332  C4    A R  63     163.819  24.461 162.578  1.00 44.00           C  
+ANISOU 1332  C4    A R  63     5111   5846   5759   -704   1517   -656       C  
+ATOM   1333  P     C R  64     169.097  21.612 163.678  1.00 50.08           P  
+ANISOU 1333  P     C R  64     6176   6165   6685   -967   1369   -620       P  
+ATOM   1334  OP1   C R  64     170.104  20.544 163.501  1.00 39.29           O  
+ANISOU 1334  OP1   C R  64     4862   4719   5348  -1020   1317   -607       O  
+ATOM   1335  OP2   C R  64     169.267  22.683 164.691  1.00 41.52           O  
+ANISOU 1335  OP2   C R  64     5106   5074   5594   -924   1398   -649       O  
+ATOM   1336  O5'   C R  64     168.937  22.303 162.249  1.00 48.19           O  
+ANISOU 1336  O5'   C R  64     5915   5919   6477   -885   1389   -620       O  
+ATOM   1337  C5'   C R  64     168.997  21.520 161.067  1.00 47.02           C  
+ANISOU 1337  C5'   C R  64     5771   5755   6340   -894   1361   -601       C  
+ATOM   1338  C4'   C R  64     168.655  22.346 159.853  1.00 33.45           C  
+ANISOU 1338  C4'   C R  64     4029   4046   4634   -811   1387   -602       C  
+ATOM   1339  O4'   C R  64     167.386  23.029 160.077  1.00 39.91           O  
+ANISOU 1339  O4'   C R  64     4791   4957   5417   -778   1416   -613       O  
+ATOM   1340  C3'   C R  64     169.625  23.478 159.552  1.00 36.03           C  
+ANISOU 1340  C3'   C R  64     4382   4297   5009   -744   1413   -605       C  
+ATOM   1341  O3'   C R  64     170.798  23.056 158.874  1.00 34.27           O  
+ANISOU 1341  O3'   C R  64     4192   4006   4823   -744   1398   -588       O  
+ATOM   1342  C2'   C R  64     168.763  24.439 158.743  1.00 34.43           C  
+ANISOU 1342  C2'   C R  64     4151   4135   4798   -668   1439   -609       C  
+ATOM   1343  O2'   C R  64     168.606  23.949 157.422  1.00 42.06           O  
+ANISOU 1343  O2'   C R  64     5113   5106   5761   -651   1426   -591       O  
+ATOM   1344  C1'   C R  64     167.419  24.304 159.441  1.00 39.95           C  
+ANISOU 1344  C1'   C R  64     4798   4938   5443   -684   1445   -624       C  
+ATOM   1345  N1    C R  64     167.122  25.407 160.404  1.00 38.45           N  
+ANISOU 1345  N1    C R  64     4604   4769   5238   -636   1472   -654       N  
+ATOM   1346  C2    C R  64     166.658  26.616 159.857  1.00 38.22           C  
+ANISOU 1346  C2    C R  64     4569   4743   5210   -539   1488   -669       C  
+ATOM   1347  O2    C R  64     166.560  26.694 158.627  1.00 40.86           O  
+ANISOU 1347  O2    C R  64     4900   5066   5560   -509   1484   -652       O  
+ATOM   1348  N3    C R  64     166.322  27.662 160.661  1.00 43.13           N  
+ANISOU 1348  N3    C R  64     5199   5378   5808   -474   1502   -704       N  
+ATOM   1349  C4    C R  64     166.441  27.537 161.989  1.00 40.50           C  
+ANISOU 1349  C4    C R  64     4878   5062   5450   -503   1506   -723       C  
+ATOM   1350  N4    C R  64     166.118  28.580 162.760  1.00 36.07           N  
+ANISOU 1350  N4    C R  64     4337   4512   4857   -423   1514   -763       N  
+ATOM   1351  C5    C R  64     166.908  26.326 162.586  1.00 34.79           C  
+ANISOU 1351  C5    C R  64     4155   4338   4725   -608   1495   -702       C  
+ATOM   1352  C6    C R  64     167.236  25.316 161.764  1.00 34.74           C  
+ANISOU 1352  C6    C R  64     4143   4311   4744   -671   1475   -669       C  
+ATOM   1353  P     A R  65     172.228  23.576 159.353  1.00 40.35           P  
+ANISOU 1353  P     A R  65     4992   4695   5646   -744   1401   -581       P  
+ATOM   1354  OP1   A R  65     173.271  22.856 158.618  1.00 42.59           O  
+ANISOU 1354  OP1   A R  65     5288   4942   5951   -741   1387   -560       O  
+ATOM   1355  OP2   A R  65     172.246  23.644 160.833  1.00 52.61           O  
+ANISOU 1355  OP2   A R  65     6558   6240   7192   -788   1390   -601       O  
+ATOM   1356  O5'   A R  65     172.241  25.104 158.869  1.00 54.44           O  
+ANISOU 1356  O5'   A R  65     6772   6457   7456   -679   1432   -571       O  
+ATOM   1357  C5'   A R  65     172.063  25.450 157.491  1.00 41.22           C  
+ANISOU 1357  C5'   A R  65     5087   4792   5781   -625   1451   -549       C  
+ATOM   1358  C4'   A R  65     173.000  26.563 157.082  1.00 37.93           C  
+ANISOU 1358  C4'   A R  65     4685   4315   5412   -598   1464   -515       C  
+ATOM   1359  O4'   A R  65     172.672  27.765 157.856  1.00 38.89           O  
+ANISOU 1359  O4'   A R  65     4828   4407   5542   -582   1458   -533       O  
+ATOM   1360  C3'   A R  65     174.459  26.246 157.383  1.00 43.81           C  
+ANISOU 1360  C3'   A R  65     5434   5010   6200   -638   1455   -489       C  
+ATOM   1361  O3'   A R  65     175.319  26.822 156.394  1.00 52.49           O  
+ANISOU 1361  O3'   A R  65     6524   6088   7330   -614   1475   -436       O  
+ATOM   1362  C2'   A R  65     174.661  26.885 158.754  1.00 47.95           C  
+ANISOU 1362  C2'   A R  65     5983   5489   6749   -670   1432   -508       C  
+ATOM   1363  O2'   A R  65     176.002  27.171 159.085  1.00 52.20           O  
+ANISOU 1363  O2'   A R  65     6526   5966   7342   -705   1416   -477       O  
+ATOM   1364  C1'   A R  65     173.788  28.140 158.633  1.00 44.98           C  
+ANISOU 1364  C1'   A R  65     5622   5107   6359   -620   1438   -519       C  
+ATOM   1365  N9    A R  65     173.351  28.737 159.906  1.00 42.65           N  
+ANISOU 1365  N9    A R  65     5359   4795   6052   -618   1417   -561       N  
+ATOM   1366  C8    A R  65     173.635  28.351 161.187  1.00 34.41           C  
+ANISOU 1366  C8    A R  65     4332   3737   5005   -661   1396   -587       C  
+ATOM   1367  N7    A R  65     173.127  29.154 162.106  1.00 37.44           N  
+ANISOU 1367  N7    A R  65     4753   4109   5365   -631   1380   -625       N  
+ATOM   1368  C5    A R  65     172.500  30.162 161.382  1.00 40.06           C  
+ANISOU 1368  C5    A R  65     5093   4439   5689   -561   1387   -625       C  
+ATOM   1369  C6    A R  65     171.808  31.342 161.770  1.00 39.66           C  
+ANISOU 1369  C6    A R  65     5086   4372   5612   -486   1369   -662       C  
+ATOM   1370  N6    A R  65     171.595  31.719 163.042  1.00 37.75           N  
+ANISOU 1370  N6    A R  65     4887   4119   5337   -464   1345   -710       N  
+ATOM   1371  N1    A R  65     171.323  32.111 160.772  1.00 38.03           N  
+ANISOU 1371  N1    A R  65     4884   4161   5403   -424   1372   -651       N  
+ATOM   1372  C2    A R  65     171.537  31.744 159.496  1.00 37.34           C  
+ANISOU 1372  C2    A R  65     4762   4088   5339   -440   1395   -603       C  
+ATOM   1373  N3    A R  65     172.168  30.665 159.023  1.00 37.10           N  
+ANISOU 1373  N3    A R  65     4689   4079   5328   -501   1417   -569       N  
+ATOM   1374  C4    A R  65     172.636  29.917 160.028  1.00 38.45           C  
+ANISOU 1374  C4    A R  65     4856   4250   5503   -558   1409   -583       C  
+ATOM   1375  P     G R  66     176.272  25.857 155.509  1.00 54.92           P  
+ANISOU 1375  P     G R  66     6808   6422   7636   -603   1490   -405       P  
+ATOM   1376  OP1   G R  66     176.529  24.637 156.308  1.00 49.19           O  
+ANISOU 1376  OP1   G R  66     6088   5698   6903   -638   1459   -439       O  
+ATOM   1377  OP2   G R  66     177.411  26.681 155.025  1.00 68.57           O  
+ANISOU 1377  OP2   G R  66     8515   8130   9409   -604   1510   -339       O  
+ATOM   1378  O5'   G R  66     175.368  25.423 154.270  1.00 55.71           O  
+ANISOU 1378  O5'   G R  66     6912   6575   7681   -546   1505   -412       O  
+ATOM   1379  C5'   G R  66     174.925  26.369 153.311  1.00 53.97           C  
+ANISOU 1379  C5'   G R  66     6694   6362   7450   -501   1530   -384       C  
+ATOM   1380  C4'   G R  66     173.978  25.757 152.299  1.00 47.70           C  
+ANISOU 1380  C4'   G R  66     5909   5616   6599   -451   1530   -403       C  
+ATOM   1381  O4'   G R  66     174.669  24.782 151.459  1.00 48.56           O  
+ANISOU 1381  O4'   G R  66     6018   5750   6680   -419   1536   -390       O  
+ATOM   1382  C3'   G R  66     172.764  25.042 152.870  1.00 40.35           C  
+ANISOU 1382  C3'   G R  66     4981   4712   5637   -472   1496   -457       C  
+ATOM   1383  O3'   G R  66     171.643  25.335 152.039  1.00 55.23           O  
+ANISOU 1383  O3'   G R  66     6867   6630   7487   -426   1495   -463       O  
+ATOM   1384  C2'   G R  66     173.136  23.560 152.714  1.00 38.95           C  
+ANISOU 1384  C2'   G R  66     4817   4546   5434   -482   1468   -471       C  
+ATOM   1385  O2'   G R  66     172.026  22.701 152.619  1.00 42.26           O  
+ANISOU 1385  O2'   G R  66     5248   4997   5812   -493   1427   -503       O  
+ATOM   1386  C1'   G R  66     173.913  23.590 151.410  1.00 45.33           C  
+ANISOU 1386  C1'   G R  66     5631   5363   6228   -417   1496   -435       C  
+ATOM   1387  N9    G R  66     174.843  22.473 151.158  1.00 42.23           N  
+ANISOU 1387  N9    G R  66     5252   4974   5818   -397   1483   -438       N  
+ATOM   1388  C8    G R  66     175.940  22.121 151.898  1.00 39.18           C  
+ANISOU 1388  C8    G R  66     4854   4570   5464   -424   1479   -435       C  
+ATOM   1389  N7    G R  66     176.608  21.123 151.408  1.00 43.18           N  
+ANISOU 1389  N7    G R  66     5378   5090   5940   -377   1464   -443       N  
+ATOM   1390  C5    G R  66     175.916  20.811 150.239  1.00 36.63           C  
+ANISOU 1390  C5    G R  66     4581   4285   5050   -315   1456   -451       C  
+ATOM   1391  C6    G R  66     176.183  19.822 149.256  1.00 38.14           C  
+ANISOU 1391  C6    G R  66     4815   4497   5179   -232   1434   -468       C  
+ATOM   1392  O6    G R  66     177.094  18.991 149.238  1.00 49.65           O  
+ANISOU 1392  O6    G R  66     6287   5957   6619   -190   1417   -481       O  
+ATOM   1393  N1    G R  66     175.253  19.842 148.224  1.00 39.21           N  
+ANISOU 1393  N1    G R  66     4985   4649   5265   -187   1423   -474       N  
+ATOM   1394  C2    G R  66     174.196  20.716 148.134  1.00 42.33           C  
+ANISOU 1394  C2    G R  66     5364   5046   5672   -217   1436   -463       C  
+ATOM   1395  N2    G R  66     173.418  20.564 147.045  1.00 39.92           N  
+ANISOU 1395  N2    G R  66     5097   4758   5313   -163   1416   -471       N  
+ATOM   1396  N3    G R  66     173.934  21.651 149.042  1.00 39.84           N  
+ANISOU 1396  N3    G R  66     5007   4718   5413   -285   1459   -451       N  
+ATOM   1397  C4    G R  66     174.834  21.646 150.057  1.00 37.81           C  
+ANISOU 1397  C4    G R  66     4725   4440   5203   -330   1468   -446       C  
+ATOM   1398  P     C R  67     170.483  26.330 152.557  1.00 56.36           P  
+ANISOU 1398  P     C R  67     6997   6786   7629   -416   1493   -486       P  
+ATOM   1399  OP1   C R  67     170.734  26.715 153.974  1.00 61.91           O  
+ANISOU 1399  OP1   C R  67     7698   7464   8363   -459   1491   -504       O  
+ATOM   1400  OP2   C R  67     169.161  25.770 152.153  1.00 54.63           O  
+ANISOU 1400  OP2   C R  67     6761   6628   7366   -402   1470   -511       O  
+ATOM   1401  O5'   C R  67     170.706  27.625 151.649  1.00 52.98           O  
+ANISOU 1401  O5'   C R  67     6589   6328   7214   -360   1516   -448       O  
+ATOM   1402  C5'   C R  67     170.322  27.614 150.288  1.00 49.47           C  
+ANISOU 1402  C5'   C R  67     6155   5906   6735   -304   1520   -430       C  
+ATOM   1403  C4'   C R  67     169.346  28.718 150.000  1.00 43.11           C  
+ANISOU 1403  C4'   C R  67     5358   5102   5920   -253   1513   -437       C  
+ATOM   1404  O4'   C R  67     168.260  28.680 150.955  1.00 44.75           O  
+ANISOU 1404  O4'   C R  67     5535   5348   6119   -259   1493   -488       O  
+ATOM   1405  C3'   C R  67     169.910  30.108 150.154  1.00 50.48           C  
+ANISOU 1405  C3'   C R  67     6322   5970   6889   -244   1520   -405       C  
+ATOM   1406  O3'   C R  67     170.673  30.508 149.039  1.00 52.66           O  
+ANISOU 1406  O3'   C R  67     6623   6222   7165   -227   1540   -342       O  
+ATOM   1407  C2'   C R  67     168.665  30.946 150.399  1.00 51.68           C  
+ANISOU 1407  C2'   C R  67     6479   6131   7025   -190   1495   -444       C  
+ATOM   1408  O2'   C R  67     167.963  31.149 149.186  1.00 60.27           O  
+ANISOU 1408  O2'   C R  67     7579   7243   8080   -128   1489   -434       O  
+ATOM   1409  C1'   C R  67     167.842  29.999 151.256  1.00 50.96           C  
+ANISOU 1409  C1'   C R  67     6338   6111   6915   -214   1488   -498       C  
+ATOM   1410  N1    C R  67     168.038  30.243 152.701  1.00 52.38           N  
+ANISOU 1410  N1    C R  67     6514   6272   7115   -246   1485   -526       N  
+ATOM   1411  C2    C R  67     167.451  31.364 153.308  1.00 53.28           C  
+ANISOU 1411  C2    C R  67     6645   6373   7225   -193   1470   -557       C  
+ATOM   1412  O2    C R  67     166.777  32.178 152.648  1.00 45.51           O  
+ANISOU 1412  O2    C R  67     5679   5388   6224   -119   1456   -561       O  
+ATOM   1413  N3    C R  67     167.636  31.537 154.634  1.00 50.43           N  
+ANISOU 1413  N3    C R  67     6291   5998   6872   -215   1465   -587       N  
+ATOM   1414  C4    C R  67     168.363  30.678 155.359  1.00 45.68           C  
+ANISOU 1414  C4    C R  67     5676   5392   6287   -293   1474   -583       C  
+ATOM   1415  N4    C R  67     168.517  30.926 156.671  1.00 37.48           N  
+ANISOU 1415  N4    C R  67     4653   4337   5251   -308   1464   -613       N  
+ATOM   1416  C5    C R  67     168.971  29.540 154.757  1.00 46.49           C  
+ANISOU 1416  C5    C R  67     5760   5505   6398   -348   1486   -551       C  
+ATOM   1417  C6    C R  67     168.786  29.372 153.443  1.00 49.30           C  
+ANISOU 1417  C6    C R  67     6113   5878   6742   -319   1491   -526       C  
+ATOM   1418  P     C R  68     172.045  31.275 149.305  1.00 55.59           P  
+ANISOU 1418  P     C R  68     7008   6528   7586   -274   1552   -279       P  
+ATOM   1419  OP1   C R  68     172.926  31.167 148.110  1.00 50.83           O  
+ANISOU 1419  OP1   C R  68     6403   5943   6968   -267   1588   -207       O  
+ATOM   1420  OP2   C R  68     172.545  30.866 150.643  1.00 63.35           O  
+ANISOU 1420  OP2   C R  68     7969   7494   8605   -334   1543   -307       O  
+ATOM   1421  O5'   C R  68     171.574  32.788 149.473  1.00 56.96           O  
+ANISOU 1421  O5'   C R  68     7231   6635   7774   -249   1517   -274       O  
+ATOM   1422  C5'   C R  68     170.501  33.298 148.706  1.00 56.15           C  
+ANISOU 1422  C5'   C R  68     7155   6543   7634   -177   1501   -288       C  
+ATOM   1423  C4'   C R  68     170.074  34.626 149.257  1.00 52.49           C  
+ANISOU 1423  C4'   C R  68     6745   6010   7188   -148   1453   -304       C  
+ATOM   1424  O4'   C R  68     169.160  34.421 150.362  1.00 57.29           O  
+ANISOU 1424  O4'   C R  68     7331   6650   7786   -122   1437   -388       O  
+ATOM   1425  C3'   C R  68     171.188  35.451 149.857  1.00 52.10           C  
+ANISOU 1425  C3'   C R  68     6735   5869   7192   -209   1430   -256       C  
+ATOM   1426  O3'   C R  68     171.987  36.083 148.875  1.00 59.82           O  
+ANISOU 1426  O3'   C R  68     7743   6805   8180   -235   1433   -162       O  
+ATOM   1427  C2'   C R  68     170.423  36.386 150.794  1.00 58.02           C  
+ANISOU 1427  C2'   C R  68     7537   6566   7943   -160   1373   -318       C  
+ATOM   1428  O2'   C R  68     169.764  37.411 150.064  1.00 50.75           O  
+ANISOU 1428  O2'   C R  68     6678   5604   6999    -89   1334   -310       O  
+ATOM   1429  C1'   C R  68     169.353  35.437 151.335  1.00 58.29           C  
+ANISOU 1429  C1'   C R  68     7509   6699   7941   -121   1395   -403       C  
+ATOM   1430  N1    C R  68     169.738  34.807 152.624  1.00 47.19           N  
+ANISOU 1430  N1    C R  68     6072   5305   6553   -176   1404   -437       N  
+ATOM   1431  C2    C R  68     169.425  35.460 153.821  1.00 47.57           C  
+ANISOU 1431  C2    C R  68     6156   5317   6601   -148   1366   -490       C  
+ATOM   1432  O2    C R  68     168.835  36.543 153.790  1.00 45.32           O  
+ANISOU 1432  O2    C R  68     5929   4989   6301    -72   1323   -512       O  
+ATOM   1433  N3    C R  68     169.763  34.886 154.998  1.00 45.91           N  
+ANISOU 1433  N3    C R  68     5924   5119   6400   -196   1373   -520       N  
+ATOM   1434  C4    C R  68     170.397  33.713 155.018  1.00 44.09           C  
+ANISOU 1434  C4    C R  68     5640   4928   6185   -271   1410   -498       C  
+ATOM   1435  N4    C R  68     170.711  33.204 156.208  1.00 42.55           N  
+ANISOU 1435  N4    C R  68     5433   4737   5997   -316   1409   -528       N  
+ATOM   1436  C5    C R  68     170.739  33.011 153.821  1.00 44.61           C  
+ANISOU 1436  C5    C R  68     5670   5028   6251   -293   1445   -449       C  
+ATOM   1437  C6    C R  68     170.385  33.592 152.661  1.00 45.22           C  
+ANISOU 1437  C6    C R  68     5768   5099   6314   -243   1443   -420       C  
+ATOM   1438  P     G R  69     173.402  36.737 149.261  1.00 74.88           P  
+ANISOU 1438  P     G R  69     9669   8635  10148   -330   1414    -80       P  
+ATOM   1439  OP1   G R  69     173.965  37.396 148.061  1.00 82.59           O  
+ANISOU 1439  OP1   G R  69    10670   9591  11119   -351   1420     26       O  
+ATOM   1440  OP2   G R  69     174.219  35.805 150.060  1.00 62.59           O  
+ANISOU 1440  OP2   G R  69     8049   7111   8622   -392   1443    -89       O  
+ATOM   1441  O5'   G R  69     172.987  37.909 150.236  1.00 70.85           O  
+ANISOU 1441  O5'   G R  69     9241   8018   9661   -313   1330   -120       O  
+ATOM   1442  C5'   G R  69     173.758  38.144 151.385  1.00 61.59           C  
+ANISOU 1442  C5'   G R  69     8082   6781   8539   -379   1293   -119       C  
+ATOM   1443  C4'   G R  69     173.099  39.116 152.316  1.00 57.89           C  
+ANISOU 1443  C4'   G R  69     7702   6224   8069   -327   1211   -186       C  
+ATOM   1444  O4'   G R  69     172.017  38.456 153.018  1.00 62.99           O  
+ANISOU 1444  O4'   G R  69     8315   6946   8674   -252   1235   -295       O  
+ATOM   1445  C3'   G R  69     174.035  39.576 153.408  1.00 53.46           C  
+ANISOU 1445  C3'   G R  69     7180   5568   7563   -403   1151   -170       C  
+ATOM   1446  O3'   G R  69     174.806  40.675 152.995  1.00 51.33           O  
+ANISOU 1446  O3'   G R  69     6980   5190   7333   -465   1086    -74       O  
+ATOM   1447  C2'   G R  69     173.116  39.842 154.578  1.00 50.93           C  
+ANISOU 1447  C2'   G R  69     6912   5226   7214   -320   1107   -283       C  
+ATOM   1448  O2'   G R  69     172.454  41.080 154.404  1.00 50.13           O  
+ANISOU 1448  O2'   G R  69     6918   5039   7091   -241   1029   -302       O  
+ATOM   1449  C1'   G R  69     172.108  38.715 154.400  1.00 49.38           C  
+ANISOU 1449  C1'   G R  69     6627   5171   6963   -256   1189   -350       C  
+ATOM   1450  N9    G R  69     172.567  37.468 155.037  1.00 43.59           N  
+ANISOU 1450  N9    G R  69     5812   4509   6241   -316   1243   -366       N  
+ATOM   1451  C8    G R  69     172.829  36.278 154.392  1.00 42.47           C  
+ANISOU 1451  C8    G R  69     5582   4459   6096   -353   1315   -338       C  
+ATOM   1452  N7    G R  69     173.219  35.327 155.199  1.00 44.74           N  
+ANISOU 1452  N7    G R  69     5822   4784   6394   -400   1338   -362       N  
+ATOM   1453  C5    G R  69     173.206  35.934 156.450  1.00 41.40           C  
+ANISOU 1453  C5    G R  69     5455   4295   5979   -396   1284   -407       C  
+ATOM   1454  C6    G R  69     173.551  35.414 157.718  1.00 44.75           C  
+ANISOU 1454  C6    G R  69     5872   4718   6413   -434   1275   -446       C  
+ATOM   1455  O6    G R  69     173.926  34.252 157.966  1.00 49.89           O  
+ANISOU 1455  O6    G R  69     6460   5427   7067   -484   1314   -447       O  
+ATOM   1456  N1    G R  69     173.410  36.372 158.729  1.00 41.70           N  
+ANISOU 1456  N1    G R  69     5571   4251   6025   -404   1207   -489       N  
+ATOM   1457  C2    G R  69     172.998  37.681 158.541  1.00 43.02           C  
+ANISOU 1457  C2    G R  69     5825   4338   6183   -339   1146   -495       C  
+ATOM   1458  N2    G R  69     172.918  38.489 159.616  1.00 41.79           N  
+ANISOU 1458  N2    G R  69     5761   4101   6018   -302   1072   -546       N  
+ATOM   1459  N3    G R  69     172.681  38.163 157.349  1.00 43.33           N  
+ANISOU 1459  N3    G R  69     5872   4373   6217   -307   1150   -456       N  
+ATOM   1460  C4    G R  69     172.815  37.251 156.364  1.00 42.48           C  
+ANISOU 1460  C4    G R  69     5678   4350   6111   -340   1223   -412       C  
+ATOM   1461  P     G R  70     176.390  40.544 153.039  1.00 51.33           P  
+ANISOU 1461  P     G R  70     6931   5171   7400   -606   1088     35       P  
+ATOM   1462  OP1   G R  70     176.936  41.671 152.233  1.00 54.60           O  
+ANISOU 1462  OP1   G R  70     7406   5499   7840   -666   1031    152       O  
+ATOM   1463  OP2   G R  70     176.791  39.179 152.637  1.00 53.26           O  
+ANISOU 1463  OP2   G R  70     7048   5550   7636   -627   1196     48       O  
+ATOM   1464  O5'   G R  70     176.676  40.747 154.602  1.00 56.57           O  
+ANISOU 1464  O5'   G R  70     7642   5753   8100   -631   1015    -24       O  
+ATOM   1465  C5'   G R  70     176.225  41.926 155.271  1.00 49.19           C  
+ANISOU 1465  C5'   G R  70     6842   4686   7162   -587    901    -69       C  
+ATOM   1466  C4'   G R  70     176.247  41.794 156.783  1.00 53.24           C  
+ANISOU 1466  C4'   G R  70     7387   5160   7680   -576    856   -155       C  
+ATOM   1467  O4'   G R  70     175.332  40.747 157.224  1.00 51.92           O  
+ANISOU 1467  O4'   G R  70     7154   5115   7457   -491    939   -261       O  
+ATOM   1468  C3'   G R  70     177.572  41.404 157.425  1.00 50.78           C  
+ANISOU 1468  C3'   G R  70     7029   4830   7436   -701    843   -101       C  
+ATOM   1469  O3'   G R  70     178.487  42.474 157.539  1.00 53.12           O  
+ANISOU 1469  O3'   G R  70     7404   4986   7793   -794    730    -16       O  
+ATOM   1470  C2'   G R  70     177.125  40.867 158.768  1.00 46.49           C  
+ANISOU 1470  C2'   G R  70     6495   4305   6862   -646    843   -219       C  
+ATOM   1471  O2'   G R  70     176.735  41.950 159.597  1.00 47.67           O  
+ANISOU 1471  O2'   G R  70     6788   4329   6996   -588    729   -278       O  
+ATOM   1472  C1'   G R  70     175.870  40.095 158.359  1.00 49.06           C  
+ANISOU 1472  C1'   G R  70     6761   4763   7114   -538    941   -293       C  
+ATOM   1473  N9    G R  70     176.187  38.707 157.969  1.00 46.72           N  
+ANISOU 1473  N9    G R  70     6333   4596   6821   -582   1047   -272       N  
+ATOM   1474  C8    G R  70     176.060  38.193 156.708  1.00 45.35           C  
+ANISOU 1474  C8    G R  70     6087   4510   6634   -577   1124   -226       C  
+ATOM   1475  N7    G R  70     176.404  36.940 156.619  1.00 44.62           N  
+ANISOU 1475  N7    G R  70     5898   4514   6542   -609   1197   -223       N  
+ATOM   1476  C5    G R  70     176.792  36.599 157.902  1.00 42.68           C  
+ANISOU 1476  C5    G R  70     5657   4245   6314   -643   1170   -265       C  
+ATOM   1477  C6    G R  70     177.253  35.352 158.428  1.00 42.49           C  
+ANISOU 1477  C6    G R  70     5562   4286   6297   -683   1211   -284       C  
+ATOM   1478  O6    G R  70     177.444  34.275 157.832  1.00 40.85           O  
+ANISOU 1478  O6    G R  70     5274   4168   6079   -693   1278   -267       O  
+ATOM   1479  N1    G R  70     177.521  35.451 159.790  1.00 46.69           N  
+ANISOU 1479  N1    G R  70     6138   4760   6843   -707   1156   -327       N  
+ATOM   1480  C2    G R  70     177.367  36.593 160.546  1.00 43.54           C  
+ANISOU 1480  C2    G R  70     5842   4254   6448   -687   1070   -355       C  
+ATOM   1481  N2    G R  70     177.682  36.499 161.839  1.00 43.05           N  
+ANISOU 1481  N2    G R  70     5817   4148   6393   -709   1023   -398       N  
+ATOM   1482  N3    G R  70     176.936  37.737 160.062  1.00 44.67           N  
+ANISOU 1482  N3    G R  70     6057   4332   6585   -644   1026   -342       N  
+ATOM   1483  C4    G R  70     176.663  37.679 158.749  1.00 42.59           C  
+ANISOU 1483  C4    G R  70     5749   4123   6310   -627   1080   -296       C  
+ATOM   1484  P     G R  71     180.047  42.250 157.249  1.00 51.27           P  
+ANISOU 1484  P     G R  71     7079   4762   7639   -955    737    121       P  
+ATOM   1485  OP1   G R  71     180.648  43.596 157.034  1.00 55.44           O  
+ANISOU 1485  OP1   G R  71     7705   5144   8217  -1043    610    223       O  
+ATOM   1486  OP2   G R  71     180.196  41.268 156.152  1.00 47.31           O  
+ANISOU 1486  OP2   G R  71     6438   4416   7122   -961    872    170       O  
+ATOM   1487  O5'   G R  71     180.656  41.667 158.602  1.00 45.92           O  
+ANISOU 1487  O5'   G R  71     6379   4074   6995   -997    712     72       O  
+ATOM   1488  C5'   G R  71     180.430  42.269 159.860  1.00 47.72           C  
+ANISOU 1488  C5'   G R  71     6731   4181   7220   -966    601     -8       C  
+ATOM   1489  C4'   G R  71     180.842  41.356 160.991  1.00 50.50           C  
+ANISOU 1489  C4'   G R  71     7035   4571   7583   -986    618    -65       C  
+ATOM   1490  O4'   G R  71     179.960  40.205 161.039  1.00 50.78           O  
+ANISOU 1490  O4'   G R  71     6998   4745   7551   -893    737   -156       O  
+ATOM   1491  C3'   G R  71     182.228  40.748 160.876  1.00 49.48           C  
+ANISOU 1491  C3'   G R  71     6786   4487   7529  -1117    641     35       C  
+ATOM   1492  O3'   G R  71     183.259  41.603 161.302  1.00 55.05           O  
+ANISOU 1492  O3'   G R  71     7543   5065   8309  -1231    514    113       O  
+ATOM   1493  C2'   G R  71     182.120  39.490 161.723  1.00 55.61           C  
+ANISOU 1493  C2'   G R  71     7501   5350   8279  -1082    705    -54       C  
+ATOM   1494  O2'   G R  71     182.248  39.811 163.094  1.00 46.45           O  
+ANISOU 1494  O2'   G R  71     6436   4087   7124  -1085    605   -116       O  
+ATOM   1495  C1'   G R  71     180.684  39.063 161.453  1.00 52.37           C  
+ANISOU 1495  C1'   G R  71     7097   5022   7777   -951    790   -150       C  
+ATOM   1496  N9    G R  71     180.608  38.039 160.398  1.00 44.58           N  
+ANISOU 1496  N9    G R  71     5985   4179   6774   -942    915   -121       N  
+ATOM   1497  C8    G R  71     180.118  38.207 159.128  1.00 41.87           C  
+ANISOU 1497  C8    G R  71     5619   3885   6405   -905    970    -83       C  
+ATOM   1498  N7    G R  71     180.149  37.104 158.413  1.00 43.31           N  
+ANISOU 1498  N7    G R  71     5694   4194   6568   -894   1072    -71       N  
+ATOM   1499  C5    G R  71     180.704  36.180 159.268  1.00 41.45           C  
+ANISOU 1499  C5    G R  71     5411   3989   6349   -928   1081   -101       C  
+ATOM   1500  C6    G R  71     180.966  34.804 159.026  1.00 41.85           C  
+ANISOU 1500  C6    G R  71     5361   4153   6386   -926   1162   -109       C  
+ATOM   1501  O6    G R  71     180.765  34.216 157.973  1.00 37.76           O  
+ANISOU 1501  O6    G R  71     4784   3726   5838   -892   1238    -89       O  
+ATOM   1502  N1    G R  71     181.538  34.177 160.129  1.00 37.91           N  
+ANISOU 1502  N1    G R  71     4849   3643   5910   -964   1135   -141       N  
+ATOM   1503  C2    G R  71     181.773  34.815 161.340  1.00 42.52           C  
+ANISOU 1503  C2    G R  71     5511   4123   6523   -997   1044   -167       C  
+ATOM   1504  N2    G R  71     182.318  34.070 162.311  1.00 40.75           N  
+ANISOU 1504  N2    G R  71     5269   3901   6314  -1030   1025   -198       N  
+ATOM   1505  N3    G R  71     181.517  36.091 161.580  1.00 41.84           N  
+ANISOU 1505  N3    G R  71     5522   3929   6445   -994    966   -165       N  
+ATOM   1506  C4    G R  71     180.984  36.715 160.502  1.00 44.08           C  
+ANISOU 1506  C4    G R  71     5819   4219   6710   -959    989   -131       C  
+ATOM   1507  P     C R  72     184.697  41.494 160.611  1.00 52.68           P  
+ANISOU 1507  P     C R  72     7115   4810   8093  -1381    526    273       P  
+ATOM   1508  OP1   C R  72     185.549  42.590 161.117  1.00 61.20           O  
+ANISOU 1508  OP1   C R  72     8275   5733   9247  -1499    365    351       O  
+ATOM   1509  OP2   C R  72     184.433  41.302 159.165  1.00 59.85           O  
+ANISOU 1509  OP2   C R  72     7943   5827   8972  -1359    636    336       O  
+ATOM   1510  O5'   C R  72     185.279  40.124 161.169  1.00 70.38           O  
+ANISOU 1510  O5'   C R  72     9231   7162  10347  -1392    600    240       O  
+ATOM   1511  C5'   C R  72     185.466  39.932 162.560  1.00 66.42           C  
+ANISOU 1511  C5'   C R  72     8784   6595   9858  -1396    527    164       C  
+ATOM   1512  C4'   C R  72     185.989  38.551 162.838  1.00 57.46           C  
+ANISOU 1512  C4'   C R  72     7522   5581   8729  -1402    610    144       C  
+ATOM   1513  O4'   C R  72     184.967  37.554 162.581  1.00 49.83           O  
+ANISOU 1513  O4'   C R  72     6526   4726   7681  -1288    730     52       O  
+ATOM   1514  C3'   C R  72     187.131  38.108 161.958  1.00 53.04           C  
+ANISOU 1514  C3'   C R  72     6803   5126   8225  -1485    668    269       C  
+ATOM   1515  O3'   C R  72     188.362  38.685 162.324  1.00 50.05           O  
+ANISOU 1515  O3'   C R  72     6401   4680   7935  -1615    564    368       O  
+ATOM   1516  C2'   C R  72     187.077  36.601 162.113  1.00 54.30           C  
+ANISOU 1516  C2'   C R  72     6871   5412   8348  -1423    770    200       C  
+ATOM   1517  O2'   C R  72     187.574  36.244 163.390  1.00 49.12           O  
+ANISOU 1517  O2'   C R  72     6235   4707   7720  -1453    701    153       O  
+ATOM   1518  C1'   C R  72     185.569  36.373 162.101  1.00 46.07           C  
+ANISOU 1518  C1'   C R  72     5907   4382   7214  -1301    824     84       C  
+ATOM   1519  N1    C R  72     185.055  36.114 160.738  1.00 43.10           N  
+ANISOU 1519  N1    C R  72     5474   4109   6795  -1248    930    112       N  
+ATOM   1520  C2    C R  72     185.180  34.828 160.202  1.00 42.40           C  
+ANISOU 1520  C2    C R  72     5277   4155   6678  -1210   1033    103       C  
+ATOM   1521  O2    C R  72     185.726  33.936 160.878  1.00 42.24           O  
+ANISOU 1521  O2    C R  72     5212   4165   6672  -1223   1033     74       O  
+ATOM   1522  N3    C R  72     184.707  34.609 158.953  1.00 40.45           N  
+ANISOU 1522  N3    C R  72     4989   3994   6385  -1156   1121    125       N  
+ATOM   1523  C4    C R  72     184.126  35.573 158.240  1.00 42.66           C  
+ANISOU 1523  C4    C R  72     5323   4236   6648  -1142   1114    157       C  
+ATOM   1524  N4    C R  72     183.686  35.269 157.019  1.00 41.56           N  
+ANISOU 1524  N4    C R  72     5143   4186   6460  -1086   1200    177       N  
+ATOM   1525  C5    C R  72     183.989  36.896 158.759  1.00 44.43           C  
+ANISOU 1525  C5    C R  72     5658   4322   6903  -1180   1008    168       C  
+ATOM   1526  C6    C R  72     184.467  37.107 159.996  1.00 50.95           C  
+ANISOU 1526  C6    C R  72     6528   5059   7772  -1230    918    144       C  
+ATOM   1527  P     U R  73     189.495  38.835 161.211  1.00 55.84           P  
+ANISOU 1527  P     U R  73     6985   5504   8729  -1720    600    538       P  
+ATOM   1528  OP1   U R  73     190.694  39.271 161.963  1.00 52.89           O  
+ANISOU 1528  OP1   U R  73     6591   5056   8448  -1852    476    615       O  
+ATOM   1529  OP2   U R  73     188.971  39.560 160.034  1.00 48.25           O  
+ANISOU 1529  OP2   U R  73     6049   4546   7736  -1710    634    600       O  
+ATOM   1530  O5'   U R  73     189.633  37.343 160.628  1.00 65.32           O  
+ANISOU 1530  O5'   U R  73     8034   6897   9889  -1647    755    516       O  
+ATOM   1531  C5'   U R  73     190.768  36.544 160.893  1.00 51.31           C  
+ANISOU 1531  C5'   U R  73     6127   5208   8161  -1690    769    554       C  
+ATOM   1532  C4'   U R  73     190.573  35.096 160.475  1.00 43.86           C  
+ANISOU 1532  C4'   U R  73     5094   4415   7156  -1581    899    490       C  
+ATOM   1533  O4'   U R  73     189.172  34.775 160.257  1.00 47.96           O  
+ANISOU 1533  O4'   U R  73     5703   4933   7588  -1467    960    380       O  
+ATOM   1534  C3'   U R  73     191.225  34.665 159.176  1.00 44.65           C  
+ANISOU 1534  C3'   U R  73     5037   4681   7246  -1573   1007    590       C  
+ATOM   1535  O3'   U R  73     192.631  34.531 159.256  1.00 51.98           O  
+ANISOU 1535  O3'   U R  73     5827   5679   8243  -1653    988    690       O  
+ATOM   1536  C2'   U R  73     190.507  33.365 158.891  1.00 47.20           C  
+ANISOU 1536  C2'   U R  73     5354   5095   7485  -1437   1109    480       C  
+ATOM   1537  O2'   U R  73     190.995  32.344 159.744  1.00 48.87           O  
+ANISOU 1537  O2'   U R  73     5530   5329   7709  -1416   1092    417       O  
+ATOM   1538  C1'   U R  73     189.082  33.718 159.318  1.00 49.43           C  
+ANISOU 1538  C1'   U R  73     5795   5266   7719  -1386   1082    372       C  
+ATOM   1539  N1    U R  73     188.295  34.113 158.136  1.00 52.78           N  
+ANISOU 1539  N1    U R  73     6241   5723   8089  -1338   1148    395       N  
+ATOM   1540  C2    U R  73     187.892  33.045 157.353  1.00 54.83           C  
+ANISOU 1540  C2    U R  73     6453   6102   8279  -1238   1252    353       C  
+ATOM   1541  O2    U R  73     188.093  31.856 157.597  1.00 56.92           O  
+ANISOU 1541  O2    U R  73     6671   6433   8523  -1188   1286    296       O  
+ATOM   1542  N3    U R  73     187.201  33.397 156.243  1.00 53.51           N  
+ANISOU 1542  N3    U R  73     6305   5965   8060  -1194   1308    376       N  
+ATOM   1543  C4    U R  73     186.887  34.648 155.802  1.00 43.50           C  
+ANISOU 1543  C4    U R  73     5097   4629   6803  -1235   1276    438       C  
+ATOM   1544  O4    U R  73     186.248  34.720 154.745  1.00 50.44           O  
+ANISOU 1544  O4    U R  73     5987   5555   7625  -1177   1337    448       O  
+ATOM   1545  C5    U R  73     187.346  35.710 156.648  1.00 45.84           C  
+ANISOU 1545  C5    U R  73     5446   4798   7173  -1339   1162    481       C  
+ATOM   1546  C6    U R  73     188.035  35.408 157.755  1.00 49.84           C  
+ANISOU 1546  C6    U R  73     5934   5271   7732  -1387   1103    459       C  
+ATOM   1547  P     G R  74     193.540  34.761 157.951  1.00 50.99           P  
+ANISOU 1547  P     G R  74     5539   5704   8129  -1699   1062    854       P  
+ATOM   1548  OP1   G R  74     194.914  34.755 158.486  1.00 55.10           O  
+ANISOU 1548  OP1   G R  74     5938   6261   8736  -1797   1002    940       O  
+ATOM   1549  OP2   G R  74     193.097  35.962 157.186  1.00 60.61           O  
+ANISOU 1549  OP2   G R  74     6820   6869   9341  -1754   1051    938       O  
+ATOM   1550  O5'   G R  74     193.322  33.414 157.120  1.00 62.10           O  
+ANISOU 1550  O5'   G R  74     6869   7279   9448  -1550   1205    795       O  
+ATOM   1551  C5'   G R  74     193.582  32.165 157.745  1.00 48.58           C  
+ANISOU 1551  C5'   G R  74     5121   5613   7724  -1475   1216    701       C  
+ATOM   1552  C4'   G R  74     193.302  30.995 156.845  1.00 55.22           C  
+ANISOU 1552  C4'   G R  74     5915   6593   8474  -1331   1335    649       C  
+ATOM   1553  O4'   G R  74     191.877  30.813 156.663  1.00 50.44           O  
+ANISOU 1553  O4'   G R  74     5444   5926   7796  -1252   1362    543       O  
+ATOM   1554  C3'   G R  74     193.841  31.084 155.429  1.00 60.04           C  
+ANISOU 1554  C3'   G R  74     6397   7367   9049  -1308   1437    767       C  
+ATOM   1555  O3'   G R  74     195.229  30.822 155.363  1.00 65.08           O  
+ANISOU 1555  O3'   G R  74     6865   8134   9727  -1335   1450    859       O  
+ATOM   1556  C2'   G R  74     192.978  30.063 154.697  1.00 51.53           C  
+ANISOU 1556  C2'   G R  74     5364   6353   7863  -1151   1525    666       C  
+ATOM   1557  O2'   G R  74     193.389  28.748 155.024  1.00 64.97           O  
+ANISOU 1557  O2'   G R  74     7020   8122   9541  -1058   1538    589       O  
+ATOM   1558  C1'   G R  74     191.624  30.299 155.364  1.00 58.80           C  
+ANISOU 1558  C1'   G R  74     6459   7109   8772  -1151   1470    553       C  
+ATOM   1559  N9    G R  74     190.820  31.278 154.608  1.00 60.13           N  
+ANISOU 1559  N9    G R  74     6695   7237   8915  -1170   1489    594       N  
+ATOM   1560  C8    G R  74     190.760  32.636 154.847  1.00 51.37           C  
+ANISOU 1560  C8    G R  74     5638   6019   7862  -1283   1420    663       C  
+ATOM   1561  N7    G R  74     189.964  33.266 154.031  1.00 52.04           N  
+ANISOU 1561  N7    G R  74     5785   6083   7903  -1266   1448    683       N  
+ATOM   1562  C5    G R  74     189.476  32.262 153.185  1.00 51.27           C  
+ANISOU 1562  C5    G R  74     5671   6092   7716  -1137   1544    626       C  
+ATOM   1563  C6    G R  74     188.571  32.352 152.081  1.00 50.03           C  
+ANISOU 1563  C6    G R  74     5563   5965   7481  -1064   1606    618       C  
+ATOM   1564  O6    G R  74     188.001  33.369 151.622  1.00 60.73           O  
+ANISOU 1564  O6    G R  74     6985   7259   8830  -1096   1591    661       O  
+ATOM   1565  N1    G R  74     188.344  31.115 151.509  1.00 40.84           N  
+ANISOU 1565  N1    G R  74     4373   4904   6239   -939   1680    550       N  
+ATOM   1566  C2    G R  74     188.908  29.939 151.933  1.00 48.60           C  
+ANISOU 1566  C2    G R  74     5298   5950   7218   -887   1691    496       C  
+ATOM   1567  N2    G R  74     188.551  28.846 151.236  1.00 66.32           N  
+ANISOU 1567  N2    G R  74     7546   8277   9377   -761   1750    431       N  
+ATOM   1568  N3    G R  74     189.753  29.836 152.952  1.00 54.87           N  
+ANISOU 1568  N3    G R  74     6044   6720   8083   -951   1637    503       N  
+ATOM   1569  C4    G R  74     189.998  31.030 153.529  1.00 54.38           C  
+ANISOU 1569  C4    G R  74     5999   6563   8101  -1077   1567    570       C  
+ATOM   1570  P     C R  75     196.077  31.226 154.059  1.00 65.64           P  
+ANISOU 1570  P     C R  75     6773   8388   9781  -1355   1541   1026       P  
+ATOM   1571  OP1   C R  75     197.499  30.969 154.385  1.00 72.73           O  
+ANISOU 1571  OP1   C R  75     7496   9400  10738  -1397   1527   1107       O  
+ATOM   1572  OP2   C R  75     195.661  32.556 153.535  1.00 60.19           O  
+ANISOU 1572  OP2   C R  75     6139   7629   9103  -1460   1527   1125       O  
+ATOM   1573  O5'   C R  75     195.627  30.146 152.989  1.00 60.23           O  
+ANISOU 1573  O5'   C R  75     6078   7835   8971  -1171   1665    958       O  
+ATOM   1574  C5'   C R  75     195.978  28.785 153.138  1.00 55.55           C  
+ANISOU 1574  C5'   C R  75     5438   7331   8338  -1039   1693    868       C  
+ATOM   1575  C4'   C R  75     195.793  28.063 151.833  1.00 56.34           C  
+ANISOU 1575  C4'   C R  75     5505   7581   8318   -882   1811    855       C  
+ATOM   1576  O4'   C R  75     194.385  27.939 151.532  1.00 55.51           O  
+ANISOU 1576  O4'   C R  75     5566   7377   8149   -823   1819    754       O  
+ATOM   1577  C3'   C R  75     196.355  28.753 150.606  1.00 59.76           C  
+ANISOU 1577  C3'   C R  75     5816   8171   8720   -906   1902   1015       C  
+ATOM   1578  O3'   C R  75     197.755  28.612 150.487  1.00 64.35           O  
+ANISOU 1578  O3'   C R  75     6198   8926   9324   -914   1936   1121       O  
+ATOM   1579  C2'   C R  75     195.572  28.084 149.481  1.00 65.07           C  
+ANISOU 1579  C2'   C R  75     6554   8910   9262   -743   1992    947       C  
+ATOM   1580  O2'   C R  75     196.095  26.789 149.231  1.00 67.14           O  
+ANISOU 1580  O2'   C R  75     6749   9306   9454   -578   2038    882       O  
+ATOM   1581  C1'   C R  75     194.204  27.907 150.130  1.00 61.28           C  
+ANISOU 1581  C1'   C R  75     6270   8231   8784   -736   1921    800       C  
+ATOM   1582  N1    C R  75     193.224  28.944 149.735  1.00 65.19           N  
+ANISOU 1582  N1    C R  75     6870   8625   9274   -805   1916    829       N  
+ATOM   1583  C2    C R  75     192.669  28.942 148.445  1.00 64.92           C  
+ANISOU 1583  C2    C R  75     6864   8663   9141   -719   1998    845       C  
+ATOM   1584  O2    C R  75     193.028  28.087 147.620  1.00 73.39           O  
+ANISOU 1584  O2    C R  75     7874   9886  10125   -584   2077    837       O  
+ATOM   1585  N3    C R  75     191.753  29.885 148.114  1.00 58.52           N  
+ANISOU 1585  N3    C R  75     6154   7754   8328   -777   1984    867       N  
+ATOM   1586  C4    C R  75     191.366  30.793 149.012  1.00 53.22           C  
+ANISOU 1586  C4    C R  75     5559   6920   7743   -903   1892    866       C  
+ATOM   1587  N4    C R  75     190.458  31.718 148.661  1.00 49.29           N  
+ANISOU 1587  N4    C R  75     5166   6327   7237   -943   1873    882       N  
+ATOM   1588  C5    C R  75     191.917  30.813 150.319  1.00 54.75           C  
+ANISOU 1588  C5    C R  75     5732   7039   8032   -987   1808    848       C  
+ATOM   1589  C6    C R  75     192.822  29.884 150.636  1.00 63.71           C  
+ANISOU 1589  C6    C R  75     6764   8270   9173   -939   1824    832       C  
+ATOM   1590  P     C R  76     198.608  29.729 149.713  1.00 67.24           P  
+ANISOU 1590  P     C R  76     6408   9426   9713  -1037   1987   1337       P  
+ATOM   1591  OP1   C R  76     200.042  29.355 149.829  1.00 66.96           O  
+ANISOU 1591  OP1   C R  76     6159   9576   9707  -1030   2011   1421       O  
+ATOM   1592  OP2   C R  76     198.138  31.063 150.151  1.00 79.57           O  
+ANISOU 1592  OP2   C R  76     8068  10806  11360  -1224   1898   1398       O  
+ATOM   1593  O5'   C R  76     198.146  29.580 148.195  1.00 85.45           O  
+ANISOU 1593  O5'   C R  76     8722  11861  11883   -913   2116   1360       O  
+ATOM   1594  C5'   C R  76     198.396  28.384 147.467  1.00 80.18           C  
+ANISOU 1594  C5'   C R  76     7995  11368  11100   -707   2212   1299       C  
+ATOM   1595  C4'   C R  76     197.926  28.511 146.035  1.00 68.05           C  
+ANISOU 1595  C4'   C R  76     6482   9934   9441   -620   2320   1341       C  
+ATOM   1596  O4'   C R  76     196.478  28.546 145.998  1.00 59.88           O  
+ANISOU 1596  O4'   C R  76     5659   8715   8377   -597   2283   1224       O  
+ATOM   1597  C3'   C R  76     198.345  29.776 145.321  1.00 61.71           C  
+ANISOU 1597  C3'   C R  76     5586   9213   8651   -763   2366   1545       C  
+ATOM   1598  O3'   C R  76     199.667  29.699 144.828  1.00 64.95           O  
+ANISOU 1598  O3'   C R  76     5768   9873   9036   -750   2451   1685       O  
+ATOM   1599  C2'   C R  76     197.285  29.906 144.233  1.00 64.85           C  
+ANISOU 1599  C2'   C R  76     6113   9589   8938   -684   2425   1518       C  
+ATOM   1600  O2'   C R  76     197.574  29.014 143.171  1.00 70.31           O  
+ANISOU 1600  O2'   C R  76     6738  10488   9488   -487   2543   1503       O  
+ATOM   1601  C1'   C R  76     196.047  29.382 144.948  1.00 60.13           C  
+ANISOU 1601  C1'   C R  76     5719   8772   8354   -631   2340   1320       C  
+ATOM   1602  N1    C R  76     195.171  30.436 145.516  1.00 57.09           N  
+ANISOU 1602  N1    C R  76     5474   8166   8053   -784   2245   1318       N  
+ATOM   1603  C2    C R  76     194.201  31.038 144.704  1.00 61.33           C  
+ANISOU 1603  C2    C R  76     6125   8644   8532   -784   2265   1331       C  
+ATOM   1604  O2    C R  76     194.125  30.712 143.514  1.00 52.67           O  
+ANISOU 1604  O2    C R  76     5011   7682   7319   -667   2362   1353       O  
+ATOM   1605  N3    C R  76     193.365  31.970 145.232  1.00 65.08           N  
+ANISOU 1605  N3    C R  76     6734   8917   9076   -901   2173   1317       N  
+ATOM   1606  C4    C R  76     193.469  32.291 146.527  1.00 63.11           C  
+ANISOU 1606  C4    C R  76     6510   8527   8942  -1012   2066   1288       C  
+ATOM   1607  N4    C R  76     192.634  33.203 147.004  1.00 57.69           N  
+ANISOU 1607  N4    C R  76     5960   7650   8308  -1106   1977   1268       N  
+ATOM   1608  C5    C R  76     194.432  31.683 147.389  1.00 57.70           C  
+ANISOU 1608  C5    C R  76     5717   7891   8317  -1022   2042   1273       C  
+ATOM   1609  C6    C R  76     195.248  30.769 146.842  1.00 58.15           C  
+ANISOU 1609  C6    C R  76     5637   8147   8309   -907   2132   1289       C  
+ATOM   1610  P     G R  77     200.589  31.013 144.740  1.00 82.36           P  
+ANISOU 1610  P     G R  77     7879  12115  11299   -963   2397   1864       P  
+ATOM   1611  OP1   G R  77     202.001  30.596 144.598  1.00 82.74           O  
+ANISOU 1611  OP1   G R  77     7735  12380  11323   -918   2425   1914       O  
+ATOM   1612  OP2   G R  77     200.169  31.927 145.836  1.00 86.61           O  
+ANISOU 1612  OP2   G R  77     8507  12415  11985  -1165   2271   1885       O  
+ATOM   1613  O5'   G R  77     200.149  31.696 143.378  1.00 73.54           O  
+ANISOU 1613  O5'   G R  77     6823  11047  10073   -964   2461   1941       O  
+ATOM   1614  C5'   G R  77     199.929  30.925 142.205  1.00 74.48           C  
+ANISOU 1614  C5'   G R  77     6949  11317  10033   -758   2577   1890       C  
+ATOM   1615  C4'   G R  77     199.127  31.707 141.199  1.00 73.81           C  
+ANISOU 1615  C4'   G R  77     6977  11191   9878   -791   2609   1948       C  
+ATOM   1616  O4'   G R  77     197.811  31.990 141.755  1.00 74.32           O  
+ANISOU 1616  O4'   G R  77     7209  11022  10008   -839   2558   1881       O  
+ATOM   1617  C3'   G R  77     199.729  33.060 140.815  1.00 71.69           C  
+ANISOU 1617  C3'   G R  77     6659  10941   9638   -988   2574   2128       C  
+ATOM   1618  O3'   G R  77     199.439  33.344 139.446  1.00 74.39           O  
+ANISOU 1618  O3'   G R  77     7040  11374   9851   -932   2654   2185       O  
+ATOM   1619  C2'   G R  77     198.960  34.029 141.708  1.00 69.18           C  
+ANISOU 1619  C2'   G R  77     6470  10365   9452  -1172   2459   2143       C  
+ATOM   1620  O2'   G R  77     198.896  35.358 141.236  1.00 73.04           O  
+ANISOU 1620  O2'   G R  77     7007  10793   9953  -1337   2417   2281       O  
+ATOM   1621  C1'   G R  77     197.581  33.387 141.736  1.00 65.53           C  
+ANISOU 1621  C1'   G R  77     6156   9786   8957  -1037   2491   2000       C  
+ATOM   1622  N9    G R  77     196.782  33.788 142.903  1.00 61.12           N  
+ANISOU 1622  N9    G R  77     5713   8978   8532  -1144   2392   1948       N  
+ATOM   1623  C8    G R  77     197.150  33.752 144.237  1.00 56.74           C  
+ANISOU 1623  C8    G R  77     5141   8316   8103  -1231   2288   1904       C  
+ATOM   1624  N7    G R  77     196.229  34.217 145.051  1.00 53.68           N  
+ANISOU 1624  N7    G R  77     4929   7682   7786  -1297   2171   1810       N  
+ATOM   1625  C5    G R  77     195.210  34.606 144.194  1.00 55.57           C  
+ANISOU 1625  C5    G R  77     5299   7866   7948  -1256   2198   1797       C  
+ATOM   1626  C6    G R  77     193.963  35.193 144.479  1.00 62.10           C  
+ANISOU 1626  C6    G R  77     6326   8474   8796  -1283   2113   1713       C  
+ATOM   1627  O6    G R  77     193.501  35.483 145.585  1.00 74.86           O  
+ANISOU 1627  O6    G R  77     8046   9898  10498  -1345   1998   1628       O  
+ATOM   1628  N1    G R  77     193.219  35.422 143.323  1.00 54.36           N  
+ANISOU 1628  N1    G R  77     5424   7516   7715  -1216   2173   1728       N  
+ATOM   1629  C2    G R  77     193.632  35.140 142.041  1.00 52.39           C  
+ANISOU 1629  C2    G R  77     5079   7474   7353  -1136   2300   1818       C  
+ATOM   1630  N2    G R  77     192.767  35.433 141.058  1.00 52.29           N  
+ANISOU 1630  N2    G R  77     5175   7443   7252  -1079   2334   1817       N  
+ATOM   1631  N3    G R  77     194.801  34.594 141.756  1.00 58.63           N  
+ANISOU 1631  N3    G R  77     5683   8481   8115  -1104   2388   1898       N  
+ATOM   1632  C4    G R  77     195.531  34.357 142.871  1.00 61.71           C  
+ANISOU 1632  C4    G R  77     5987   8853   8607  -1167   2330   1882       C  
+ATOM   1633  P     A R  78     200.461  32.906 138.283  1.00 96.13           P  
+ANISOU 1633  P     A R  78     9653  14404  12468   -808   2760   2243       P  
+ATOM   1634  OP1   A R  78     200.888  31.507 138.564  1.00 89.98           O  
+ANISOU 1634  OP1   A R  78     8798  13739  11651   -611   2801   2115       O  
+ATOM   1635  OP2   A R  78     201.520  33.933 138.154  1.00 65.16           O  
+ANISOU 1635  OP2   A R  78     5612  10553   8591   -990   2731   2422       O  
+ATOM   1636  O5'   A R  78     199.545  32.902 136.981  1.00 66.74           O  
+ANISOU 1636  O5'   A R  78     6052  10706   8601   -694   2838   2229       O  
+ATOM   1637  C5'   A R  78     198.832  34.062 136.580  1.00 68.57           C  
+ANISOU 1637  C5'   A R  78     6395  10814   8842   -832   2809   2321       C  
+ATOM   1638  C4'   A R  78     197.914  33.778 135.416  1.00 67.05           C  
+ANISOU 1638  C4'   A R  78     6320  10652   8505   -681   2887   2276       C  
+ATOM   1639  O4'   A R  78     196.820  32.925 135.852  1.00 70.81           O  
+ANISOU 1639  O4'   A R  78     6917  11007   8980   -546   2882   2104       O  
+ATOM   1640  C3'   A R  78     197.229  34.994 134.811  1.00 65.25           C  
+ANISOU 1640  C3'   A R  78     6203  10321   8267   -810   2866   2387       C  
+ATOM   1641  O3'   A R  78     198.059  35.663 133.879  1.00 73.69           O  
+ANISOU 1641  O3'   A R  78     7188  11539   9271   -880   2905   2545       O  
+ATOM   1642  C2'   A R  78     195.975  34.401 134.182  1.00 69.80           C  
+ANISOU 1642  C2'   A R  78     6929  10853   8738   -634   2917   2271       C  
+ATOM   1643  O2'   A R  78     196.291  33.809 132.932  1.00 80.01           O  
+ANISOU 1643  O2'   A R  78     8189  12347   9865   -463   3016   2267       O  
+ATOM   1644  C1'   A R  78     195.629  33.284 135.176  1.00 69.24           C  
+ANISOU 1644  C1'   A R  78     6874  10712   8720   -519   2897   2096       C  
+ATOM   1645  N9    A R  78     194.617  33.683 136.183  1.00 63.98           N  
+ANISOU 1645  N9    A R  78     6325   9801   8181   -616   2817   2047       N  
+ATOM   1646  C8    A R  78     194.857  33.865 137.522  1.00 67.93           C  
+ANISOU 1646  C8    A R  78     6792  10182   8836   -741   2732   2034       C  
+ATOM   1647  N7    A R  78     193.801  34.202 138.217  1.00 71.94           N  
+ANISOU 1647  N7    A R  78     7446  10461   9429   -796   2650   1959       N  
+ATOM   1648  C5    A R  78     192.771  34.251 137.288  1.00 71.07           C  
+ANISOU 1648  C5    A R  78     7477  10311   9217   -702   2674   1912       C  
+ATOM   1649  C6    A R  78     191.387  34.551 137.406  1.00 70.77           C  
+ANISOU 1649  C6    A R  78     7638  10059   9192   -693   2589   1798       C  
+ATOM   1650  N6    A R  78     190.758  34.874 138.555  1.00 55.83           N  
+ANISOU 1650  N6    A R  78     5844   7950   7418   -775   2466   1705       N  
+ATOM   1651  N1    A R  78     190.645  34.508 136.272  1.00 68.85           N  
+ANISOU 1651  N1    A R  78     7490   9843   8828   -587   2636   1783       N  
+ATOM   1652  C2    A R  78     191.253  34.183 135.128  1.00 70.34           C  
+ANISOU 1652  C2    A R  78     7589  10252   8887   -494   2760   1871       C  
+ATOM   1653  N3    A R  78     192.531  33.880 134.900  1.00 77.51           N  
+ANISOU 1653  N3    A R  78     8310  11381   9761   -483   2855   1980       N  
+ATOM   1654  C4    A R  78     193.258  33.929 136.030  1.00 69.07           C  
+ANISOU 1654  C4    A R  78     7138  10285   8819   -594   2806   1997       C  
+ATOM   1655  P     A R  79     198.006  37.262 133.700  1.00 86.97           P  
+ANISOU 1655  P     A R  79     8922  13113  11011  -1121   2836   2723       P  
+ATOM   1656  OP1   A R  79     198.942  37.629 132.609  1.00 88.20           O  
+ANISOU 1656  OP1   A R  79     8971  13471  11071  -1142   2904   2869       O  
+ATOM   1657  OP2   A R  79     198.174  37.906 135.031  1.00 91.00           O  
+ANISOU 1657  OP2   A R  79     9431  13446  11697  -1313   2709   2746       O  
+ATOM   1658  O5'   A R  79     196.520  37.538 133.211  1.00 78.89           O  
+ANISOU 1658  O5'   A R  79     8097  11940   9937  -1078   2836   2682       O  
+ATOM   1659  C5'   A R  79     196.123  37.307 131.870  1.00 75.71           C  
+ANISOU 1659  C5'   A R  79     7747  11650   9371   -939   2930   2688       C  
+ATOM   1660  C4'   A R  79     194.683  37.697 131.690  1.00 70.19           C  
+ANISOU 1660  C4'   A R  79     7239  10768   8661   -931   2903   2654       C  
+ATOM   1661  O4'   A R  79     193.861  36.810 132.484  1.00 69.59           O  
+ANISOU 1661  O4'   A R  79     7229  10583   8631   -811   2890   2477       O  
+ATOM   1662  C3'   A R  79     194.329  39.087 132.200  1.00 74.27           C  
+ANISOU 1662  C3'   A R  79     7844  11075   9298  -1162   2788   2766       C  
+ATOM   1663  O3'   A R  79     194.594  40.104 131.262  1.00 89.38           O  
+ANISOU 1663  O3'   A R  79     9776  13030  11154  -1273   2788   2934       O  
+ATOM   1664  C2'   A R  79     192.858  38.965 132.544  1.00 79.84           C  
+ANISOU 1664  C2'   A R  79     8717  11585  10032  -1094   2760   2657       C  
+ATOM   1665  O2'   A R  79     192.073  39.076 131.371  1.00 91.15           O  
+ANISOU 1665  O2'   A R  79    10260  13038  11334   -999   2818   2676       O  
+ATOM   1666  C1'   A R  79     192.791  37.530 133.063  1.00 71.88           C  
+ANISOU 1666  C1'   A R  79     7661  10634   9017   -910   2810   2475       C  
+ATOM   1667  N9    A R  79     192.939  37.488 134.525  1.00 70.68           N  
+ANISOU 1667  N9    A R  79     7477  10351   9026  -1002   2726   2419       N  
+ATOM   1668  C8    A R  79     194.054  37.217 135.281  1.00 70.89           C  
+ANISOU 1668  C8    A R  79     7360  10449   9125  -1059   2699   2422       C  
+ATOM   1669  N7    A R  79     193.832  37.270 136.575  1.00 74.09           N  
+ANISOU 1669  N7    A R  79     7789  10690   9673  -1136   2613   2362       N  
+ATOM   1670  C5    A R  79     192.481  37.600 136.665  1.00 75.56           C  
+ANISOU 1670  C5    A R  79     8168  10668   9874  -1118   2552   2274       C  
+ATOM   1671  C6    A R  79     191.608  37.815 137.754  1.00 75.12           C  
+ANISOU 1671  C6    A R  79     8256  10363   9925  -1153   2417   2133       C  
+ATOM   1672  N6    A R  79     191.975  37.719 139.038  1.00 65.42           N  
+ANISOU 1672  N6    A R  79     6989   9049   8817  -1227   2339   2082       N  
+ATOM   1673  N1    A R  79     190.318  38.130 137.477  1.00 77.26           N  
+ANISOU 1673  N1    A R  79     8711  10480  10165  -1102   2365   2042       N  
+ATOM   1674  C2    A R  79     189.934  38.226 136.198  1.00 73.80           C  
+ANISOU 1674  C2    A R  79     8318  10119   9603  -1026   2435   2089       C  
+ATOM   1675  N3    A R  79     190.655  38.054 135.092  1.00 75.77           N  
+ANISOU 1675  N3    A R  79     8458  10589   9741   -988   2559   2219       N  
+ATOM   1676  C4    A R  79     191.927  37.740 135.406  1.00 73.66           C  
+ANISOU 1676  C4    A R  79     8002  10482   9505  -1036   2616   2306       C  
+ATOM   1677  P     A R  80     194.982  41.576 131.770  1.00 93.00           P  
+ANISOU 1677  P     A R  80    10257  13341  11739  -1547   2657   3093       P  
+ATOM   1678  OP1   A R  80     195.257  42.393 130.547  1.00 94.83           O  
+ANISOU 1678  OP1   A R  80    10503  13657  11872  -1616   2686   3256       O  
+ATOM   1679  OP2   A R  80     196.028  41.439 132.826  1.00 85.06           O  
+ANISOU 1679  OP2   A R  80     9110  12357  10851  -1636   2606   3088       O  
+ATOM   1680  O5'   A R  80     193.637  42.103 132.437  1.00 78.55           O  
+ANISOU 1680  O5'   A R  80     8618  11229   9999  -1594   2554   3040       O  
+ATOM   1681  C5'   A R  80     192.497  42.365 131.639  1.00 81.73           C  
+ANISOU 1681  C5'   A R  80     9176  11559  10319  -1527   2576   3046       C  
+ATOM   1682  C4'   A R  80     191.301  42.710 132.486  1.00 79.29           C  
+ANISOU 1682  C4'   A R  80     9026  10984  10118  -1551   2478   2974       C  
+ATOM   1683  O4'   A R  80     190.949  41.580 133.322  1.00 84.85           O  
+ANISOU 1683  O4'   A R  80     9721  11658  10861  -1401   2481   2746       O  
+ATOM   1684  C3'   A R  80     191.478  43.856 133.469  1.00 79.02           C  
+ANISOU 1684  C3'   A R  80     9045  10741  10239  -1774   2312   3052       C  
+ATOM   1685  O3'   A R  80     191.353  45.129 132.856  1.00 87.87           O  
+ANISOU 1685  O3'   A R  80    10277  11767  11342  -1914   2231   3203       O  
+ATOM   1686  C2'   A R  80     190.400  43.563 134.501  1.00 85.49           C  
+ANISOU 1686  C2'   A R  80    10010  11333  11138  -1681   2204   2806       C  
+ATOM   1687  O2'   A R  80     189.122  43.943 134.011  1.00 88.35           O  
+ANISOU 1687  O2'   A R  80    10572  11548  11447  -1599   2149   2721       O  
+ATOM   1688  C1'   A R  80     190.468  42.039 134.570  1.00 82.84           C  
+ANISOU 1688  C1'   A R  80     9569  11158  10750  -1484   2326   2649       C  
+ATOM   1689  N9    A R  80     191.419  41.600 135.605  1.00 80.10           N  
+ANISOU 1689  N9    A R  80     9070  10862  10502  -1546   2322   2645       N  
+ATOM   1690  C8    A R  80     192.678  41.088 135.393  1.00 80.04           C  
+ANISOU 1690  C8    A R  80     8856  11090  10464  -1555   2424   2740       C  
+ATOM   1691  N7    A R  80     193.314  40.794 136.498  1.00 76.02           N  
+ANISOU 1691  N7    A R  80     8261  10564  10061  -1607   2372   2690       N  
+ATOM   1692  C5    A R  80     192.415  41.142 137.500  1.00 75.00           C  
+ANISOU 1692  C5    A R  80     8280  10178  10038  -1643   2247   2584       C  
+ATOM   1693  C6    A R  80     192.494  41.068 138.906  1.00 78.76           C  
+ANISOU 1693  C6    A R  80     8765  10513  10645  -1698   2141   2487       C  
+ATOM   1694  N6    A R  80     193.578  40.596 139.542  1.00 81.06           N  
+ANISOU 1694  N6    A R  80     8887  10915  10998  -1744   2163   2523       N  
+ATOM   1695  N1    A R  80     191.419  41.492 139.625  1.00 70.70           N  
+ANISOU 1695  N1    A R  80     7935   9244   9683  -1695   2013   2353       N  
+ATOM   1696  C2    A R  80     190.350  41.959 138.959  1.00 73.64           C  
+ANISOU 1696  C2    A R  80     8468   9519   9993  -1640   1991   2319       C  
+ATOM   1697  N3    A R  80     190.163  42.084 137.641  1.00 75.05           N  
+ANISOU 1697  N3    A R  80     8658   9801  10055  -1591   2074   2402       N  
+ATOM   1698  C4    A R  80     191.241  41.645 136.965  1.00 73.19           C  
+ANISOU 1698  C4    A R  80     8240   9811   9759  -1596   2204   2533       C  
+ATOM   1699  P     U R  81     192.104  46.415 133.460  1.00100.06           P  
+ANISOU 1699  P     U R  81    11843  13175  13002  -2163   2064   3327       P  
+ATOM   1700  OP1   U R  81     191.619  47.579 132.675  1.00 97.14           O  
+ANISOU 1700  OP1   U R  81    11633  12688  12588  -2255   1990   3455       O  
+ATOM   1701  OP2   U R  81     193.563  46.144 133.553  1.00 96.67           O  
+ANISOU 1701  OP2   U R  81    11214  12936  12579  -2220   2106   3375       O  
+ATOM   1702  O5'   U R  81     191.477  46.588 134.916  1.00 83.77           O  
+ANISOU 1702  O5'   U R  81     9878  10856  11096  -2206   1925   3221       O  
+ATOM   1703  C5'   U R  81     190.113  46.962 135.064  1.00 78.73           C  
+ANISOU 1703  C5'   U R  81     9465   9986  10461  -2124   1822   3079       C  
+ATOM   1704  C4'   U R  81     189.715  47.106 136.509  1.00 73.32           C  
+ANISOU 1704  C4'   U R  81     8871   9079   9908  -2139   1675   2925       C  
+ATOM   1705  O4'   U R  81     189.734  45.813 137.173  1.00 87.37           O  
+ANISOU 1705  O4'   U R  81    10546  10950  11703  -1998   1758   2748       O  
+ATOM   1706  C3'   U R  81     190.625  47.963 137.368  1.00 77.44           C  
+ANISOU 1706  C3'   U R  81     9363   9502  10559  -2368   1543   3062       C  
+ATOM   1707  O3'   U R  81     190.447  49.353 137.187  1.00 85.28           O  
+ANISOU 1707  O3'   U R  81    10517  10308  11579  -2521   1389   3191       O  
+ATOM   1708  C2'   U R  81     190.302  47.469 138.769  1.00 85.19           C  
+ANISOU 1708  C2'   U R  81    10374  10359  11636  -2300   1473   2855       C  
+ATOM   1709  O2'   U R  81     189.054  47.974 139.213  1.00 86.15           O  
+ANISOU 1709  O2'   U R  81    10719  10239  11776  -2226   1344   2701       O  
+ATOM   1710  C1'   U R  81     190.159  45.972 138.514  1.00 86.25           C  
+ANISOU 1710  C1'   U R  81    10384  10692  11693  -2097   1650   2713       C  
+ATOM   1711  N1    U R  81     191.473  45.318 138.674  1.00 83.89           N  
+ANISOU 1711  N1    U R  81     9853  10603  11418  -2154   1747   2805       N  
+ATOM   1712  C2    U R  81     191.873  45.107 139.974  1.00 81.79           C  
+ANISOU 1712  C2    U R  81     9545  10264  11266  -2203   1672   2734       C  
+ATOM   1713  O2    U R  81     191.178  45.399 140.932  1.00 85.70           O  
+ANISOU 1713  O2    U R  81    10186  10543  11831  -2192   1544   2599       O  
+ATOM   1714  N3    U R  81     193.107  44.527 140.105  1.00 75.53           N  
+ANISOU 1714  N3    U R  81     8538   9667  10491  -2247   1750   2811       N  
+ATOM   1715  C4    U R  81     193.959  44.166 139.080  1.00 80.59           C  
+ANISOU 1715  C4    U R  81     9033  10561  11025  -2213   1874   2891       C  
+ATOM   1716  O4    U R  81     195.033  43.649 139.367  1.00 87.77           O  
+ANISOU 1716  O4    U R  81     9783  11618  11949  -2218   1908   2891       O  
+ATOM   1717  C5    U R  81     193.486  44.442 137.756  1.00 70.57           C  
+ANISOU 1717  C5    U R  81     7820   9356   9638  -2167   1949   2968       C  
+ATOM   1718  C6    U R  81     192.286  45.005 137.604  1.00 74.34           C  
+ANISOU 1718  C6    U R  81     8479   9649  10119  -2161   1895   2961       C  
+ATOM   1719  P     A R  82     191.698  50.322 137.435  1.00 99.35           P  
+ANISOU 1719  P     A R  82    12254  12069  13426  -2742   1276   3347       P  
+ATOM   1720  OP1   A R  82     191.334  51.729 137.097  1.00 98.63           O  
+ANISOU 1720  OP1   A R  82    12366  11773  13337  -2855   1113   3445       O  
+ATOM   1721  OP2   A R  82     192.861  49.691 136.750  1.00 99.22           O  
+ANISOU 1721  OP2   A R  82    12009  12352  13337  -2734   1435   3422       O  
+ATOM   1722  O5'   A R  82     191.933  50.212 139.007  1.00 88.19           O  
+ANISOU 1722  O5'   A R  82    10838  10521  12149  -2781   1161   3234       O  
+ATOM   1723  C5'   A R  82     190.972  50.713 139.923  1.00 83.27           C  
+ANISOU 1723  C5'   A R  82    10416   9616  11607  -2779    998   3135       C  
+ATOM   1724  C4'   A R  82     191.430  50.513 141.343  1.00 84.06           C  
+ANISOU 1724  C4'   A R  82    10481   9638  11820  -2814    912   3037       C  
+ATOM   1725  O4'   A R  82     191.562  49.091 141.606  1.00 85.74           O  
+ANISOU 1725  O4'   A R  82    10517  10033  12026  -2692   1075   2939       O  
+ATOM   1726  C3'   A R  82     192.803  51.078 141.685  1.00 87.29           C  
+ANISOU 1726  C3'   A R  82    10801  10085  12280  -2968    831   3132       C  
+ATOM   1727  O3'   A R  82     192.789  52.477 141.951  1.00 89.03           O  
+ANISOU 1727  O3'   A R  82    11202  10078  12548  -3093    621   3190       O  
+ATOM   1728  C2'   A R  82     193.226  50.215 142.869  1.00 86.11           C  
+ANISOU 1728  C2'   A R  82    10541   9971  12207  -2933    846   3013       C  
+ATOM   1729  O2'   A R  82     192.569  50.625 144.054  1.00 87.75           O  
+ANISOU 1729  O2'   A R  82    10925   9918  12499  -2933    679   2895       O  
+ATOM   1730  C1'   A R  82     192.664  48.854 142.458  1.00 84.47           C  
+ANISOU 1730  C1'   A R  82    10228   9931  11934  -2760   1047   2927       C  
+ATOM   1731  N9    A R  82     193.674  48.078 141.718  1.00 82.52           N  
+ANISOU 1731  N9    A R  82     9753   9984  11618  -2733   1217   2995       N  
+ATOM   1732  C8    A R  82     193.826  48.015 140.355  1.00 83.29           C  
+ANISOU 1732  C8    A R  82     9784  10262  11602  -2703   1344   3099       C  
+ATOM   1733  N7    A R  82     194.838  47.276 139.972  1.00 85.67           N  
+ANISOU 1733  N7    A R  82     9878  10818  11856  -2672   1474   3133       N  
+ATOM   1734  C5    A R  82     195.392  46.828 141.171  1.00 85.28           C  
+ANISOU 1734  C5    A R  82     9751  10750  11902  -2688   1425   3052       C  
+ATOM   1735  C6    A R  82     196.498  45.997 141.457  1.00 85.23           C  
+ANISOU 1735  C6    A R  82     9540  10940  11904  -2664   1499   3040       C  
+ATOM   1736  N6    A R  82     197.274  45.450 140.508  1.00 88.30           N  
+ANISOU 1736  N6    A R  82     9756  11594  12200  -2609   1645   3109       N  
+ATOM   1737  N1    A R  82     196.777  45.750 142.763  1.00 81.42           N  
+ANISOU 1737  N1    A R  82     9042  10367  11527  -2691   1413   2952       N  
+ATOM   1738  C2    A R  82     196.011  46.308 143.707  1.00 81.13           C  
+ANISOU 1738  C2    A R  82     9185  10067  11575  -2735   1265   2878       C  
+ATOM   1739  N3    A R  82     194.945  47.095 143.559  1.00 86.89           N  
+ANISOU 1739  N3    A R  82    10115  10596  12304  -2751   1183   2874       N  
+ATOM   1740  C4    A R  82     194.687  47.321 142.258  1.00 82.21           C  
+ANISOU 1740  C4    A R  82     9530  10094  11610  -2729   1269   2967       C  
+ATOM   1741  P     U R  83     194.066  53.399 141.593  1.00110.15           P  
+ANISOU 1741  P     U R  83    13807  12811  15233  -3271    547   3368       P  
+ATOM   1742  OP1   U R  83     193.750  54.807 141.943  1.00105.74           O  
+ANISOU 1742  OP1   U R  83    13478  11977  14721  -3367    312   3395       O  
+ATOM   1743  OP2   U R  83     194.527  53.091 140.212  1.00113.79           O  
+ANISOU 1743  OP2   U R  83    14119  13525  15590  -3269    721   3500       O  
+ATOM   1744  O5'   U R  83     195.181  52.916 142.616  1.00 89.14           O  
+ANISOU 1744  O5'   U R  83    10980  10233  12654  -3320    536   3338       O  
+ATOM   1745  C5'   U R  83     195.013  53.117 144.006  1.00 84.74           C  
+ANISOU 1745  C5'   U R  83    10529   9474  12195  -3328    380   3219       C  
+ATOM   1746  C4'   U R  83     196.039  52.344 144.787  1.00 83.89           C  
+ANISOU 1746  C4'   U R  83    10229   9503  12142  -3343    423   3189       C  
+ATOM   1747  O4'   U R  83     195.964  50.947 144.424  1.00 88.31           O  
+ANISOU 1747  O4'   U R  83    10621  10283  12648  -3209    640   3127       O  
+ATOM   1748  C3'   U R  83     197.491  52.711 144.524  1.00 87.61           C  
+ANISOU 1748  C3'   U R  83    10536  10123  12630  -3487    407   3351       C  
+ATOM   1749  O3'   U R  83     197.901  53.876 145.222  1.00 90.20           O  
+ANISOU 1749  O3'   U R  83    10977  10262  13034  -3628    182   3401       O  
+ATOM   1750  C2'   U R  83     198.228  51.450 144.948  1.00 88.81           C  
+ANISOU 1750  C2'   U R  83    10465  10481  12797  -3425    539   3295       C  
+ATOM   1751  O2'   U R  83     198.332  51.389 146.361  1.00 94.53           O  
+ANISOU 1751  O2'   U R  83    11238  11062  13616  -3435    413   3185       O  
+ATOM   1752  C1'   U R  83     197.248  50.364 144.503  1.00 89.49           C  
+ANISOU 1752  C1'   U R  83    10542  10650  12812  -3245    716   3181       C  
+ATOM   1753  N1    U R  83     197.601  49.785 143.189  1.00 87.49           N  
+ANISOU 1753  N1    U R  83    10124  10666  12454  -3193    912   3271       N  
+ATOM   1754  C2    U R  83     198.595  48.822 143.153  1.00 84.95           C  
+ANISOU 1754  C2    U R  83     9569  10590  12118  -3153   1037   3280       C  
+ATOM   1755  O2    U R  83     199.219  48.426 144.126  1.00 78.94           O  
+ANISOU 1755  O2    U R  83     8725   9837  11430  -3168    996   3227       O  
+ATOM   1756  N3    U R  83     198.851  48.334 141.905  1.00 88.91           N  
+ANISOU 1756  N3    U R  83     9940  11333  12510  -3086   1212   3353       N  
+ATOM   1757  C4    U R  83     198.245  48.677 140.715  1.00 87.69           C  
+ANISOU 1757  C4    U R  83     9858  11203  12258  -3060   1277   3420       C  
+ATOM   1758  O4    U R  83     198.605  48.123 139.671  1.00 90.43           O  
+ANISOU 1758  O4    U R  83    10070  11788  12502  -2987   1438   3475       O  
+ATOM   1759  C5    U R  83     197.226  49.672 140.836  1.00 82.54           C  
+ANISOU 1759  C5    U R  83     9445  10285  11632  -3113   1139   3412       C  
+ATOM   1760  C6    U R  83     196.949  50.177 142.043  1.00 82.32           C  
+ANISOU 1760  C6    U R  83     9551  10016  11711  -3172    964   3337       C  
+ATOM   1761  P     C R  84     199.200  54.702 144.754  1.00102.60           P  
+ANISOU 1761  P     C R  84    12439  11929  14616  -3813    114   3610       P  
+ATOM   1762  OP1   C R  84     199.195  55.994 145.488  1.00106.32           O  
+ANISOU 1762  OP1   C R  84    13104  12138  15156  -3931   -146   3629       O  
+ATOM   1763  OP2   C R  84     199.245  54.754 143.268  1.00102.25           O  
+ANISOU 1763  OP2   C R  84    12322  12055  14474  -3822    251   3745       O  
+ATOM   1764  O5'   C R  84     200.415  53.829 145.308  1.00 75.82           O  
+ANISOU 1764  O5'   C R  84     8801   8737  11269  -3828    186   3615       O  
+ATOM   1765  C5'   C R  84     201.759  54.226 145.075  1.00 87.33           C  
+ANISOU 1765  C5'   C R  84    10098  10336  12749  -3977    153   3788       C  
+ATOM   1766  C4'   C R  84     202.739  53.165 145.508  1.00 89.43           C  
+ANISOU 1766  C4'   C R  84    10124  10813  13042  -3944    256   3768       C  
+ATOM   1767  O4'   C R  84     202.149  51.850 145.320  1.00 90.06           O  
+ANISOU 1767  O4'   C R  84    10137  11014  13066  -3756    454   3632       O  
+ATOM   1768  C3'   C R  84     204.042  53.124 144.721  1.00 87.95           C  
+ANISOU 1768  C3'   C R  84     9697  10894  12827  -4035    338   3954       C  
+ATOM   1769  O3'   C R  84     205.001  54.040 145.219  1.00 95.65           O  
+ANISOU 1769  O3'   C R  84    10654  11811  13879  -4218    155   4080       O  
+ATOM   1770  C2'   C R  84     204.478  51.669 144.843  1.00 89.16           C  
+ANISOU 1770  C2'   C R  84     9637  11277  12962  -3899    521   3872       C  
+ATOM   1771  O2'   C R  84     205.148  51.451 146.080  1.00 92.38           O  
+ANISOU 1771  O2'   C R  84     9989  11644  13467  -3937    420   3822       O  
+ATOM   1772  C1'   C R  84     203.127  50.938 144.868  1.00 88.92           C  
+ANISOU 1772  C1'   C R  84     9733  11166  12887  -3719    617   3687       C  
+ATOM   1773  N1    C R  84     202.698  50.422 143.540  1.00 83.65           N  
+ANISOU 1773  N1    C R  84     9010  10674  12098  -3609    814   3710       N  
+ATOM   1774  C2    C R  84     203.279  49.263 143.002  1.00 77.96           C  
+ANISOU 1774  C2    C R  84     8068  10241  11312  -3496   1010   3707       C  
+ATOM   1775  O2    C R  84     204.172  48.673 143.627  1.00 76.18           O  
+ANISOU 1775  O2    C R  84     7684  10126  11134  -3493   1019   3692       O  
+ATOM   1776  N3    C R  84     202.860  48.800 141.802  1.00 75.61           N  
+ANISOU 1776  N3    C R  84     7737  10098  10895  -3384   1182   3719       N  
+ATOM   1777  C4    C R  84     201.894  49.440 141.135  1.00 82.36           C  
+ANISOU 1777  C4    C R  84     8765  10831  11698  -3388   1167   3739       C  
+ATOM   1778  N4    C R  84     201.517  48.948 139.952  1.00 86.03           N  
+ANISOU 1778  N4    C R  84     9194  11455  12040  -3272   1336   3751       N  
+ATOM   1779  C5    C R  84     201.279  50.620 141.653  1.00 81.11           C  
+ANISOU 1779  C5    C R  84     8831  10378  11608  -3503    971   3745       C  
+ATOM   1780  C6    C R  84     201.706  51.061 142.843  1.00 80.21           C  
+ANISOU 1780  C6    C R  84     8752  10116  11608  -3605    801   3726       C  
+TER    1781        C R  84                                                      
+ATOM   1782  P     G A   2     166.317  31.688 126.737  1.00 84.64           P  
+ANISOU 1782  P     G A   2    11628  10545   9986    947   1439     91       P  
+ATOM   1783  OP1   G A   2     166.428  33.026 126.080  1.00 79.00           O  
+ANISOU 1783  OP1   G A   2    10969   9806   9241    948   1459    187       O  
+ATOM   1784  OP2   G A   2     166.546  31.551 128.202  1.00 77.07           O  
+ANISOU 1784  OP2   G A   2    10565   9572   9146    852   1456     58       O  
+ATOM   1785  O5'   G A   2     164.903  31.007 126.417  1.00 67.19           O  
+ANISOU 1785  O5'   G A   2     9458   8309   7761   1005   1316    -10       O  
+ATOM   1786  C5'   G A   2     164.415  30.884 125.088  1.00 70.07           C  
+ANISOU 1786  C5'   G A   2     9930   8678   8017   1104   1265    -10       C  
+ATOM   1787  C4'   G A   2     163.399  29.770 124.977  1.00 75.31           C  
+ANISOU 1787  C4'   G A   2    10613   9331   8671   1142   1152   -112       C  
+ATOM   1788  O4'   G A   2     164.048  28.497 125.233  1.00 71.42           O  
+ANISOU 1788  O4'   G A   2    10108   8872   8155   1145   1172   -151       O  
+ATOM   1789  C3'   G A   2     162.240  29.806 125.967  1.00 74.98           C  
+ANISOU 1789  C3'   G A   2    10490   9255   8746   1078   1067   -178       C  
+ATOM   1790  O3'   G A   2     161.187  30.659 125.553  1.00 83.59           O  
+ANISOU 1790  O3'   G A   2    11607  10311   9842   1109    995   -179       O  
+ATOM   1791  C2'   G A   2     161.826  28.342 126.057  1.00 72.75           C  
+ANISOU 1791  C2'   G A   2    10209   8981   8451   1083    988   -258       C  
+ATOM   1792  O2'   G A   2     161.032  27.987 124.934  1.00 75.35           O  
+ANISOU 1792  O2'   G A   2    10634   9297   8700   1164    887   -286       O  
+ATOM   1793  C1'   G A   2     163.176  27.637 125.934  1.00 63.12           C  
+ANISOU 1793  C1'   G A   2     9015   7797   7170   1103   1075   -237       C  
+ATOM   1794  N9    G A   2     163.795  27.337 127.239  1.00 60.37           N  
+ANISOU 1794  N9    G A   2     8566   7460   6911   1013   1131   -247       N  
+ATOM   1795  C8    G A   2     164.924  27.925 127.764  1.00 55.86           C  
+ANISOU 1795  C8    G A   2     7942   6911   6372    970   1249   -185       C  
+ATOM   1796  N7    G A   2     165.263  27.457 128.938  1.00 59.88           N  
+ANISOU 1796  N7    G A   2     8369   7422   6959    894   1269   -212       N  
+ATOM   1797  C5    G A   2     164.302  26.491 129.199  1.00 59.70           C  
+ANISOU 1797  C5    G A   2     8347   7379   6956    881   1161   -292       C  
+ATOM   1798  C6    G A   2     164.155  25.634 130.315  1.00 62.74           C  
+ANISOU 1798  C6    G A   2     8668   7759   7412    804   1127   -345       C  
+ATOM   1799  O6    G A   2     164.854  25.537 131.348  1.00 71.03           O  
+ANISOU 1799  O6    G A   2     9648   8816   8523    737   1186   -340       O  
+ATOM   1800  N1    G A   2     163.041  24.827 130.136  1.00 55.09           N  
+ANISOU 1800  N1    G A   2     7725   6772   6436    804   1002   -404       N  
+ATOM   1801  C2    G A   2     162.182  24.814 129.069  1.00 57.92           C  
+ANISOU 1801  C2    G A   2     8157   7117   6732    870    916   -418       C  
+ATOM   1802  N2    G A   2     161.165  23.935 129.140  1.00 72.19           N  
+ANISOU 1802  N2    G A   2     9969   8908   8553    841    788   -471       N  
+ATOM   1803  N3    G A   2     162.307  25.603 128.022  1.00 59.22           N  
+ANISOU 1803  N3    G A   2     8388   7285   6829    952    947   -376       N  
+ATOM   1804  C4    G A   2     163.386  26.404 128.159  1.00 60.51           C  
+ANISOU 1804  C4    G A   2     8528   7467   6994    951   1072   -313       C  
+ATOM   1805  P     U A   3     160.378  31.546 126.623  1.00 80.76           P  
+ANISOU 1805  P     U A   3    11155   9928   9604   1053    965   -199       P  
+ATOM   1806  OP1   U A   3     159.503  32.441 125.823  1.00 78.37           O  
+ANISOU 1806  OP1   U A   3    10913   9592   9270   1120    895   -189       O  
+ATOM   1807  OP2   U A   3     161.316  32.105 127.633  1.00 71.28           O  
+ANISOU 1807  OP2   U A   3     9892   8722   8470    977   1063   -159       O  
+ATOM   1808  O5'   U A   3     159.464  30.497 127.399  1.00 67.48           O  
+ANISOU 1808  O5'   U A   3     9387   8269   7983   1010    886   -286       O  
+ATOM   1809  C5'   U A   3     158.479  29.737 126.718  1.00 73.22           C  
+ANISOU 1809  C5'   U A   3    10147   9002   8670   1052    772   -334       C  
+ATOM   1810  C4'   U A   3     157.988  28.608 127.582  1.00 70.17           C  
+ANISOU 1810  C4'   U A   3     9676   8644   8342    979    717   -394       C  
+ATOM   1811  O4'   U A   3     159.091  27.708 127.864  1.00 71.94           O  
+ANISOU 1811  O4'   U A   3     9915   8872   8547    947    778   -392       O  
+ATOM   1812  C3'   U A   3     157.476  29.007 128.955  1.00 70.25           C  
+ANISOU 1812  C3'   U A   3     9549   8680   8463    903    730   -414       C  
+ATOM   1813  O3'   U A   3     156.135  29.481 128.925  1.00 74.97           O  
+ANISOU 1813  O3'   U A   3    10096   9297   9091    927    643   -439       O  
+ATOM   1814  C2'   U A   3     157.674  27.729 129.768  1.00 73.97           C  
+ANISOU 1814  C2'   U A   3     9965   9174   8967    819    721   -446       C  
+ATOM   1815  O2'   U A   3     156.633  26.799 129.514  1.00 77.66           O  
+ANISOU 1815  O2'   U A   3    10422   9657   9427    803    596   -486       O  
+ATOM   1816  C1'   U A   3     158.962  27.174 129.163  1.00 68.07           C  
+ANISOU 1816  C1'   U A   3     9317   8402   8143    850    779   -423       C  
+ATOM   1817  N1    U A   3     160.167  27.532 129.953  1.00 64.69           N  
+ANISOU 1817  N1    U A   3     8853   7976   7750    808    903   -389       N  
+ATOM   1818  C2    U A   3     160.447  26.801 131.101  1.00 62.92           C  
+ANISOU 1818  C2    U A   3     8555   7766   7586    723    920   -414       C  
+ATOM   1819  O2    U A   3     159.745  25.888 131.487  1.00 69.11           O  
+ANISOU 1819  O2    U A   3     9304   8563   8394    675    839   -457       O  
+ATOM   1820  N3    U A   3     161.583  27.176 131.788  1.00 62.87           N  
+ANISOU 1820  N3    U A   3     8519   7759   7611    688   1028   -382       N  
+ATOM   1821  C4    U A   3     162.462  28.193 131.442  1.00 66.53           C  
+ANISOU 1821  C4    U A   3     9013   8210   8055    719   1117   -320       C  
+ATOM   1822  O4    U A   3     163.446  28.421 132.151  1.00 68.11           O  
+ANISOU 1822  O4    U A   3     9176   8412   8293    672   1200   -290       O  
+ATOM   1823  C5    U A   3     162.114  28.901 130.244  1.00 64.54           C  
+ANISOU 1823  C5    U A   3     8838   7944   7738    800   1095   -290       C  
+ATOM   1824  C6    U A   3     161.008  28.555 129.566  1.00 67.71           C  
+ANISOU 1824  C6    U A   3     9276   8345   8107    845    993   -328       C  
+ATOM   1825  P     A A   4     155.607  30.590 129.977  1.00 78.41           P  
+ANISOU 1825  P     A A   4    10425   9757   9611    914    669   -447       P  
+ATOM   1826  OP1   A A   4     154.141  30.735 129.790  1.00 82.34           O  
+ANISOU 1826  OP1   A A   4    10865  10297  10124    951    563   -482       O  
+ATOM   1827  OP2   A A   4     156.457  31.802 129.932  1.00 77.29           O  
+ANISOU 1827  OP2   A A   4    10339   9563   9463    946    753   -400       O  
+ATOM   1828  O5'   A A   4     155.842  29.914 131.391  1.00 70.86           O  
+ANISOU 1828  O5'   A A   4     9357   8842   8724    810    713   -469       O  
+ATOM   1829  C5'   A A   4     155.158  28.726 131.758  1.00 72.07           C  
+ANISOU 1829  C5'   A A   4     9440   9046   8898    744    643   -502       C  
+ATOM   1830  C4'   A A   4     155.404  28.414 133.205  1.00 75.77           C  
+ANISOU 1830  C4'   A A   4     9804   9553   9433    651    699   -513       C  
+ATOM   1831  O4'   A A   4     156.810  28.069 133.405  1.00 76.91           O  
+ANISOU 1831  O4'   A A   4    10006   9651   9566    618    783   -492       O  
+ATOM   1832  C3'   A A   4     155.127  29.588 134.145  1.00 80.24           C  
+ANISOU 1832  C3'   A A   4    10288  10147  10054    667    750   -519       C  
+ATOM   1833  O3'   A A   4     154.656  29.069 135.383  1.00 86.04           O  
+ANISOU 1833  O3'   A A   4    10894  10955  10841    586    752   -542       O  
+ATOM   1834  C2'   A A   4     156.518  30.176 134.344  1.00 76.36           C  
+ANISOU 1834  C2'   A A   4     9863   9588   9562    667    854   -487       C  
+ATOM   1835  O2'   A A   4     156.688  31.003 135.477  1.00 71.04           O  
+ANISOU 1835  O2'   A A   4     9131   8920   8942    653    913   -492       O  
+ATOM   1836  C1'   A A   4     157.336  28.900 134.423  1.00 73.68           C  
+ANISOU 1836  C1'   A A   4     9548   9240   9209    597    873   -482       C  
+ATOM   1837  N9    A A   4     158.778  29.099 134.278  1.00 70.23           N  
+ANISOU 1837  N9    A A   4     9184   8749   8752    598    961   -443       N  
+ATOM   1838  C8    A A   4     159.497  29.808 133.342  1.00 72.04           C  
+ANISOU 1838  C8    A A   4     9508   8931   8932    660   1000   -398       C  
+ATOM   1839  N7    A A   4     160.791  29.809 133.573  1.00 69.81           N  
+ANISOU 1839  N7    A A   4     9249   8627   8649    631   1085   -362       N  
+ATOM   1840  C5    A A   4     160.912  29.071 134.745  1.00 63.21           C  
+ANISOU 1840  C5    A A   4     8336   7816   7867    551   1097   -393       C  
+ATOM   1841  C6    A A   4     162.019  28.700 135.517  1.00 68.30           C  
+ANISOU 1841  C6    A A   4     8959   8454   8538    491   1166   -380       C  
+ATOM   1842  N6    A A   4     163.257  29.058 135.183  1.00 68.08           N  
+ANISOU 1842  N6    A A   4     8977   8402   8488    503   1240   -328       N  
+ATOM   1843  N1    A A   4     161.804  27.954 136.637  1.00 73.12           N  
+ANISOU 1843  N1    A A   4     9496   9090   9197    416   1152   -418       N  
+ATOM   1844  C2    A A   4     160.543  27.603 136.939  1.00 69.42           C  
+ANISOU 1844  C2    A A   4     8969   8661   8746    397   1079   -458       C  
+ATOM   1845  N3    A A   4     159.417  27.901 136.289  1.00 68.73           N  
+ANISOU 1845  N3    A A   4     8881   8595   8640    447   1012   -470       N  
+ATOM   1846  C4    A A   4     159.681  28.640 135.196  1.00 65.61           C  
+ANISOU 1846  C4    A A   4     8568   8162   8199    527   1023   -440       C  
+ATOM   1847  P     C A   5     153.092  28.798 135.577  1.00 90.28           P  
+ANISOU 1847  P     C A   5    11308  11596  11398    576    662   -566       P  
+ATOM   1848  OP1   C A   5     152.916  27.412 136.084  1.00 88.29           O  
+ANISOU 1848  OP1   C A   5    10997  11388  11161    457    623   -565       O  
+ATOM   1849  OP2   C A   5     152.397  29.280 134.356  1.00 90.22           O  
+ANISOU 1849  OP2   C A   5    11352  11575  11354    671    586   -568       O  
+ATOM   1850  O5'   C A   5     152.695  29.771 136.756  1.00 87.04           O  
+ANISOU 1850  O5'   C A   5    10789  11250  11032    600    716   -586       O  
+ATOM   1851  C5'   C A   5     152.752  31.183 136.619  1.00 84.24           C  
+ANISOU 1851  C5'   C A   5    10477  10857  10674    708    745   -593       C  
+ATOM   1852  C4'   C A   5     152.009  31.826 137.759  1.00 84.76           C  
+ANISOU 1852  C4'   C A   5    10419  11014  10773    738    764   -625       C  
+ATOM   1853  O4'   C A   5     150.625  32.008 137.352  1.00 87.55           O  
+ANISOU 1853  O4'   C A   5    10690  11456  11117    804    682   -645       O  
+ATOM   1854  C3'   C A   5     151.974  30.970 139.023  1.00 85.75           C  
+ANISOU 1854  C3'   C A   5    10429  11222  10928    629    801   -630       C  
+ATOM   1855  O3'   C A   5     151.931  31.793 140.194  1.00 86.38           O  
+ANISOU 1855  O3'   C A   5    10451  11342  11028    667    860   -656       O  
+ATOM   1856  C2'   C A   5     150.667  30.191 138.863  1.00 89.90           C  
+ANISOU 1856  C2'   C A   5    10834  11871  11454    596    718   -631       C  
+ATOM   1857  O2'   C A   5     150.110  29.723 140.073  1.00 90.86           O  
+ANISOU 1857  O2'   C A   5    10805  12119  11598    524    739   -635       O  
+ATOM   1858  C1'   C A   5     149.768  31.212 138.154  1.00 91.63           C  
+ANISOU 1858  C1'   C A   5    11047  12111  11656    732    665   -652       C  
+ATOM   1859  N1    C A   5     148.771  30.601 137.251  1.00 94.19           N  
+ANISOU 1859  N1    C A   5    11330  12489  11968    725    558   -643       N  
+ATOM   1860  C2    C A   5     147.506  31.182 137.117  1.00 91.30           C  
+ANISOU 1860  C2    C A   5    10861  12226  11601    815    501   -664       C  
+ATOM   1861  O2    C A   5     147.254  32.206 137.757  1.00 93.93           O  
+ANISOU 1861  O2    C A   5    11148  12603  11939    910    543   -695       O  
+ATOM   1862  N3    C A   5     146.590  30.627 136.285  1.00 97.45           N  
+ANISOU 1862  N3    C A   5    11599  13054  12373    803    393   -652       N  
+ATOM   1863  C4    C A   5     146.883  29.520 135.593  1.00 97.03           C  
+ANISOU 1863  C4    C A   5    11616  12942  12309    708    336   -623       C  
+ATOM   1864  N4    C A   5     145.947  29.003 134.785  1.00 91.16           N  
+ANISOU 1864  N4    C A   5    10837  12240  11558    696    216   -612       N  
+ATOM   1865  C5    C A   5     148.161  28.897 135.708  1.00 95.05           C  
+ANISOU 1865  C5    C A   5    11477  12585  12052    627    392   -608       C  
+ATOM   1866  C6    C A   5     149.059  29.463 136.536  1.00 94.52           C  
+ANISOU 1866  C6    C A   5    11436  12481  11996    638    505   -616       C  
+ATOM   1867  P     A A   6     153.181  31.848 141.216  1.00 95.85           P  
+ANISOU 1867  P     A A   6    11691  12479  12249    607    950   -651       P  
+ATOM   1868  OP1   A A   6     152.651  32.044 142.590  1.00 92.82           O  
+ANISOU 1868  OP1   A A   6    11188  12201  11878    609    986   -682       O  
+ATOM   1869  OP2   A A   6     154.155  32.827 140.660  1.00 92.64           O  
+ANISOU 1869  OP2   A A   6    11427  11935  11836    667    974   -637       O  
+ATOM   1870  O5'   A A   6     153.867  30.405 141.123  1.00 82.02           O  
+ANISOU 1870  O5'   A A   6     9960  10704  10501    473    955   -620       O  
+ATOM   1871  C5'   A A   6     153.467  29.305 141.940  1.00 70.53           C  
+ANISOU 1871  C5'   A A   6     8399   9342   9059    366    948   -617       C  
+ATOM   1872  C4'   A A   6     154.578  28.276 142.055  1.00 70.05           C  
+ANISOU 1872  C4'   A A   6     8403   9209   9003    261    969   -594       C  
+ATOM   1873  O4'   A A   6     154.946  27.771 140.737  1.00 67.02           O  
+ANISOU 1873  O4'   A A   6     8125   8749   8593    268    921   -576       O  
+ATOM   1874  C3'   A A   6     155.879  28.797 142.658  1.00 68.33           C  
+ANISOU 1874  C3'   A A   6     8254   8907   8802    260   1053   -593       C  
+ATOM   1875  O3'   A A   6     155.876  28.684 144.069  1.00 66.56           O  
+ANISOU 1875  O3'   A A   6     7951   8740   8599    206   1097   -605       O  
+ATOM   1876  C2'   A A   6     156.953  27.934 142.003  1.00 71.77           C  
+ANISOU 1876  C2'   A A   6     8788   9254   9226    210   1052   -568       C  
+ATOM   1877  O2'   A A   6     157.099  26.708 142.700  1.00 75.50           O  
+ANISOU 1877  O2'   A A   6     9224   9754   9708     99   1042   -564       O  
+ATOM   1878  C1'   A A   6     156.347  27.646 140.629  1.00 69.64           C  
+ANISOU 1878  C1'   A A   6     8559   8981   8921    252    974   -561       C  
+ATOM   1879  N9    A A   6     156.809  28.595 139.595  1.00 74.36           N  
+ANISOU 1879  N9    A A   6     9256   9503   9494    349    989   -549       N  
+ATOM   1880  C8    A A   6     156.006  29.163 138.638  1.00 74.07           C  
+ANISOU 1880  C8    A A   6     9236   9473   9432    433    936   -552       C  
+ATOM   1881  N7    A A   6     156.612  29.978 137.812  1.00 66.71           N  
+ANISOU 1881  N7    A A   6     8406   8465   8476    505    958   -531       N  
+ATOM   1882  C5    A A   6     157.923  29.945 138.251  1.00 67.72           C  
+ANISOU 1882  C5    A A   6     8575   8537   8616    461   1034   -509       C  
+ATOM   1883  C6    A A   6     159.066  30.611 137.779  1.00 68.00           C  
+ANISOU 1883  C6    A A   6     8705   8495   8638    489   1089   -469       C  
+ATOM   1884  N6    A A   6     159.045  31.445 136.732  1.00 67.78           N  
+ANISOU 1884  N6    A A   6     8754   8425   8575    566   1075   -443       N  
+ATOM   1885  N1    A A   6     160.230  30.377 138.431  1.00 66.47           N  
+ANISOU 1885  N1    A A   6     8517   8273   8467    428   1155   -451       N  
+ATOM   1886  C2    A A   6     160.227  29.534 139.480  1.00 69.16           C  
+ANISOU 1886  C2    A A   6     8787   8652   8838    351   1162   -476       C  
+ATOM   1887  N3    A A   6     159.210  28.845 140.009  1.00 75.09           N  
+ANISOU 1887  N3    A A   6     9457   9474   9602    314   1115   -511       N  
+ATOM   1888  C4    A A   6     158.067  29.098 139.346  1.00 71.63           C  
+ANISOU 1888  C4    A A   6     9001   9071   9143    371   1052   -524       C  
+ATOM   1889  P     C A   7     156.280  29.923 145.010  1.00 72.76           P  
+ANISOU 1889  P     C A   7     8743   9502   9400    266   1162   -628       P  
+ATOM   1890  OP1   C A   7     156.464  29.388 146.384  1.00 78.37           O  
+ANISOU 1890  OP1   C A   7     9390  10263  10124    183   1201   -634       O  
+ATOM   1891  OP2   C A   7     155.322  31.035 144.730  1.00 82.60           O  
+ANISOU 1891  OP2   C A   7     9962  10789  10632    388   1138   -655       O  
+ATOM   1892  O5'   C A   7     157.729  30.365 144.521  1.00 68.54           O  
+ANISOU 1892  O5'   C A   7     8341   8825   8876    275   1196   -605       O  
+ATOM   1893  C5'   C A   7     158.886  29.615 144.863  1.00 65.39           C  
+ANISOU 1893  C5'   C A   7     7979   8372   8492    187   1231   -584       C  
+ATOM   1894  C4'   C A   7     160.113  30.339 144.399  1.00 58.85           C  
+ANISOU 1894  C4'   C A   7     7254   7433   7673    214   1266   -556       C  
+ATOM   1895  O4'   C A   7     160.120  30.375 142.955  1.00 65.45           O  
+ANISOU 1895  O4'   C A   7     8153   8235   8478    262   1238   -531       O  
+ATOM   1896  C3'   C A   7     160.170  31.805 144.813  1.00 60.93           C  
+ANISOU 1896  C3'   C A   7     7544   7655   7952    283   1281   -566       C  
+ATOM   1897  O3'   C A   7     160.740  31.945 146.095  1.00 67.13           O  
+ANISOU 1897  O3'   C A   7     8315   8427   8766    240   1318   -578       O  
+ATOM   1898  C2'   C A   7     161.004  32.455 143.719  1.00 50.87           C  
+ANISOU 1898  C2'   C A   7     6373   6285   6670    316   1286   -519       C  
+ATOM   1899  O2'   C A   7     162.387  32.277 143.988  1.00 56.27           O  
+ANISOU 1899  O2'   C A   7     7096   6909   7377    250   1332   -483       O  
+ATOM   1900  C1'   C A   7     160.645  31.606 142.498  1.00 60.60           C  
+ANISOU 1900  C1'   C A   7     7615   7546   7865    322   1255   -506       C  
+ATOM   1901  N1    C A   7     159.666  32.238 141.584  1.00 58.67           N  
+ANISOU 1901  N1    C A   7     7387   7314   7593    413   1205   -513       N  
+ATOM   1902  C2    C A   7     160.049  33.298 140.749  1.00 59.32           C  
+ANISOU 1902  C2    C A   7     7561   7319   7660    474   1202   -479       C  
+ATOM   1903  O2    C A   7     161.202  33.740 140.797  1.00 66.79           O  
+ANISOU 1903  O2    C A   7     8565   8192   8619    446   1244   -436       O  
+ATOM   1904  N3    C A   7     159.144  33.818 139.899  1.00 58.47           N  
+ANISOU 1904  N3    C A   7     7475   7219   7523    558   1149   -487       N  
+ATOM   1905  C4    C A   7     157.908  33.325 139.856  1.00 58.46           C  
+ANISOU 1905  C4    C A   7     7398   7304   7511    583   1100   -527       C  
+ATOM   1906  N4    C A   7     157.050  33.873 139.006  1.00 59.66           N  
+ANISOU 1906  N4    C A   7     7571   7461   7636    670   1043   -535       N  
+ATOM   1907  C5    C A   7     157.484  32.247 140.680  1.00 59.39           C  
+ANISOU 1907  C5    C A   7     7412   7509   7645    513   1102   -556       C  
+ATOM   1908  C6    C A   7     158.397  31.740 141.517  1.00 60.32           C  
+ANISOU 1908  C6    C A   7     7521   7610   7787    429   1155   -547       C  
+ATOM   1909  P     G A   8     160.174  33.022 147.125  1.00 67.65           P  
+ANISOU 1909  P     G A   8     8359   8511   8836    306   1316   -621       P  
+ATOM   1910  OP1   G A   8     160.887  32.835 148.412  1.00 67.81           O  
+ANISOU 1910  OP1   G A   8     8370   8517   8879    241   1351   -630       O  
+ATOM   1911  OP2   G A   8     158.696  32.929 147.114  1.00 70.44           O  
+ANISOU 1911  OP2   G A   8     8624   8981   9160    363   1286   -658       O  
+ATOM   1912  O5'   G A   8     160.657  34.405 146.488  1.00 49.90           O  
+ANISOU 1912  O5'   G A   8     6219   6149   6593    378   1298   -600       O  
+ATOM   1913  C5'   G A   8     162.040  34.677 146.275  1.00 47.31           C  
+ANISOU 1913  C5'   G A   8     5972   5713   6291    326   1319   -548       C  
+ATOM   1914  C4'   G A   8     162.253  36.022 145.614  1.00 57.81           C  
+ANISOU 1914  C4'   G A   8     7399   6946   7620    391   1286   -519       C  
+ATOM   1915  O4'   G A   8     161.652  36.007 144.283  1.00 55.13           O  
+ANISOU 1915  O4'   G A   8     7076   6624   7245    445   1260   -503       O  
+ATOM   1916  C3'   G A   8     161.626  37.215 146.349  1.00 57.75           C  
+ANISOU 1916  C3'   G A   8     7419   6912   7610    481   1244   -569       C  
+ATOM   1917  O3'   G A   8     162.409  38.381 146.105  1.00 64.23           O  
+ANISOU 1917  O3'   G A   8     8354   7601   8448    489   1213   -526       O  
+ATOM   1918  C2'   G A   8     160.295  37.370 145.618  1.00 58.21           C  
+ANISOU 1918  C2'   G A   8     7449   7038   7630    582   1205   -601       C  
+ATOM   1919  O2'   G A   8     159.676  38.638 145.741  1.00 60.95           O  
+ANISOU 1919  O2'   G A   8     7850   7346   7963    700   1148   -638       O  
+ATOM   1920  C1'   G A   8     160.722  37.064 144.181  1.00 55.67           C  
+ANISOU 1920  C1'   G A   8     7172   6682   7297    553   1207   -537       C  
+ATOM   1921  N9    G A   8     159.625  36.695 143.282  1.00 54.73           N  
+ANISOU 1921  N9    G A   8     7015   6639   7143    612   1176   -554       N  
+ATOM   1922  C8    G A   8     158.531  35.919 143.562  1.00 55.51           C  
+ANISOU 1922  C8    G A   8     7003   6861   7228    625   1169   -601       C  
+ATOM   1923  N7    G A   8     157.702  35.816 142.559  1.00 53.57           N  
+ANISOU 1923  N7    G A   8     6748   6652   6954    679   1127   -603       N  
+ATOM   1924  C5    G A   8     158.276  36.590 141.564  1.00 49.05           C  
+ANISOU 1924  C5    G A   8     6293   5974   6370    710   1109   -557       C  
+ATOM   1925  C6    G A   8     157.829  36.868 140.244  1.00 56.89           C  
+ANISOU 1925  C6    G A   8     7341   6948   7328    774   1062   -537       C  
+ATOM   1926  O6    G A   8     156.804  36.469 139.683  1.00 60.58           O  
+ANISOU 1926  O6    G A   8     7759   7487   7771    818   1020   -561       O  
+ATOM   1927  N1    G A   8     158.702  37.702 139.555  1.00 52.39           N  
+ANISOU 1927  N1    G A   8     6893   6262   6749    778   1061   -477       N  
+ATOM   1928  C2    G A   8     159.853  38.211 140.090  1.00 52.12           C  
+ANISOU 1928  C2    G A   8     6915   6145   6745    721   1095   -439       C  
+ATOM   1929  N2    G A   8     160.562  38.984 139.264  1.00 51.00           N  
+ANISOU 1929  N2    G A   8     6882   5906   6589    720   1085   -368       N  
+ATOM   1930  N3    G A   8     160.288  37.960 141.320  1.00 51.91           N  
+ANISOU 1930  N3    G A   8     6838   6130   6756    663   1133   -461       N  
+ATOM   1931  C4    G A   8     159.455  37.145 141.993  1.00 53.73           C  
+ANISOU 1931  C4    G A   8     6957   6470   6989    665   1140   -522       C  
+ATOM   1932  P     A A   9     163.625  38.806 147.066  1.00 60.33           P  
+ANISOU 1932  P     A A   9     7911   7012   7998    416   1218   -502       P  
+ATOM   1933  OP1   A A   9     164.630  37.707 147.112  1.00 67.37           O  
+ANISOU 1933  OP1   A A   9     8754   7929   8914    298   1281   -458       O  
+ATOM   1934  OP2   A A   9     163.031  39.396 148.283  1.00 45.38           O  
+ANISOU 1934  OP2   A A   9     6022   5122   6100    486   1185   -578       O  
+ATOM   1935  O5'   A A   9     164.312  39.985 146.259  1.00 55.51           O  
+ANISOU 1935  O5'   A A   9     7424   6269   7398    415   1171   -429       O  
+ATOM   1936  C5'   A A   9     164.559  39.823 144.873  1.00 59.56           C  
+ANISOU 1936  C5'   A A   9     7957   6781   7894    397   1186   -359       C  
+ATOM   1937  C4'   A A   9     165.797  40.549 144.429  1.00 60.55           C  
+ANISOU 1937  C4'   A A   9     8168   6796   8043    323   1176   -258       C  
+ATOM   1938  O4'   A A   9     166.050  40.181 143.053  1.00 63.66           O  
+ANISOU 1938  O4'   A A   9     8564   7220   8405    307   1209   -188       O  
+ATOM   1939  C3'   A A   9     165.679  42.063 144.444  1.00 58.09           C  
+ANISOU 1939  C3'   A A   9     7979   6357   7735    372   1084   -245       C  
+ATOM   1940  O3'   A A   9     166.973  42.637 144.595  1.00 59.77           O  
+ANISOU 1940  O3'   A A   9     8253   6469   7989    268   1069   -156       O  
+ATOM   1941  C2'   A A   9     165.155  42.365 143.047  1.00 61.92           C  
+ANISOU 1941  C2'   A A   9     8510   6842   8174    431   1062   -209       C  
+ATOM   1942  O2'   A A   9     165.451  43.671 142.588  1.00 67.14           O  
+ANISOU 1942  O2'   A A   9     9302   7373   8835    435    985   -146       O  
+ATOM   1943  C1'   A A   9     165.855  41.295 142.204  1.00 62.44           C  
+ANISOU 1943  C1'   A A   9     8511   6984   8227    352   1150   -142       C  
+ATOM   1944  N9    A A   9     165.045  40.819 141.078  1.00 63.76           N  
+ANISOU 1944  N9    A A   9     8662   7222   8340    420   1159   -153       N  
+ATOM   1945  C8    A A   9     163.892  40.068 141.167  1.00 63.02           C  
+ANISOU 1945  C8    A A   9     8494   7226   8224    491   1161   -241       C  
+ATOM   1946  N7    A A   9     163.358  39.766 140.013  1.00 63.99           N  
+ANISOU 1946  N7    A A   9     8623   7390   8299    538   1157   -231       N  
+ATOM   1947  C5    A A   9     164.226  40.351 139.099  1.00 61.32           C  
+ANISOU 1947  C5    A A   9     8371   6983   7945    501   1161   -130       C  
+ATOM   1948  C6    A A   9     164.218  40.395 137.692  1.00 58.50           C  
+ANISOU 1948  C6    A A   9     8067   6629   7531    526   1160    -70       C  
+ATOM   1949  N6    A A   9     163.271  39.813 136.944  1.00 60.22           N  
+ANISOU 1949  N6    A A   9     8264   6914   7703    599   1146   -112       N  
+ATOM   1950  N1    A A   9     165.226  41.065 137.084  1.00 59.56           N  
+ANISOU 1950  N1    A A   9     8277   6699   7656    469   1171     41       N  
+ATOM   1951  C2    A A   9     166.165  41.642 137.842  1.00 60.15           C  
+ANISOU 1951  C2    A A   9     8369   6705   7782    386   1173     89       C  
+ATOM   1952  N3    A A   9     166.275  41.677 139.163  1.00 64.04           N  
+ANISOU 1952  N3    A A   9     8824   7176   8334    357   1164     36       N  
+ATOM   1953  C4    A A   9     165.269  40.999 139.738  1.00 64.19           C  
+ANISOU 1953  C4    A A   9     8771   7265   8353    422   1163    -76       C  
+ATOM   1954  P     C A  10     167.579  42.960 146.045  1.00 65.03           P  
+ANISOU 1954  P     C A  10     8935   7067   8706    218   1038   -181       P  
+ATOM   1955  OP1   C A  10     169.005  42.557 145.979  1.00 67.81           O  
+ANISOU 1955  OP1   C A  10     9253   7413   9099     77   1089    -84       O  
+ATOM   1956  OP2   C A  10     166.707  42.473 147.144  1.00 67.40           O  
+ANISOU 1956  OP2   C A  10     9175   7439   8996    291   1049   -302       O  
+ATOM   1957  O5'   C A  10     167.564  44.538 146.115  1.00 53.15           O  
+ANISOU 1957  O5'   C A  10     7585   5402   7208    252    917   -161       O  
+ATOM   1958  C5'   C A  10     166.361  45.269 145.970  1.00 57.14           C  
+ANISOU 1958  C5'   C A  10     8159   5880   7673    395    844   -233       C  
+ATOM   1959  C4'   C A  10     166.657  46.698 145.603  1.00 58.23           C  
+ANISOU 1959  C4'   C A  10     8459   5849   7815    395    727   -171       C  
+ATOM   1960  O4'   C A  10     167.711  47.203 146.470  1.00 67.24           O  
+ANISOU 1960  O4'   C A  10     9661   6878   9009    295    677   -129       O  
+ATOM   1961  C3'   C A  10     167.147  46.913 144.176  1.00 64.70           C  
+ANISOU 1961  C3'   C A  10     9316   6644   8623    327    736    -44       C  
+ATOM   1962  O3'   C A  10     166.699  48.189 143.719  1.00 70.18           O  
+ANISOU 1962  O3'   C A  10    10164   7209   9295    398    614    -31       O  
+ATOM   1963  C2'   C A  10     168.664  46.933 144.343  1.00 65.63           C  
+ANISOU 1963  C2'   C A  10     9430   6710   8795    155    754     73       C  
+ATOM   1964  O2'   C A  10     169.364  47.606 143.318  1.00 65.77           O  
+ANISOU 1964  O2'   C A  10     9524   6655   8811     70    723    214       O  
+ATOM   1965  C1'   C A  10     168.813  47.633 145.690  1.00 64.58           C  
+ANISOU 1965  C1'   C A  10     9373   6463   8700    160    661     19       C  
+ATOM   1966  N1    C A  10     170.042  47.277 146.413  1.00 61.56           N  
+ANISOU 1966  N1    C A  10     8940   6072   8377     19    692     72       N  
+ATOM   1967  C2    C A  10     171.044  48.239 146.560  1.00 58.44           C  
+ANISOU 1967  C2    C A  10     8647   5530   8028    -95    598    175       C  
+ATOM   1968  O2    C A  10     170.866  49.385 146.079  1.00 63.59           O  
+ANISOU 1968  O2    C A  10     9441   6051   8667    -76    486    218       O  
+ATOM   1969  N3    C A  10     172.172  47.894 147.234  1.00 55.27           N  
+ANISOU 1969  N3    C A  10     8188   5129   7685   -225    622    225       N  
+ATOM   1970  C4    C A  10     172.309  46.662 147.742  1.00 57.14           C  
+ANISOU 1970  C4    C A  10     8283   5498   7931   -235    733    173       C  
+ATOM   1971  N4    C A  10     173.429  46.375 148.399  1.00 59.83           N  
+ANISOU 1971  N4    C A  10     8574   5832   8328   -358    746    222       N  
+ATOM   1972  C5    C A  10     171.306  45.660 147.616  1.00 52.23           C  
+ANISOU 1972  C5    C A  10     7566   5019   7260   -124    826     70       C  
+ATOM   1973  C6    C A  10     170.202  46.014 146.943  1.00 56.88           C  
+ANISOU 1973  C6    C A  10     8204   5611   7795     -5    801     26       C  
+ATOM   1974  P     A A  11     165.663  48.285 142.497  1.00 84.24           P  
+ANISOU 1974  P     A A  11    11965   9029  11013    510    604    -44       P  
+ATOM   1975  OP1   A A  11     165.807  49.641 141.902  1.00 85.93           O  
+ANISOU 1975  OP1   A A  11    12356   9078  11217    510    479     31       O  
+ATOM   1976  OP2   A A  11     164.331  47.829 142.981  1.00 81.69           O  
+ANISOU 1976  OP2   A A  11    11568   8810  10659    663    618   -190       O  
+ATOM   1977  O5'   A A  11     166.230  47.230 141.441  1.00 69.01           O  
+ANISOU 1977  O5'   A A  11     9932   7220   9071    415    729     46       O  
+ATOM   1978  C5'   A A  11     167.471  47.450 140.783  1.00 68.11           C  
+ANISOU 1978  C5'   A A  11     9848   7061   8971    273    749    197       C  
+ATOM   1979  C4'   A A  11     167.419  47.052 139.330  1.00 67.43           C  
+ANISOU 1979  C4'   A A  11     9743   7049   8827    273    808    269       C  
+ATOM   1980  O4'   A A  11     167.100  45.645 139.212  1.00 69.38           O  
+ANISOU 1980  O4'   A A  11     9849   7457   9054    303    919    207       O  
+ATOM   1981  C3'   A A  11     166.369  47.743 138.475  1.00 66.18           C  
+ANISOU 1981  C3'   A A  11     9687   6845   8615    392    728    247       C  
+ATOM   1982  O3'   A A  11     166.795  49.020 138.030  1.00 65.53           O  
+ANISOU 1982  O3'   A A  11     9757   6611   8529    346    627    351       O  
+ATOM   1983  C2'   A A  11     166.171  46.764 137.331  1.00 69.07           C  
+ANISOU 1983  C2'   A A  11     9976   7343   8924    410    822    268       C  
+ATOM   1984  O2'   A A  11     167.205  46.920 136.372  1.00 72.82           O  
+ANISOU 1984  O2'   A A  11    10483   7811   9376    303    860    420       O  
+ATOM   1985  C1'   A A  11     166.369  45.418 138.030  1.00 65.20           C  
+ANISOU 1985  C1'   A A  11     9330   6982   8460    382    928    205       C  
+ATOM   1986  N9    A A  11     165.109  44.722 138.362  1.00 61.91           N  
+ANISOU 1986  N9    A A  11     8839   6654   8030    499    934     68       N  
+ATOM   1987  C8    A A  11     164.584  44.464 139.601  1.00 66.47           C  
+ANISOU 1987  C8    A A  11     9354   7259   8642    541    927    -42       C  
+ATOM   1988  N7    A A  11     163.460  43.789 139.580  1.00 70.23           N  
+ANISOU 1988  N7    A A  11     9755   7836   9093    634    938   -136       N  
+ATOM   1989  C5    A A  11     163.240  43.570 138.225  1.00 64.49           C  
+ANISOU 1989  C5    A A  11     9049   7140   8314    657    948    -90       C  
+ATOM   1990  C6    A A  11     162.217  42.907 137.513  1.00 59.59           C  
+ANISOU 1990  C6    A A  11     8381   6612   7650    739    951   -141       C  
+ATOM   1991  N6    A A  11     161.167  42.293 138.078  1.00 55.81           N  
+ANISOU 1991  N6    A A  11     7806   6226   7175    806    948   -245       N  
+ATOM   1992  N1    A A  11     162.313  42.883 136.166  1.00 62.46           N  
+ANISOU 1992  N1    A A  11     8797   6974   7959    745    954    -73       N  
+ATOM   1993  C2    A A  11     163.356  43.478 135.576  1.00 66.94           C  
+ANISOU 1993  C2    A A  11     9450   7467   8515    672    963     43       C  
+ATOM   1994  N3    A A  11     164.372  44.126 136.136  1.00 65.93           N  
+ANISOU 1994  N3    A A  11     9363   7258   8429    581    962    109       N  
+ATOM   1995  C4    A A  11     164.247  44.142 137.473  1.00 63.24           C  
+ANISOU 1995  C4    A A  11     8977   6906   8145    580    950     33       C  
+ATOM   1996  P     A A  12     165.763  50.247 137.969  1.00 82.99           P  
+ANISOU 1996  P     A A  12    12128   8689  10717    478    473    293       P  
+ATOM   1997  OP1   A A  12     166.561  51.470 137.679  1.00 83.89           O  
+ANISOU 1997  OP1   A A  12    12399   8635  10842    377    370    426       O  
+ATOM   1998  OP2   A A  12     164.912  50.218 139.190  1.00 84.21           O  
+ANISOU 1998  OP2   A A  12    12255   8850  10893    598    435    134       O  
+ATOM   1999  O5'   A A  12     164.834  49.908 136.716  1.00 73.20           O  
+ANISOU 1999  O5'   A A  12    10878   7529   9404    582    495    276       O  
+ATOM   2000  C5'   A A  12     165.360  49.806 135.397  1.00 67.48           C  
+ANISOU 2000  C5'   A A  12    10177   6831   8634    511    540    406       C  
+ATOM   2001  C4'   A A  12     164.347  49.215 134.443  1.00 68.71           C  
+ANISOU 2001  C4'   A A  12    10297   7085   8724    628    569    351       C  
+ATOM   2002  O4'   A A  12     164.226  47.787 134.691  1.00 70.45           O  
+ANISOU 2002  O4'   A A  12    10349   7469   8949    634    689    282       O  
+ATOM   2003  C3'   A A  12     162.917  49.728 134.568  1.00 73.64           C  
+ANISOU 2003  C3'   A A  12    10977   7671   9331    803    461    227       C  
+ATOM   2004  O3'   A A  12     162.680  50.962 133.914  1.00 77.63           O  
+ANISOU 2004  O3'   A A  12    11658   8035   9803    845    335    279       O  
+ATOM   2005  C2'   A A  12     162.108  48.573 133.999  1.00 72.51           C  
+ANISOU 2005  C2'   A A  12    10716   7687   9149    881    536    158       C  
+ATOM   2006  O2'   A A  12     162.222  48.535 132.587  1.00 73.29           O  
+ANISOU 2006  O2'   A A  12    10869   7796   9180    869    549    248       O  
+ATOM   2007  C1'   A A  12     162.876  47.386 134.554  1.00 70.32           C  
+ANISOU 2007  C1'   A A  12    10292   7522   8906    778    667    161       C  
+ATOM   2008  N9    A A  12     162.369  46.981 135.882  1.00 65.75           N  
+ANISOU 2008  N9    A A  12     9615   6990   8375    823    675     36       N  
+ATOM   2009  C8    A A  12     162.906  47.285 137.106  1.00 64.85           C  
+ANISOU 2009  C8    A A  12     9498   6823   8320    771    666     19       C  
+ATOM   2010  N7    A A  12     162.252  46.776 138.121  1.00 64.83           N  
+ANISOU 2010  N7    A A  12     9398   6894   8340    833    682    -99       N  
+ATOM   2011  C5    A A  12     161.194  46.100 137.534  1.00 63.47           C  
+ANISOU 2011  C5    A A  12     9153   6833   8128    925    699   -161       C  
+ATOM   2012  C6    A A  12     160.129  45.344 138.069  1.00 62.33           C  
+ANISOU 2012  C6    A A  12     8885   6814   7983   1008    720   -275       C  
+ATOM   2013  N6    A A  12     159.933  45.139 139.375  1.00 62.28           N  
+ANISOU 2013  N6    A A  12     8804   6849   8011   1021    736   -354       N  
+ATOM   2014  N1    A A  12     159.249  44.788 137.206  1.00 59.14           N  
+ANISOU 2014  N1    A A  12     8434   6499   7540   1074    720   -301       N  
+ATOM   2015  C2    A A  12     159.443  44.992 135.899  1.00 60.01           C  
+ANISOU 2015  C2    A A  12     8626   6567   7606   1067    704   -223       C  
+ATOM   2016  N3    A A  12     160.400  45.684 135.278  1.00 62.82           N  
+ANISOU 2016  N3    A A  12     9103   6816   7951    998    692   -113       N  
+ATOM   2017  C4    A A  12     161.255  46.222 136.158  1.00 64.15           C  
+ANISOU 2017  C4    A A  12     9306   6902   8166    923    690    -83       C  
+ATOM   2018  P     U A  13     161.453  51.895 134.376  1.00 87.18           P  
+ANISOU 2018  P     U A  13    12964   9153  11009   1023    187    156       P  
+ATOM   2019  OP1   U A  13     161.510  53.141 133.575  1.00 88.38           O  
+ANISOU 2019  OP1   U A  13    13315   9141  11125   1029     58    244       O  
+ATOM   2020  OP2   U A  13     161.421  51.966 135.859  1.00 89.86           O  
+ANISOU 2020  OP2   U A  13    13261   9476  11404   1047    172     60       O  
+ATOM   2021  O5'   U A  13     160.154  51.093 133.929  1.00 79.45           O  
+ANISOU 2021  O5'   U A  13    11878   8319   9991   1168    219     46       O  
+ATOM   2022  C5'   U A  13     159.853  50.905 132.558  1.00 75.76           C  
+ANISOU 2022  C5'   U A  13    11440   7885   9461   1191    224     98       C  
+ATOM   2023  C4'   U A  13     158.552  50.161 132.367  1.00 79.53           C  
+ANISOU 2023  C4'   U A  13    11808   8496   9915   1330    235    -21       C  
+ATOM   2024  O4'   U A  13     158.650  48.797 132.875  1.00 80.31           O  
+ANISOU 2024  O4'   U A  13    11722   8751  10040   1279    362    -67       O  
+ATOM   2025  C3'   U A  13     157.341  50.716 133.093  1.00 80.54           C  
+ANISOU 2025  C3'   U A  13    11937   8611  10053   1503    134   -158       C  
+ATOM   2026  O3'   U A  13     156.794  51.879 132.508  1.00 80.73           O  
+ANISOU 2026  O3'   U A  13    12124   8511  10039   1612     -7   -155       O  
+ATOM   2027  C2'   U A  13     156.399  49.526 133.082  1.00 79.63           C  
+ANISOU 2027  C2'   U A  13    11643   8682   9932   1568    200   -250       C  
+ATOM   2028  O2'   U A  13     155.852  49.359 131.784  1.00 81.09           O  
+ANISOU 2028  O2'   U A  13    11857   8893  10061   1618    173   -226       O  
+ATOM   2029  C1'   U A  13     157.378  48.381 133.354  1.00 76.74           C  
+ANISOU 2029  C1'   U A  13    11161   8401   9594   1410    343   -202       C  
+ATOM   2030  N1    U A  13     157.455  48.070 134.809  1.00 74.61           N  
+ANISOU 2030  N1    U A  13    10788   8180   9380   1394    387   -276       N  
+ATOM   2031  C2    U A  13     156.469  47.250 135.338  1.00 73.62           C  
+ANISOU 2031  C2    U A  13    10507   8204   9263   1467    417   -383       C  
+ATOM   2032  O2    U A  13     155.572  46.768 134.679  1.00 73.06           O  
+ANISOU 2032  O2    U A  13    10376   8221   9162   1535    405   -417       O  
+ATOM   2033  N3    U A  13     156.557  46.990 136.679  1.00 72.11           N  
+ANISOU 2033  N3    U A  13    10227   8059   9114   1450    459   -444       N  
+ATOM   2034  C4    U A  13     157.510  47.467 137.550  1.00 69.32           C  
+ANISOU 2034  C4    U A  13     9929   7612   8798   1376    466   -418       C  
+ATOM   2035  O4    U A  13     157.443  47.139 138.732  1.00 63.52           O  
+ANISOU 2035  O4    U A  13     9106   6936   8092   1377    503   -484       O  
+ATOM   2036  C5    U A  13     158.497  48.318 136.953  1.00 71.74           C  
+ANISOU 2036  C5    U A  13    10395   7761   9101   1299    424   -307       C  
+ATOM   2037  C6    U A  13     158.430  48.585 135.640  1.00 73.36           C  
+ANISOU 2037  C6    U A  13    10684   7925   9263   1309    390   -239       C  
+ATOM   2038  P     A A  14     156.137  52.989 133.467  1.00102.51           P  
+ANISOU 2038  P     A A  14    14966  11170  12811   1761   -140   -258       P  
+ATOM   2039  OP1   A A  14     155.869  54.222 132.679  1.00102.30           O  
+ANISOU 2039  OP1   A A  14    15146  10982  12741   1840   -293   -220       O  
+ATOM   2040  OP2   A A  14     156.994  53.077 134.680  1.00 99.00           O  
+ANISOU 2040  OP2   A A  14    14511  10682  12422   1669   -106   -255       O  
+ATOM   2041  O5'   A A  14     154.762  52.328 133.937  1.00 87.39           O  
+ANISOU 2041  O5'   A A  14    12879   9430  10893   1922   -120   -410       O  
+ATOM   2042  C5'   A A  14     153.733  52.027 133.006  1.00 84.19           C  
+ANISOU 2042  C5'   A A  14    12432   9111  10447   2026   -147   -443       C  
+ATOM   2043  C4'   A A  14     152.767  50.995 133.540  1.00 80.99           C  
+ANISOU 2043  C4'   A A  14    11806   8911  10055   2096    -79   -552       C  
+ATOM   2044  O4'   A A  14     153.486  49.848 134.059  1.00 85.17           O  
+ANISOU 2044  O4'   A A  14    12199   9540  10623   1942     63   -525       O  
+ATOM   2045  C3'   A A  14     151.888  51.410 134.706  1.00 76.90           C  
+ANISOU 2045  C3'   A A  14    11228   8444   9546   2257   -127   -683       C  
+ATOM   2046  O3'   A A  14     150.802  52.221 134.324  1.00 75.75           O  
+ANISOU 2046  O3'   A A  14    11144   8275   9361   2452   -256   -749       O  
+ATOM   2047  C2'   A A  14     151.463  50.068 135.279  1.00 79.09           C  
+ANISOU 2047  C2'   A A  14    11267   8936   9848   2221     -8   -736       C  
+ATOM   2048  O2'   A A  14     150.475  49.465 134.453  1.00 76.34           O  
+ANISOU 2048  O2'   A A  14    10819   8710   9475   2281    -18   -758       O  
+ATOM   2049  C1'   A A  14     152.756  49.272 135.129  1.00 80.49           C  
+ANISOU 2049  C1'   A A  14    11434   9095  10053   2005    106   -633       C  
+ATOM   2050  N9    A A  14     153.572  49.306 136.361  1.00 75.45           N  
+ANISOU 2050  N9    A A  14    10784   8426   9456   1927    160   -638       N  
+ATOM   2051  C8    A A  14     154.702  50.035 136.638  1.00 73.51           C  
+ANISOU 2051  C8    A A  14    10683   8019   9230   1841    139   -571       C  
+ATOM   2052  N7    A A  14     155.187  49.819 137.840  1.00 71.55           N  
+ANISOU 2052  N7    A A  14    10379   7789   9019   1787    194   -600       N  
+ATOM   2053  C5    A A  14     154.319  48.885 138.390  1.00 67.81           C  
+ANISOU 2053  C5    A A  14     9713   7504   8546   1840    259   -687       C  
+ATOM   2054  C6    A A  14     154.272  48.235 139.639  1.00 66.95           C  
+ANISOU 2054  C6    A A  14     9467   7508   8462   1820    337   -748       C  
+ATOM   2055  N6    A A  14     155.153  48.429 140.620  1.00 65.64           N  
+ANISOU 2055  N6    A A  14     9339   7273   8326   1747    360   -740       N  
+ATOM   2056  N1    A A  14     153.272  47.361 139.865  1.00 71.36           N  
+ANISOU 2056  N1    A A  14     9846   8258   9012   1872    384   -814       N  
+ATOM   2057  C2    A A  14     152.380  47.155 138.891  1.00 71.01           C  
+ANISOU 2057  C2    A A  14     9760   8282   8941   1941    351   -821       C  
+ATOM   2058  N3    A A  14     152.317  47.697 137.678  1.00 74.04           N  
+ANISOU 2058  N3    A A  14    10263   8570   9299   1974    277   -775       N  
+ATOM   2059  C4    A A  14     153.325  48.565 137.490  1.00 71.97           C  
+ANISOU 2059  C4    A A  14    10182   8122   9042   1921    237   -708       C  
+ATOM   2060  P     C A  15     150.277  53.342 135.332  1.00107.69           P  
+ANISOU 2060  P     C A  15    15261  12260  13395   2638   -363   -855       P  
+ATOM   2061  OP1   C A  15     148.878  53.667 134.941  1.00108.18           O  
+ANISOU 2061  OP1   C A  15    15289  12398  13418   2853   -456   -944       O  
+ATOM   2062  OP2   C A  15     151.312  54.408 135.354  1.00101.58           O  
+ANISOU 2062  OP2   C A  15    14721  11250  12626   2576   -442   -784       O  
+ATOM   2063  O5'   C A  15     150.307  52.611 136.749  1.00 89.81           O  
+ANISOU 2063  O5'   C A  15    12817  10141  11165   2611   -249   -923       O  
+ATOM   2064  C5'   C A  15     149.236  52.727 137.673  1.00 74.20           C  
+ANISOU 2064  C5'   C A  15    10727   8298   9169   2798   -268  -1054       C  
+ATOM   2065  C4'   C A  15     148.695  51.377 138.071  1.00 69.48           C  
+ANISOU 2065  C4'   C A  15     9865   7947   8589   2752   -138  -1085       C  
+ATOM   2066  O4'   C A  15     149.783  50.425 138.234  1.00 67.64           O  
+ANISOU 2066  O4'   C A  15     9582   7718   8399   2524    -14  -1003       O  
+ATOM   2067  C3'   C A  15     147.974  51.346 139.404  1.00 72.03           C  
+ANISOU 2067  C3'   C A  15    10050   8422   8898   2885   -110  -1199       C  
+ATOM   2068  O3'   C A  15     146.640  51.781 139.311  1.00 70.03           O  
+ANISOU 2068  O3'   C A  15     9735   8272   8600   3110   -188  -1290       O  
+ATOM   2069  C2'   C A  15     148.111  49.898 139.838  1.00 75.94           C  
+ANISOU 2069  C2'   C A  15    10331   9095   9427   2725     40  -1173       C  
+ATOM   2070  O2'   C A  15     147.174  49.092 139.146  1.00 87.18           O  
+ANISOU 2070  O2'   C A  15    11593  10686  10846   2736     57  -1174       O  
+ATOM   2071  C1'   C A  15     149.511  49.562 139.324  1.00 73.79           C  
+ANISOU 2071  C1'   C A  15    10166   8676   9194   2502     88  -1057       C  
+ATOM   2072  N1    C A  15     150.564  49.757 140.355  1.00 72.58           N  
+ANISOU 2072  N1    C A  15    10079   8432   9067   2415    128  -1045       N  
+ATOM   2073  C2    C A  15     150.539  49.104 141.605  1.00 66.75           C  
+ANISOU 2073  C2    C A  15     9196   7827   8340   2388    221  -1093       C  
+ATOM   2074  O2    C A  15     149.616  48.332 141.909  1.00 68.62           O  
+ANISOU 2074  O2    C A  15     9236   8272   8566   2430    276  -1142       O  
+ATOM   2075  N3    C A  15     151.539  49.334 142.491  1.00 59.08           N  
+ANISOU 2075  N3    C A  15     8302   6756   7391   2310    244  -1081       N  
+ATOM   2076  C4    C A  15     152.532  50.170 142.174  1.00 64.76           C  
+ANISOU 2076  C4    C A  15     9226   7256   8126   2251    178  -1019       C  
+ATOM   2077  N4    C A  15     153.497  50.371 143.069  1.00 69.70           N  
+ANISOU 2077  N4    C A  15     9918   7788   8777   2169    193  -1005       N  
+ATOM   2078  C5    C A  15     152.588  50.846 140.928  1.00 65.94           C  
+ANISOU 2078  C5    C A  15     9520   7271   8262   2268     86   -961       C  
+ATOM   2079  C6    C A  15     151.597  50.603 140.067  1.00 72.40           C  
+ANISOU 2079  C6    C A  15    10266   8187   9054   2353     68   -979       C  
+ATOM   2080  P     U A  16     146.177  53.015 140.214  1.00 75.89           P  
+ANISOU 2080  P     U A  16    10572   8969   9294   3350   -288  -1404       P  
+ATOM   2081  OP1   U A  16     144.830  53.482 139.789  1.00 86.98           O  
+ANISOU 2081  OP1   U A  16    11928  10470  10651   3584   -382  -1483       O  
+ATOM   2082  OP2   U A  16     147.327  53.959 140.205  1.00 78.88           O  
+ANISOU 2082  OP2   U A  16    11216   9072   9682   3291   -365  -1356       O  
+ATOM   2083  O5'   U A  16     146.006  52.363 141.656  1.00 79.78           O  
+ANISOU 2083  O5'   U A  16    10875   9654   9784   3353   -170  -1466       O  
+ATOM   2084  C5'   U A  16     145.201  51.206 141.817  1.00 73.46           C  
+ANISOU 2084  C5'   U A  16     9801   9121   8988   3325    -65  -1477       C  
+ATOM   2085  C4'   U A  16     145.535  50.472 143.087  1.00 67.22           C  
+ANISOU 2085  C4'   U A  16     8879   8453   8208   3234     61  -1489       C  
+ATOM   2086  O4'   U A  16     146.916  50.047 143.059  1.00 67.38           O  
+ANISOU 2086  O4'   U A  16     8993   8327   8283   2998    120  -1397       O  
+ATOM   2087  C3'   U A  16     145.429  51.287 144.364  1.00 69.91           C  
+ANISOU 2087  C3'   U A  16     9271   8794   8499   3408     37  -1589       C  
+ATOM   2088  O3'   U A  16     144.097  51.403 144.831  1.00 80.05           O  
+ANISOU 2088  O3'   U A  16    10391  10303   9723   3629     32  -1687       O  
+ATOM   2089  C2'   U A  16     146.343  50.532 145.319  1.00 63.96           C  
+ANISOU 2089  C2'   U A  16     8469   8057   7777   3223    156  -1553       C  
+ATOM   2090  O2'   U A  16     145.666  49.408 145.864  1.00 69.09           O  
+ANISOU 2090  O2'   U A  16     8853   8978   8421   3183    275  -1562       O  
+ATOM   2091  C1'   U A  16     147.442  50.040 144.370  1.00 69.45           C  
+ANISOU 2091  C1'   U A  16     9253   8594   8541   2976    177  -1430       C  
+ATOM   2092  N1    U A  16     148.661  50.881 144.415  1.00 68.51           N  
+ANISOU 2092  N1    U A  16     9381   8208   8443   2916    114  -1394       N  
+ATOM   2093  C2    U A  16     149.485  50.701 145.499  1.00 72.40           C  
+ANISOU 2093  C2    U A  16     9888   8669   8950   2825    174  -1393       C  
+ATOM   2094  O2    U A  16     149.235  49.911 146.387  1.00 76.94           O  
+ANISOU 2094  O2    U A  16    10294   9423   9519   2801    276  -1423       O  
+ATOM   2095  N3    U A  16     150.612  51.480 145.512  1.00 71.71           N  
+ANISOU 2095  N3    U A  16    10023   8336   8886   2758    104  -1351       N  
+ATOM   2096  C4    U A  16     150.999  52.406 144.572  1.00 69.83           C  
+ANISOU 2096  C4    U A  16     9992   7886   8656   2763    -15  -1303       C  
+ATOM   2097  O4    U A  16     152.052  53.017 144.740  1.00 73.76           O  
+ANISOU 2097  O4    U A  16    10668   8180   9178   2679    -69  -1256       O  
+ATOM   2098  C5    U A  16     150.100  52.533 143.470  1.00 68.28           C  
+ANISOU 2098  C5    U A  16     9773   7734   8437   2862    -67  -1306       C  
+ATOM   2099  C6    U A  16     148.991  51.782 143.431  1.00 66.59           C  
+ANISOU 2099  C6    U A  16     9342   7756   8202   2935     -3  -1353       C  
+ATOM   2100  P     A A  17     143.609  52.766 145.516  1.00 89.53           P  
+ANISOU 2100  P     A A  17    11717  11458  10843   3929    -78  -1813       P  
+ATOM   2101  OP1   A A  17     142.149  52.681 145.777  1.00 92.21           O  
+ANISOU 2101  OP1   A A  17    11837  12077  11121   4144    -66  -1897       O  
+ATOM   2102  OP2   A A  17     144.194  53.893 144.741  1.00 88.06           O  
+ANISOU 2102  OP2   A A  17    11824  10971  10665   3964   -229  -1797       O  
+ATOM   2103  O5'   A A  17     144.370  52.780 146.904  1.00 79.46           O  
+ANISOU 2103  O5'   A A  17    10484  10154   9553   3891    -15  -1842       O  
+ATOM   2104  C5'   A A  17     144.276  51.687 147.803  1.00 76.98           C  
+ANISOU 2104  C5'   A A  17     9946  10061   9239   3789    137  -1832       C  
+ATOM   2105  C4'   A A  17     145.218  51.894 148.955  1.00 77.84           C  
+ANISOU 2105  C4'   A A  17    10169  10066   9340   3744    165  -1852       C  
+ATOM   2106  O4'   A A  17     146.565  51.989 148.418  1.00 74.05           O  
+ANISOU 2106  O4'   A A  17     9886   9315   8935   3533    131  -1759       O  
+ATOM   2107  C3'   A A  17     144.959  53.182 149.749  1.00 85.14           C  
+ANISOU 2107  C3'   A A  17    11250  10921  10179   4020     59  -1976       C  
+ATOM   2108  O3'   A A  17     144.974  52.955 151.155  1.00 90.43           O  
+ANISOU 2108  O3'   A A  17    11843  11720  10796   4067    142  -2034       O  
+ATOM   2109  C2'   A A  17     146.113  54.106 149.354  1.00 82.55           C  
+ANISOU 2109  C2'   A A  17    11236  10239   9891   3954    -69  -1941       C  
+ATOM   2110  O2'   A A  17     146.561  54.934 150.404  1.00 87.22           O  
+ANISOU 2110  O2'   A A  17    12001  10703  10434   4067   -135  -2016       O  
+ATOM   2111  C1'   A A  17     147.213  53.130 148.936  1.00 78.02           C  
+ANISOU 2111  C1'   A A  17    10636   9593   9414   3622     23  -1805       C  
+ATOM   2112  N9    A A  17     148.083  53.694 147.903  1.00 73.32           N  
+ANISOU 2112  N9    A A  17    10261   8722   8875   3508    -78  -1722       N  
+ATOM   2113  C8    A A  17     147.727  54.051 146.631  1.00 74.16           C  
+ANISOU 2113  C8    A A  17    10426   8759   8991   3542   -160  -1690       C  
+ATOM   2114  N7    A A  17     148.706  54.588 145.944  1.00 71.96           N  
+ANISOU 2114  N7    A A  17    10361   8224   8755   3420   -242  -1607       N  
+ATOM   2115  C5    A A  17     149.766  54.600 146.837  1.00 67.06           C  
+ANISOU 2115  C5    A A  17     9822   7498   8160   3301   -216  -1587       C  
+ATOM   2116  C6    A A  17     151.092  55.044 146.714  1.00 71.87           C  
+ANISOU 2116  C6    A A  17    10633   7856   8819   3134   -273  -1501       C  
+ATOM   2117  N6    A A  17     151.581  55.575 145.591  1.00 77.18           N  
+ANISOU 2117  N6    A A  17    11467   8339   9521   3054   -363  -1411       N  
+ATOM   2118  N1    A A  17     151.907  54.913 147.788  1.00 73.09           N  
+ANISOU 2118  N1    A A  17    10814   7968   8990   3045   -235  -1503       N  
+ATOM   2119  C2    A A  17     151.409  54.372 148.914  1.00 73.82           C  
+ANISOU 2119  C2    A A  17    10748   8257   9044   3125   -142  -1588       C  
+ATOM   2120  N3    A A  17     150.175  53.919 149.148  1.00 71.76           N  
+ANISOU 2120  N3    A A  17    10288   8248   8730   3279    -75  -1668       N  
+ATOM   2121  C4    A A  17     149.397  54.059 148.052  1.00 67.57           C  
+ANISOU 2121  C4    A A  17     9728   7755   8191   3358   -118  -1662       C  
+ATOM   2122  P     A A  18     143.923  53.753 152.070  1.00 96.38           P  
+ANISOU 2122  P     A A  18    12571  12627  11424   4414    101  -2183       P  
+ATOM   2123  OP1   A A  18     142.568  53.297 151.687  1.00104.20           O  
+ANISOU 2123  OP1   A A  18    13299  13906  12385   4490    149  -2182       O  
+ATOM   2124  OP2   A A  18     144.252  55.205 152.033  1.00 87.16           O  
+ANISOU 2124  OP2   A A  18    11704  11186  10226   4539    -84  -2228       O  
+ATOM   2125  O5'   A A  18     144.216  53.246 153.545  1.00 92.00           O  
+ANISOU 2125  O5'   A A  18    11930  12198  10828   4352    216  -2195       O  
+ATOM   2126  C5'   A A  18     144.020  51.890 153.905  1.00 80.68           C  
+ANISOU 2126  C5'   A A  18    10229  11016   9409   4210    389  -2148       C  
+ATOM   2127  C4'   A A  18     144.683  51.600 155.223  1.00 82.03           C  
+ANISOU 2127  C4'   A A  18    10417  11199   9553   4138    465  -2157       C  
+ATOM   2128  O4'   A A  18     146.125  51.627 155.056  1.00 93.83           O  
+ANISOU 2128  O4'   A A  18    12117  12401  11133   3924    428  -2091       O  
+ATOM   2129  C3'   A A  18     144.422  52.620 156.316  1.00 81.28           C  
+ANISOU 2129  C3'   A A  18    10438  11089   9357   4310    388  -2232       C  
+ATOM   2130  O3'   A A  18     143.170  52.445 156.955  1.00 79.41           O  
+ANISOU 2130  O3'   A A  18     9984  11160   9028   4422    448  -2252       O  
+ATOM   2131  C2'   A A  18     145.627  52.443 157.230  1.00 89.35           C  
+ANISOU 2131  C2'   A A  18    11585  11971  10393   4192    421  -2229       C  
+ATOM   2132  O2'   A A  18     145.479  51.279 158.033  1.00 92.35           O  
+ANISOU 2132  O2'   A A  18    11739  12595  10755   4077    587  -2195       O  
+ATOM   2133  C1'   A A  18     146.733  52.172 156.212  1.00 91.61           C  
+ANISOU 2133  C1'   A A  18    11991  12015  10801   3994    398  -2156       C  
+ATOM   2134  N9    A A  18     147.489  53.388 155.833  1.00 88.92           N  
+ANISOU 2134  N9    A A  18    11965  11336  10485   4042    224  -2175       N  
+ATOM   2135  C8    A A  18     147.548  53.985 154.602  1.00 84.65           C  
+ANISOU 2135  C8    A A  18    11552  10617   9995   4041    109  -2141       C  
+ATOM   2136  N7    A A  18     148.325  55.039 154.541  1.00 80.31           N  
+ANISOU 2136  N7    A A  18    11288   9769   9458   4066    -43  -2153       N  
+ATOM   2137  C5    A A  18     148.831  55.149 155.826  1.00 80.53           C  
+ANISOU 2137  C5    A A  18    11386   9768   9443   4088    -32  -2205       C  
+ATOM   2138  C6    A A  18     149.725  56.072 156.426  1.00 76.57           C  
+ANISOU 2138  C6    A A  18    11161   9000   8933   4114   -165  -2239       C  
+ATOM   2139  N6    A A  18     150.290  57.096 155.781  1.00 77.06           N  
+ANISOU 2139  N6    A A  18    11485   8762   9031   4111   -341  -2217       N  
+ATOM   2140  N1    A A  18     150.024  55.898 157.735  1.00 71.49           N  
+ANISOU 2140  N1    A A  18    10508   8412   8242   4107   -118  -2274       N  
+ATOM   2141  C2    A A  18     149.459  54.864 158.391  1.00 77.53           C  
+ANISOU 2141  C2    A A  18    11012   9479   8967   4093     56  -2282       C  
+ATOM   2142  N3    A A  18     148.612  53.930 157.939  1.00 79.52           N  
+ANISOU 2142  N3    A A  18    10995   9998   9222   4076    193  -2256       N  
+ATOM   2143  C4    A A  18     148.330  54.132 156.633  1.00 84.73           C  
+ANISOU 2143  C4    A A  18    11666  10595   9933   4076    137  -2220       C  
+ATOM   2144  P     A A  19     142.255  53.727 157.265  1.00 97.39           P  
+ANISOU 2144  P     A A  19    12344  13463  11195   4689    320  -2335       P  
+ATOM   2145  OP1   A A  19     141.007  53.250 157.918  1.00 98.06           O  
+ANISOU 2145  OP1   A A  19    12158  13907  11194   4764    419  -2335       O  
+ATOM   2146  OP2   A A  19     142.153  54.550 156.026  1.00102.33           O  
+ANISOU 2146  OP2   A A  19    13119  13903  11857   4776    174  -2349       O  
+ATOM   2147  O5'   A A  19     143.105  54.540 158.342  1.00 95.07           O  
+ANISOU 2147  O5'   A A  19    12300  12972  10852   4741    243  -2389       O  
+ATOM   2148  C5'   A A  19     143.400  53.970 159.610  1.00 91.67           C  
+ANISOU 2148  C5'   A A  19    11799  12653  10379   4673    351  -2386       C  
+ATOM   2149  C4'   A A  19     144.360  54.824 160.407  1.00 87.11           C  
+ANISOU 2149  C4'   A A  19    11500  11826   9772   4712    246  -2437       C  
+ATOM   2150  O4'   A A  19     145.652  54.878 159.749  1.00 93.17           O  
+ANISOU 2150  O4'   A A  19    12462  12285  10653   4558    189  -2402       O  
+ATOM   2151  C3'   A A  19     143.972  56.279 160.580  1.00 85.47           C  
+ANISOU 2151  C3'   A A  19    11493  11508   9475   4950     66  -2519       C  
+ATOM   2152  O3'   A A  19     143.011  56.459 161.605  1.00 84.29           O  
+ANISOU 2152  O3'   A A  19    11233  11603   9191   5122     97  -2570       O  
+ATOM   2153  C2'   A A  19     145.314  56.944 160.874  1.00 87.26           C  
+ANISOU 2153  C2'   A A  19    12025  11393   9736   4891    -53  -2533       C  
+ATOM   2154  O2'   A A  19     145.682  56.749 162.232  1.00 87.28           O  
+ANISOU 2154  O2'   A A  19    12038  11446   9679   4879     -1  -2556       O  
+ATOM   2155  C1'   A A  19     146.261  56.131 159.991  1.00 87.27           C  
+ANISOU 2155  C1'   A A  19    12018  11259   9882   4650     10  -2452       C  
+ATOM   2156  N9    A A  19     146.519  56.793 158.700  1.00 80.17           N  
+ANISOU 2156  N9    A A  19    11284  10124   9054   4649   -123  -2433       N  
+ATOM   2157  C8    A A  19     145.953  56.511 157.485  1.00 82.04           C  
+ANISOU 2157  C8    A A  19    11408  10425   9339   4641   -104  -2399       C  
+ATOM   2158  N7    A A  19     146.382  57.281 156.513  1.00 80.81           N  
+ANISOU 2158  N7    A A  19    11463  10006   9235   4642   -250  -2384       N  
+ATOM   2159  C5    A A  19     147.292  58.129 157.127  1.00 76.33           C  
+ANISOU 2159  C5    A A  19    11162   9183   8656   4639   -377  -2406       C  
+ATOM   2160  C6    A A  19     148.096  59.183 156.642  1.00 80.63           C  
+ANISOU 2160  C6    A A  19    12011   9386   9239   4621   -567  -2391       C  
+ATOM   2161  N6    A A  19     148.129  59.604 155.372  1.00 78.31           N  
+ANISOU 2161  N6    A A  19    11820   8934   9000   4605   -662  -2350       N  
+ATOM   2162  N1    A A  19     148.888  59.813 157.534  1.00 84.90           N  
+ANISOU 2162  N1    A A  19    12757   9744   9757   4609   -665  -2413       N  
+ATOM   2163  C2    A A  19     148.866  59.408 158.812  1.00 84.51           C  
+ANISOU 2163  C2    A A  19    12616   9846   9647   4629   -574  -2453       C  
+ATOM   2164  N3    A A  19     148.155  58.439 159.382  1.00 82.96           N  
+ANISOU 2164  N3    A A  19    12147   9968   9407   4650   -392  -2469       N  
+ATOM   2165  C4    A A  19     147.381  57.833 158.476  1.00 77.20           C  
+ANISOU 2165  C4    A A  19    11213   9413   8704   4649   -302  -2440       C  
+ATOM   2166  P     C A  20     141.763  57.448 161.391  1.00 96.17           P  
+ANISOU 2166  P     C A  20    12739  13212  10590   5391    -14  -2637       P  
+ATOM   2167  OP1   C A  20     141.104  57.610 162.718  1.00 92.89           O  
+ANISOU 2167  OP1   C A  20    12251  13013  10029   5549     22  -2690       O  
+ATOM   2168  OP2   C A  20     140.975  56.966 160.223  1.00 98.64           O  
+ANISOU 2168  OP2   C A  20    12858  13663  10958   5366     32  -2594       O  
+ATOM   2169  O5'   C A  20     142.446  58.835 160.999  1.00 87.04           O  
+ANISOU 2169  O5'   C A  20    11939  11692   9440   5479   -241  -2686       O  
+ATOM   2170  C5'   C A  20     143.276  59.523 161.920  1.00 86.88           C  
+ANISOU 2170  C5'   C A  20    12159  11473   9376   5510   -340  -2729       C  
+ATOM   2171  C4'   C A  20     144.056  60.622 161.244  1.00 85.73           C  
+ANISOU 2171  C4'   C A  20    12334  10960   9278   5514   -549  -2739       C  
+ATOM   2172  O4'   C A  20     144.925  60.064 160.232  1.00 84.72           O  
+ANISOU 2172  O4'   C A  20    12228  10661   9303   5284   -517  -2657       O  
+ATOM   2173  C3'   C A  20     143.237  61.648 160.488  1.00 87.01           C  
+ANISOU 2173  C3'   C A  20    12584  11088   9388   5710   -704  -2784       C  
+ATOM   2174  O3'   C A  20     142.641  62.616 161.336  1.00 83.15           O  
+ANISOU 2174  O3'   C A  20    12195  10649   8747   5957   -817  -2876       O  
+ATOM   2175  C2'   C A  20     144.251  62.214 159.500  1.00 83.41           C  
+ANISOU 2175  C2'   C A  20    12386  10268   9039   5588   -851  -2741       C  
+ATOM   2176  O2'   C A  20     145.126  63.127 160.137  1.00 92.65           O  
+ANISOU 2176  O2'   C A  20    13845  11175  10181   5601  -1010  -2769       O  
+ATOM   2177  C1'   C A  20     145.058  60.973 159.159  1.00 83.40           C  
+ANISOU 2177  C1'   C A  20    12258  10256   9172   5320   -689  -2652       C  
+ATOM   2178  N1    C A  20     144.576  60.318 157.930  1.00 85.94           N  
+ANISOU 2178  N1    C A  20    12404  10677   9570   5254   -608  -2600       N  
+ATOM   2179  C2    C A  20     144.949  60.824 156.675  1.00 83.25           C  
+ANISOU 2179  C2    C A  20    12228  10096   9307   5205   -730  -2561       C  
+ATOM   2180  O2    C A  20     145.673  61.826 156.589  1.00 78.11           O  
+ANISOU 2180  O2    C A  20    11865   9150   8662   5206   -907  -2564       O  
+ATOM   2181  N3    C A  20     144.506  60.192 155.567  1.00 88.64           N  
+ANISOU 2181  N3    C A  20    12751  10874  10054   5150   -657  -2514       N  
+ATOM   2182  C4    C A  20     143.727  59.110 155.677  1.00 90.59           C  
+ANISOU 2182  C4    C A  20    12687  11439  10295   5136   -478  -2503       C  
+ATOM   2183  N4    C A  20     143.303  58.510 154.560  1.00 91.47           N  
+ANISOU 2183  N4    C A  20    12650  11633  10470   5081   -422  -2456       N  
+ATOM   2184  C5    C A  20     143.336  58.583 156.941  1.00 89.60           C  
+ANISOU 2184  C5    C A  20    12387  11562  10094   5171   -353  -2533       C  
+ATOM   2185  C6    C A  20     143.782  59.211 158.035  1.00 88.91           C  
+ANISOU 2185  C6    C A  20    12463  11379   9939   5233   -420  -2582       C  
+ATOM   2186  P     C A  21     141.222  63.246 160.953  1.00 88.40           P  
+ANISOU 2186  P     C A  21    12788  11493   9306   6213   -885  -2938       P  
+ATOM   2187  OP1   C A  21     140.778  64.082 162.101  1.00 94.12           O  
+ANISOU 2187  OP1   C A  21    13610  12285   9865   6453   -975  -3032       O  
+ATOM   2188  OP2   C A  21     140.337  62.151 160.485  1.00 88.24           O  
+ANISOU 2188  OP2   C A  21    12428  11779   9319   6164   -699  -2893       O  
+ATOM   2189  O5'   C A  21     141.555  64.189 159.710  1.00 97.28           O  
+ANISOU 2189  O5'   C A  21    14159  12313  10490   6215  -1084  -2930       O  
+ATOM   2190  C5'   C A  21     142.475  65.267 159.834  1.00 95.23           C  
+ANISOU 2190  C5'   C A  21    14243  11714  10225   6218  -1289  -2949       C  
+ATOM   2191  C4'   C A  21     142.618  66.044 158.545  1.00 91.89           C  
+ANISOU 2191  C4'   C A  21    14010  11047   9856   6210  -1460  -2927       C  
+ATOM   2192  O4'   C A  21     143.318  65.245 157.561  1.00 85.50           O  
+ANISOU 2192  O4'   C A  21    13145  10134   9208   5958  -1371  -2825       O  
+ATOM   2193  C3'   C A  21     141.325  66.430 157.849  1.00 92.61           C  
+ANISOU 2193  C3'   C A  21    14014  11295   9880   6410  -1507  -2973       C  
+ATOM   2194  O3'   C A  21     140.705  67.570 158.408  1.00 93.64           O  
+ANISOU 2194  O3'   C A  21    14290  11434   9855   6675  -1671  -3073       O  
+ATOM   2195  C2'   C A  21     141.759  66.611 156.397  1.00 91.81           C  
+ANISOU 2195  C2'   C A  21    14029  10960   9894   6279  -1592  -2904       C  
+ATOM   2196  O2'   C A  21     142.377  67.873 156.196  1.00 94.53           O  
+ANISOU 2196  O2'   C A  21    14722  10977  10220   6307  -1834  -2916       O  
+ATOM   2197  C1'   C A  21     142.831  65.534 156.266  1.00 85.74           C  
+ANISOU 2197  C1'   C A  21    13186  10119   9270   5990  -1442  -2806       C  
+ATOM   2198  N1    C A  21     142.319  64.286 155.654  1.00 84.57           N  
+ANISOU 2198  N1    C A  21    12729  10209   9196   5898  -1241  -2756       N  
+ATOM   2199  C2    C A  21     141.994  64.261 154.291  1.00 85.36           C  
+ANISOU 2199  C2    C A  21    12805  10269   9357   5874  -1272  -2716       C  
+ATOM   2200  O2    C A  21     142.109  65.294 153.616  1.00 87.72           O  
+ANISOU 2200  O2    C A  21    13342  10341   9646   5932  -1464  -2722       O  
+ATOM   2201  N3    C A  21     141.547  63.114 153.730  1.00 84.71           N  
+ANISOU 2201  N3    C A  21    12447  10398   9340   5786  -1100  -2668       N  
+ATOM   2202  C4    C A  21     141.428  62.013 154.479  1.00 83.65           C  
+ANISOU 2202  C4    C A  21    12064  10507   9212   5713   -902  -2656       C  
+ATOM   2203  N4    C A  21     140.991  60.889 153.900  1.00 80.86           N  
+ANISOU 2203  N4    C A  21    11444  10356   8921   5617   -747  -2604       N  
+ATOM   2204  C5    C A  21     141.761  62.010 155.865  1.00 86.67           C  
+ANISOU 2204  C5    C A  21    12465  10934   9532   5729   -862  -2692       C  
+ATOM   2205  C6    C A  21     142.199  63.154 156.402  1.00 85.02           C  
+ANISOU 2205  C6    C A  21    12532  10514   9259   5826  -1033  -2743       C  
+ATOM   2206  P     A A  22     139.108  67.692 158.350  1.00 95.74           P  
+ANISOU 2206  P     A A  22    14360  12016  10001   6935  -1647  -3147       P  
+ATOM   2207  OP1   A A  22     138.713  68.813 159.244  1.00104.94           O  
+ANISOU 2207  OP1   A A  22    15700  13178  10995   7198  -1807  -3254       O  
+ATOM   2208  OP2   A A  22     138.545  66.329 158.559  1.00 91.45           O  
+ANISOU 2208  OP2   A A  22    13446  11810   9490   6858  -1390  -3108       O  
+ATOM   2209  O5'   A A  22     138.810  68.079 156.833  1.00 92.75           O  
+ANISOU 2209  O5'   A A  22    14044  11516   9682   6933  -1753  -3122       O  
+ATOM   2210  C5'   A A  22     139.446  69.193 156.223  1.00 93.41           C  
+ANISOU 2210  C5'   A A  22    14464  11248   9778   6927  -1986  -3121       C  
+ATOM   2211  C4'   A A  22     139.095  69.280 154.761  1.00 94.89           C  
+ANISOU 2211  C4'   A A  22    14648  11374  10033   6900  -2038  -3083       C  
+ATOM   2212  O4'   A A  22     139.761  68.218 154.032  1.00 96.04           O  
+ANISOU 2212  O4'   A A  22    14673  11477  10342   6630  -1891  -2972       O  
+ATOM   2213  C3'   A A  22     137.624  69.088 154.439  1.00 94.89           C  
+ANISOU 2213  C3'   A A  22    14409  11684   9962   7092  -1979  -3135       C  
+ATOM   2214  O3'   A A  22     136.866  70.269 154.621  1.00 97.59           O  
+ANISOU 2214  O3'   A A  22    14897  12027  10154   7368  -2164  -3239       O  
+ATOM   2215  C2'   A A  22     137.647  68.588 152.999  1.00 94.77           C  
+ANISOU 2215  C2'   A A  22    14321  11611  10076   6942  -1943  -3053       C  
+ATOM   2216  O2'   A A  22     137.772  69.674 152.093  1.00 95.29           O  
+ANISOU 2216  O2'   A A  22    14662  11411  10133   6993  -2167  -3060       O  
+ATOM   2217  C1'   A A  22     138.939  67.771 152.973  1.00 91.78           C  
+ANISOU 2217  C1'   A A  22    13949  11082   9840   6646  -1832  -2950       C  
+ATOM   2218  N9    A A  22     138.709  66.323 153.135  1.00 90.38           N  
+ANISOU 2218  N9    A A  22    13432  11178   9728   6525  -1579  -2904       N  
+ATOM   2219  C8    A A  22     138.894  65.568 154.270  1.00 91.07           C  
+ANISOU 2219  C8    A A  22    13363  11434   9804   6470  -1418  -2904       C  
+ATOM   2220  N7    A A  22     138.622  64.299 154.104  1.00 90.66           N  
+ANISOU 2220  N7    A A  22    13017  11608   9820   6348  -1215  -2850       N  
+ATOM   2221  C5    A A  22     138.238  64.211 152.768  1.00 84.86           C  
+ANISOU 2221  C5    A A  22    12243  10852   9149   6327  -1246  -2814       C  
+ATOM   2222  C6    A A  22     137.831  63.121 151.963  1.00 90.62           C  
+ANISOU 2222  C6    A A  22    12716  11752   9963   6216  -1106  -2751       C  
+ATOM   2223  N6    A A  22     137.739  61.864 152.425  1.00 81.93           N  
+ANISOU 2223  N6    A A  22    11340  10890   8900   6094   -899  -2710       N  
+ATOM   2224  N1    A A  22     137.523  63.371 150.662  1.00 83.42           N  
+ANISOU 2224  N1    A A  22    11849  10754   9093   6233  -1195  -2730       N  
+ATOM   2225  C2    A A  22     137.621  64.633 150.220  1.00 93.53           C  
+ANISOU 2225  C2    A A  22    13412  11793  10331   6346  -1407  -2767       C  
+ATOM   2226  N3    A A  22     137.987  65.737 150.881  1.00 95.17           N  
+ANISOU 2226  N3    A A  22    13878  11825  10459   6450  -1558  -2824       N  
+ATOM   2227  C4    A A  22     138.291  65.451 152.160  1.00 88.95           C  
+ANISOU 2227  C4    A A  22    13038  11127   9633   6436  -1467  -2846       C  
+ATOM   2228  P     U A  23     135.348  70.167 155.127  1.00 99.07           P  
+ANISOU 2228  P     U A  23    14835  12604  10204   7632  -2091  -3328       P  
+ATOM   2229  OP1   U A  23     134.862  71.549 155.414  1.00103.55           O  
+ANISOU 2229  OP1   U A  23    15635  13098  10610   7910  -2318  -3440       O  
+ATOM   2230  OP2   U A  23     135.317  69.154 156.215  1.00 98.16           O  
+ANISOU 2230  OP2   U A  23    14470  12744  10081   7575  -1871  -3313       O  
+ATOM   2231  O5'   U A  23     134.552  69.627 153.849  1.00 98.42           O  
+ANISOU 2231  O5'   U A  23    14544  12657  10192   7605  -2025  -3289       O  
+ATOM   2232  C5'   U A  23     134.096  70.530 152.850  1.00 99.95           C  
+ANISOU 2232  C5'   U A  23    14897  12724  10356   7730  -2213  -3325       C  
+ATOM   2233  C4'   U A  23     133.669  69.825 151.581  1.00 98.55           C  
+ANISOU 2233  C4'   U A  23    14535  12624  10286   7629  -2134  -3259       C  
+ATOM   2234  O4'   U A  23     134.649  68.822 151.201  1.00 95.25           O  
+ANISOU 2234  O4'   U A  23    14052  12109  10031   7329  -1996  -3143       O  
+ATOM   2235  C3'   U A  23     132.363  69.050 151.635  1.00 99.22           C  
+ANISOU 2235  C3'   U A  23    14252  13112  10335   7732  -1976  -3280       C  
+ATOM   2236  O3'   U A  23     131.212  69.873 151.557  1.00102.30           O  
+ANISOU 2236  O3'   U A  23    14652  13627  10590   8014  -2098  -3379       O  
+ATOM   2237  C2'   U A  23     132.508  68.066 150.473  1.00 98.49           C  
+ANISOU 2237  C2'   U A  23    14002  13019  10400   7515  -1869  -3176       C  
+ATOM   2238  O2'   U A  23     132.207  68.676 149.225  1.00103.16           O  
+ANISOU 2238  O2'   U A  23    14723  13466  11007   7571  -2023  -3181       O  
+ATOM   2239  C1'   U A  23     134.008  67.764 150.513  1.00 94.03           C  
+ANISOU 2239  C1'   U A  23    13595  12181   9952   7256  -1840  -3093       C  
+ATOM   2240  N1    U A  23     134.299  66.491 151.206  1.00 93.05           N  
+ANISOU 2240  N1    U A  23    13220  12244   9889   7089  -1608  -3036       N  
+ATOM   2241  C2    U A  23     133.973  65.319 150.558  1.00 90.31           C  
+ANISOU 2241  C2    U A  23    12599  12075   9639   6953  -1450  -2965       C  
+ATOM   2242  O2    U A  23     133.465  65.287 149.446  1.00 90.37           O  
+ANISOU 2242  O2    U A  23    12561  12091   9685   6968  -1493  -2947       O  
+ATOM   2243  N3    U A  23     134.272  64.184 151.269  1.00 88.61           N  
+ANISOU 2243  N3    U A  23    12171  12025   9470   6798  -1248  -2915       N  
+ATOM   2244  C4    U A  23     134.843  64.104 152.528  1.00 88.41           C  
+ANISOU 2244  C4    U A  23    12179  12007   9407   6767  -1186  -2929       C  
+ATOM   2245  O4    U A  23     135.052  63.005 153.043  1.00 86.83           O  
+ANISOU 2245  O4    U A  23    11773  11965   9255   6616  -1001  -2876       O  
+ATOM   2246  C5    U A  23     135.136  65.365 153.130  1.00 91.13           C  
+ANISOU 2246  C5    U A  23    12811  12162   9651   6922  -1359  -3006       C  
+ATOM   2247  C6    U A  23     134.861  66.483 152.459  1.00 92.96           C  
+ANISOU 2247  C6    U A  23    13255  12231   9835   7072  -1561  -3055       C  
+ATOM   2248  P     C A  24     129.908  69.487 152.411  1.00104.31           P  
+ANISOU 2248  P     C A  24    14593  14315  10723   8211  -1969  -3441       P  
+ATOM   2249  OP1   C A  24     128.911  70.571 152.227  1.00109.88           O  
+ANISOU 2249  OP1   C A  24    15393  15070  11287   8509  -2142  -3551       O  
+ATOM   2250  OP2   C A  24     130.352  69.166 153.789  1.00104.04           O  
+ANISOU 2250  OP2   C A  24    14520  14366  10645   8182  -1859  -3445       O  
+ATOM   2251  O5'   C A  24     129.371  68.148 151.719  1.00108.50           O  
+ANISOU 2251  O5'   C A  24    14764  15091  11370   8056  -1772  -3354       O  
+ATOM   2252  C5'   C A  24     128.776  68.181 150.428  1.00104.44           C  
+ANISOU 2252  C5'   C A  24    14204  14574  10904   8075  -1834  -3342       C  
+ATOM   2253  C4'   C A  24     128.580  66.806 149.820  1.00103.55           C  
+ANISOU 2253  C4'   C A  24    13781  14639  10923   7871  -1648  -3241       C  
+ATOM   2254  O4'   C A  24     129.825  66.055 149.782  1.00104.24           O  
+ANISOU 2254  O4'   C A  24    13906  14554  11145   7589  -1551  -3145       O  
+ATOM   2255  C3'   C A  24     127.625  65.840 150.501  1.00104.29           C  
+ANISOU 2255  C3'   C A  24    13488  15155  10982   7892  -1451  -3228       C  
+ATOM   2256  O3'   C A  24     126.254  66.159 150.339  1.00109.15           O  
+ANISOU 2256  O3'   C A  24    13953  16021  11499   8119  -1490  -3292       O  
+ATOM   2257  C2'   C A  24     128.012  64.517 149.849  1.00102.06           C  
+ANISOU 2257  C2'   C A  24    13010  14904  10864   7609  -1299  -3108       C  
+ATOM   2258  O2'   C A  24     127.495  64.439 148.527  1.00101.60           O  
+ANISOU 2258  O2'   C A  24    12900  14834  10868   7607  -1360  -3086       O  
+ATOM   2259  C1'   C A  24     129.531  64.665 149.758  1.00100.55           C  
+ANISOU 2259  C1'   C A  24    13098  14346  10759   7428  -1342  -3066       C  
+ATOM   2260  N1    C A  24     130.198  63.977 150.886  1.00 98.46           N  
+ANISOU 2260  N1    C A  24    12757  14144  10508   7291  -1188  -3030       N  
+ATOM   2261  C2    C A  24     130.443  62.593 150.783  1.00 93.13           C  
+ANISOU 2261  C2    C A  24    11840  13598   9946   7052   -999  -2931       C  
+ATOM   2262  O2    C A  24     130.126  61.968 149.757  1.00 94.14           O  
+ANISOU 2262  O2    C A  24    11825  13781  10163   6960   -968  -2875       O  
+ATOM   2263  N3    C A  24     131.039  61.960 151.812  1.00 90.71           N  
+ANISOU 2263  N3    C A  24    11467  13350   9648   6926   -862  -2899       N  
+ATOM   2264  C4    C A  24     131.369  62.645 152.909  1.00 91.90           C  
+ANISOU 2264  C4    C A  24    11776  13439   9701   7033   -904  -2961       C  
+ATOM   2265  N4    C A  24     131.956  61.977 153.900  1.00 93.84           N  
+ANISOU 2265  N4    C A  24    11954  13744   9958   6902   -768  -2926       N  
+ATOM   2266  C5    C A  24     131.126  64.039 153.048  1.00 94.31           C  
+ANISOU 2266  C5    C A  24    12326  13618   9889   7277  -1097  -3061       C  
+ATOM   2267  C6    C A  24     130.535  64.657 152.021  1.00 97.41           C  
+ANISOU 2267  C6    C A  24    12784  13954  10273   7398  -1232  -3093       C  
+ATOM   2268  P     C A  25     125.191  65.710 151.465  1.00115.83           P  
+ANISOU 2268  P     C A  25    14486  17295  12229   8246  -1343  -3318       P  
+ATOM   2269  OP1   C A  25     123.867  66.296 151.121  1.00111.77           O  
+ANISOU 2269  OP1   C A  25    13886  16973  11610   8503  -1431  -3394       O  
+ATOM   2270  OP2   C A  25     125.804  65.997 152.788  1.00117.14           O  
+ANISOU 2270  OP2   C A  25    14775  17421  12311   8280  -1320  -3352       O  
+ATOM   2271  O5'   C A  25     125.118  64.120 151.349  1.00104.02           O  
+ANISOU 2271  O5'   C A  25    12642  16023  10857   7987  -1120  -3194       O  
+ATOM   2272  C5'   C A  25     124.651  63.489 150.167  1.00105.07           C  
+ANISOU 2272  C5'   C A  25    12603  16222  11096   7888  -1100  -3133       C  
+ATOM   2273  C4'   C A  25     124.881  61.992 150.189  1.00105.91           C  
+ANISOU 2273  C4'   C A  25    12437  16480  11323   7611   -901  -3012       C  
+ATOM   2274  O4'   C A  25     126.296  61.672 150.330  1.00106.75           O  
+ANISOU 2274  O4'   C A  25    12713  16324  11524   7396   -863  -2960       O  
+ATOM   2275  C3'   C A  25     124.229  61.220 151.323  1.00106.60           C  
+ANISOU 2275  C3'   C A  25    12215  16941  11345   7600   -722  -2982       C  
+ATOM   2276  O3'   C A  25     122.834  61.038 151.138  1.00112.89           O  
+ANISOU 2276  O3'   C A  25    12738  18066  12089   7721   -697  -2986       O  
+ATOM   2277  C2'   C A  25     125.030  59.921 151.323  1.00104.10           C  
+ANISOU 2277  C2'   C A  25    11776  16611  11166   7283   -567  -2865       C  
+ATOM   2278  O2'   C A  25     124.629  59.087 150.246  1.00101.50           O  
+ANISOU 2278  O2'   C A  25    11248  16368  10950   7146   -534  -2787       O  
+ATOM   2279  C1'   C A  25     126.436  60.439 151.014  1.00101.38           C  
+ANISOU 2279  C1'   C A  25    11785  15848  10888   7202   -663  -2877       C  
+ATOM   2280  N1    C A  25     127.250  60.621 152.244  1.00 98.40           N  
+ANISOU 2280  N1    C A  25    11542  15390  10458   7185   -618  -2898       N  
+ATOM   2281  C2    C A  25     127.873  59.481 152.763  1.00 96.02           C  
+ANISOU 2281  C2    C A  25    11103  15150  10230   6943   -449  -2810       C  
+ATOM   2282  O2    C A  25     127.715  58.404 152.176  1.00 96.51           O  
+ANISOU 2282  O2    C A  25    10947  15330  10395   6760   -350  -2722       O  
+ATOM   2283  N3    C A  25     128.633  59.566 153.879  1.00 95.35           N  
+ANISOU 2283  N3    C A  25    11130  14995  10104   6913   -403  -2824       N  
+ATOM   2284  C4    C A  25     128.789  60.738 154.490  1.00 95.10           C  
+ANISOU 2284  C4    C A  25    11340  14833   9960   7114   -524  -2920       C  
+ATOM   2285  N4    C A  25     129.553  60.767 155.588  1.00 94.62           N  
+ANISOU 2285  N4    C A  25    11384  14705   9864   7076   -480  -2929       N  
+ATOM   2286  C5    C A  25     128.165  61.921 153.988  1.00 97.41           C  
+ANISOU 2286  C5    C A  25    11780  15059  10171   7363   -703  -3010       C  
+ATOM   2287  C6    C A  25     127.412  61.820 152.881  1.00 97.80           C  
+ANISOU 2287  C6    C A  25    11715  15181  10263   7390   -741  -2997       C  
+ATOM   2288  P     G A  26     121.796  61.243 152.354  1.00116.81           P  
+ANISOU 2288  P     G A  26    13052  18915  12414   7927   -631  -3036       P  
+ATOM   2289  OP1   G A  26     120.476  61.589 151.765  1.00116.13           O  
+ANISOU 2289  OP1   G A  26    12819  19034  12271   8119   -698  -3076       O  
+ATOM   2290  OP2   G A  26     122.394  62.114 153.399  1.00108.88           O  
+ANISOU 2290  OP2   G A  26    12301  17772  11295   8064   -683  -3119       O  
+ATOM   2291  O5'   G A  26     121.693  59.792 152.991  1.00113.16           O  
+ANISOU 2291  O5'   G A  26    12260  18734  12003   7692   -408  -2915       O  
+ATOM   2292  C5'   G A  26     122.730  59.332 153.828  1.00108.04           C  
+ANISOU 2292  C5'   G A  26    11681  17987  11381   7525   -310  -2874       C  
+ATOM   2293  C4'   G A  26     122.794  57.836 153.941  1.00106.56           C  
+ANISOU 2293  C4'   G A  26    11211  17983  11295   7238   -128  -2740       C  
+ATOM   2294  O4'   G A  26     124.165  57.435 153.658  1.00103.32           O  
+ANISOU 2294  O4'   G A  26    10973  17271  11012   7010   -114  -2695       O  
+ATOM   2295  C3'   G A  26     122.523  57.341 155.359  1.00110.17           C  
+ANISOU 2295  C3'   G A  26    11489  18715  11655   7223     24  -2709       C  
+ATOM   2296  O3'   G A  26     121.156  57.044 155.601  1.00114.04           O  
+ANISOU 2296  O3'   G A  26    11670  19595  12066   7312     89  -2684       O  
+ATOM   2297  C2'   G A  26     123.495  56.178 155.530  1.00105.81           C  
+ANISOU 2297  C2'   G A  26    10888  18091  11226   6903    153  -2601       C  
+ATOM   2298  O2'   G A  26     123.001  54.996 154.917  1.00106.60           O  
+ANISOU 2298  O2'   G A  26    10696  18380  11427   6697    242  -2487       O  
+ATOM   2299  C1'   G A  26     124.684  56.684 154.728  1.00101.03           C  
+ANISOU 2299  C1'   G A  26    10605  17065  10719   6853     34  -2638       C  
+ATOM   2300  N9    G A  26     125.510  57.613 155.525  1.00100.34           N  
+ANISOU 2300  N9    G A  26    10816  16753  10554   6971    -32  -2723       N  
+ATOM   2301  C8    G A  26     125.554  58.979 155.358  1.00102.38           C  
+ANISOU 2301  C8    G A  26    11350  16815  10737   7211   -206  -2837       C  
+ATOM   2302  N7    G A  26     126.344  59.596 156.185  1.00104.18           N  
+ANISOU 2302  N7    G A  26    11814  16864  10905   7270   -246  -2892       N  
+ATOM   2303  C5    G A  26     126.876  58.572 156.951  1.00103.70           C  
+ANISOU 2303  C5    G A  26    11629  16887  10885   7057    -82  -2812       C  
+ATOM   2304  C6    G A  26     127.806  58.632 158.025  1.00107.12           C  
+ANISOU 2304  C6    G A  26    12210  17204  11286   7012    -45  -2824       C  
+ATOM   2305  O6    G A  26     128.374  59.621 158.518  1.00111.32           O  
+ANISOU 2305  O6    G A  26    13021  17528  11750   7148   -156  -2907       O  
+ATOM   2306  N1    G A  26     128.065  57.360 158.524  1.00106.35           N  
+ANISOU 2306  N1    G A  26    11906  17254  11247   6773    135  -2723       N  
+ATOM   2307  C2    G A  26     127.504  56.191 158.057  1.00105.78           C  
+ANISOU 2307  C2    G A  26    11530  17408  11252   6596    255  -2621       C  
+ATOM   2308  N2    G A  26     127.894  55.069 158.682  1.00105.28           N  
+ANISOU 2308  N2    G A  26    11319  17450  11232   6370    411  -2531       N  
+ATOM   2309  N3    G A  26     126.634  56.121 157.062  1.00104.74           N  
+ANISOU 2309  N3    G A  26    11256  17388  11153   6634    217  -2607       N  
+ATOM   2310  C4    G A  26     126.367  57.342 156.560  1.00102.24           C  
+ANISOU 2310  C4    G A  26    11131  16933  10781   6870     51  -2707       C  
+ATOM   2311  P     C A  27     120.300  57.989 156.584  1.00127.98           P  
+ANISOU 2311  P     C A  27    13436  21566  13624   7634     59  -2783       P  
+ATOM   2312  OP1   C A  27     119.057  57.256 156.931  1.00129.51           O  
+ANISOU 2312  OP1   C A  27    13251  22192  13766   7624    183  -2709       O  
+ATOM   2313  OP2   C A  27     120.173  59.350 155.993  1.00124.69           O  
+ANISOU 2313  OP2   C A  27    13275  20952  13150   7900   -137  -2913       O  
+ATOM   2314  O5'   C A  27     121.216  58.091 157.887  1.00111.89           O  
+ANISOU 2314  O5'   C A  27    11558  19436  11521   7617    117  -2803       O  
+ATOM   2315  C5'   C A  27     121.104  59.201 158.765  1.00111.22           C  
+ANISOU 2315  C5'   C A  27    11649  19345  11266   7899     41  -2919       C  
+ATOM   2316  C4'   C A  27     121.177  58.767 160.205  1.00111.92           C  
+ANISOU 2316  C4'   C A  27    11640  19627  11259   7874    179  -2888       C  
+ATOM   2317  O4'   C A  27     120.063  57.889 160.497  1.00113.59           O  
+ANISOU 2317  O4'   C A  27    11472  20254  11434   7824    323  -2799       O  
+ATOM   2318  C3'   C A  27     122.408  57.962 160.599  1.00108.69           C  
+ANISOU 2318  C3'   C A  27    11294  19047  10956   7592    275  -2812       C  
+ATOM   2319  O3'   C A  27     123.519  58.791 160.917  1.00107.68           O  
+ANISOU 2319  O3'   C A  27    11520  18580  10814   7656    171  -2895       O  
+ATOM   2320  C2'   C A  27     121.918  57.144 161.792  1.00109.94           C  
+ANISOU 2320  C2'   C A  27    11191  19552  11030   7533    451  -2738       C  
+ATOM   2321  O2'   C A  27     121.967  57.914 162.985  1.00111.98           O  
+ANISOU 2321  O2'   C A  27    11586  19840  11120   7755    427  -2825       O  
+ATOM   2322  C1'   C A  27     120.449  56.910 161.436  1.00112.53           C  
+ANISOU 2322  C1'   C A  27    11209  20238  11310   7619    485  -2704       C  
+ATOM   2323  N1    C A  27     120.172  55.566 160.871  1.00111.06           N  
+ANISOU 2323  N1    C A  27    10733  20206  11258   7326    603  -2558       N  
+ATOM   2324  C2    C A  27     120.121  54.444 161.708  1.00110.80           C  
+ANISOU 2324  C2    C A  27    10477  20399  11223   7123    773  -2441       C  
+ATOM   2325  O2    C A  27     120.347  54.569 162.918  1.00111.67           O  
+ANISOU 2325  O2    C A  27    10635  20572  11222   7187    830  -2461       O  
+ATOM   2326  N3    C A  27     119.833  53.237 161.171  1.00109.65           N  
+ANISOU 2326  N3    C A  27    10075  20391  11197   6856    862  -2306       N  
+ATOM   2327  C4    C A  27     119.598  53.119 159.861  1.00108.78           C  
+ANISOU 2327  C4    C A  27     9920  20207  11204   6795    791  -2288       C  
+ATOM   2328  N4    C A  27     119.323  51.909 159.368  1.00107.74           N  
+ANISOU 2328  N4    C A  27     9539  20211  11187   6529    871  -2153       N  
+ATOM   2329  C5    C A  27     119.635  54.240 158.986  1.00108.99           C  
+ANISOU 2329  C5    C A  27    10165  20012  11236   7004    625  -2407       C  
+ATOM   2330  C6    C A  27     119.917  55.428 159.536  1.00110.16           C  
+ANISOU 2330  C6    C A  27    10569  20023  11264   7260    537  -2537       C  
+ATOM   2331  P     G A  28     124.950  58.564 160.213  1.00113.66           P  
+ANISOU 2331  P     G A  28    12498  18941  11748   7417    132  -2862       P  
+ATOM   2332  OP1   G A  28     125.914  59.614 160.645  1.00109.73           O  
+ANISOU 2332  OP1   G A  28    12364  18125  11203   7534      3  -2958       O  
+ATOM   2333  OP2   G A  28     124.640  58.360 158.776  1.00116.78           O  
+ANISOU 2333  OP2   G A  28    12823  19285  12262   7342     82  -2829       O  
+ATOM   2334  O5'   G A  28     125.493  57.202 160.833  1.00110.03           O  
+ANISOU 2334  O5'   G A  28    11867  18577  11364   7119    322  -2742       O  
+ATOM   2335  C5'   G A  28     125.489  56.985 162.237  1.00108.59           C  
+ANISOU 2335  C5'   G A  28    11625  18565  11071   7144    424  -2735       C  
+ATOM   2336  C4'   G A  28     125.525  55.512 162.551  1.00105.43           C  
+ANISOU 2336  C4'   G A  28    10958  18357  10744   6857    611  -2599       C  
+ATOM   2337  O4'   G A  28     124.297  54.880 162.109  1.00106.09           O  
+ANISOU 2337  O4'   G A  28    10717  18764  10830   6829    678  -2527       O  
+ATOM   2338  C3'   G A  28     126.627  54.747 161.846  1.00102.30           C  
+ANISOU 2338  C3'   G A  28    10625  17712  10531   6560    638  -2526       C  
+ATOM   2339  O3'   G A  28     127.841  54.829 162.568  1.00102.85           O  
+ANISOU 2339  O3'   G A  28    10911  17557  10610   6488    646  -2545       O  
+ATOM   2340  C2'   G A  28     126.063  53.333 161.752  1.00102.74           C  
+ANISOU 2340  C2'   G A  28    10337  18050  10649   6324    792  -2389       C  
+ATOM   2341  O2'   G A  28     126.253  52.662 162.988  1.00106.90           O  
+ANISOU 2341  O2'   G A  28    10771  18726  11121   6220    926  -2333       O  
+ATOM   2342  C1'   G A  28     124.566  53.598 161.586  1.00106.04           C  
+ANISOU 2342  C1'   G A  28    10539  18779  10972   6512    779  -2400       C  
+ATOM   2343  N9    G A  28     124.085  53.566 160.187  1.00107.08           N  
+ANISOU 2343  N9    G A  28    10598  18888  11200   6494    707  -2386       N  
+ATOM   2344  C8    G A  28     124.142  54.616 159.301  1.00104.60           C  
+ANISOU 2344  C8    G A  28    10492  18354  10898   6669    545  -2483       C  
+ATOM   2345  N7    G A  28     123.614  54.355 158.136  1.00102.90           N  
+ANISOU 2345  N7    G A  28    10156  18174  10768   6622    508  -2448       N  
+ATOM   2346  C5    G A  28     123.157  53.050 158.246  1.00104.84           C  
+ANISOU 2346  C5    G A  28    10089  18682  11064   6399    649  -2318       C  
+ATOM   2347  C6    G A  28     122.488  52.234 157.284  1.00104.00           C  
+ANISOU 2347  C6    G A  28     9739  18722  11055   6255    670  -2227       C  
+ATOM   2348  O6    G A  28     122.160  52.498 156.115  1.00102.76           O  
+ANISOU 2348  O6    G A  28     9589  18493  10960   6302    570  -2247       O  
+ATOM   2349  N1    G A  28     122.200  50.976 157.806  1.00104.19           N  
+ANISOU 2349  N1    G A  28     9490  18997  11099   6029    817  -2098       N  
+ATOM   2350  C2    G A  28     122.510  50.557 159.075  1.00102.59           C  
+ANISOU 2350  C2    G A  28     9255  18893  10830   5953    933  -2061       C  
+ATOM   2351  N2    G A  28     122.135  49.298 159.356  1.00103.10           N  
+ANISOU 2351  N2    G A  28     9047  19198  10930   5718   1057  -1923       N  
+ATOM   2352  N3    G A  28     123.131  51.308 159.981  1.00104.40           N  
+ANISOU 2352  N3    G A  28     9708  18992  10968   6094    920  -2149       N  
+ATOM   2353  C4    G A  28     123.431  52.543 159.509  1.00106.89           C  
+ANISOU 2353  C4    G A  28    10291  19060  11263   6314    774  -2275       C  
+ATOM   2354  P     A A  29     129.242  54.971 161.802  1.00109.31           P  
+ANISOU 2354  P     A A  29    12000  17959  11575   6342    567  -2555       P  
+ATOM   2355  OP1   A A  29     130.214  55.499 162.798  1.00109.45           O  
+ANISOU 2355  OP1   A A  29    12265  17783  11538   6387    537  -2613       O  
+ATOM   2356  OP2   A A  29     129.007  55.725 160.545  1.00 99.50           O  
+ANISOU 2356  OP2   A A  29    10867  16562  10376   6455    420  -2606       O  
+ATOM   2357  O5'   A A  29     129.647  53.461 161.482  1.00 93.71           O  
+ANISOU 2357  O5'   A A  29     9831  16035   9740   6001    711  -2421       O  
+ATOM   2358  C5'   A A  29     129.794  52.527 162.543  1.00 93.38           C  
+ANISOU 2358  C5'   A A  29     9645  16163   9672   5848    861  -2349       C  
+ATOM   2359  C4'   A A  29     129.672  51.103 162.054  1.00 95.17           C  
+ANISOU 2359  C4'   A A  29     9619  16528  10012   5563    980  -2217       C  
+ATOM   2360  O4'   A A  29     128.349  50.894 161.515  1.00 93.57           O  
+ANISOU 2360  O4'   A A  29     9164  16599   9790   5617    988  -2180       O  
+ATOM   2361  C3'   A A  29     130.621  50.705 160.930  1.00 91.79           C  
+ANISOU 2361  C3'   A A  29     9294  15833   9751   5366    948  -2183       C  
+ATOM   2362  O3'   A A  29     131.879  50.288 161.421  1.00 92.56           O  
+ANISOU 2362  O3'   A A  29     9526  15742   9900   5195    999  -2162       O  
+ATOM   2363  C2'   A A  29     129.864  49.593 160.202  1.00 91.17           C  
+ANISOU 2363  C2'   A A  29     8917  15976   9746   5192   1019  -2073       C  
+ATOM   2364  O2'   A A  29     130.138  48.318 160.777  1.00 87.23           O  
+ANISOU 2364  O2'   A A  29     8261  15600   9283   4936   1157  -1964       O  
+ATOM   2365  C1'   A A  29     128.399  49.978 160.446  1.00 93.69           C  
+ANISOU 2365  C1'   A A  29     9050  16602   9947   5395   1011  -2091       C  
+ATOM   2366  N9    A A  29     127.787  50.627 159.276  1.00 96.44           N  
+ANISOU 2366  N9    A A  29     9412  16911  10319   5540    892  -2139       N  
+ATOM   2367  C8    A A  29     128.049  51.881 158.777  1.00 94.38           C  
+ANISOU 2367  C8    A A  29     9410  16410  10042   5749    745  -2252       C  
+ATOM   2368  N7    A A  29     127.340  52.179 157.713  1.00 93.58           N  
+ANISOU 2368  N7    A A  29     9254  16335   9968   5837    660  -2267       N  
+ATOM   2369  C5    A A  29     126.566  51.043 157.511  1.00 94.62           C  
+ANISOU 2369  C5    A A  29     9065  16746  10139   5674    760  -2157       C  
+ATOM   2370  C6    A A  29     125.604  50.718 156.547  1.00 95.68           C  
+ANISOU 2370  C6    A A  29     8994  17040  10318   5663    734  -2113       C  
+ATOM   2371  N6    A A  29     125.253  51.556 155.567  1.00100.39           N  
+ANISOU 2371  N6    A A  29     9688  17531  10924   5834    599  -2184       N  
+ATOM   2372  N1    A A  29     125.014  49.499 156.629  1.00 95.70           N  
+ANISOU 2372  N1    A A  29     8695  17312  10356   5464    843  -1990       N  
+ATOM   2373  C2    A A  29     125.361  48.663 157.618  1.00 97.60           C  
+ANISOU 2373  C2    A A  29     8849  17653  10584   5288    972  -1916       C  
+ATOM   2374  N3    A A  29     126.263  48.854 158.578  1.00 99.89           N  
+ANISOU 2374  N3    A A  29     9312  17810  10831   5283   1012  -1950       N  
+ATOM   2375  C4    A A  29     126.829  50.075 158.466  1.00 98.84           C  
+ANISOU 2375  C4    A A  29     9473  17415  10668   5485    901  -2073       C  
+ATOM   2376  P     G A  30     133.237  50.864 160.787  1.00112.35           P  
+ANISOU 2376  P     G A  30    12350  17837  12501   5167    897  -2216       P  
+ATOM   2377  OP1   G A  30     134.097  49.701 160.466  1.00107.86           O  
+ANISOU 2377  OP1   G A  30    11734  17191  12058   4874    985  -2126       O  
+ATOM   2378  OP2   G A  30     133.764  51.936 161.667  1.00114.55           O  
+ANISOU 2378  OP2   G A  30    12883  17953  12688   5343    823  -2314       O  
+ATOM   2379  O5'   G A  30     132.774  51.517 159.414  1.00 92.30           O  
+ANISOU 2379  O5'   G A  30     9857  15206  10006   5285    769  -2254       O  
+ATOM   2380  C5'   G A  30     133.351  51.084 158.190  1.00 91.18           C  
+ANISOU 2380  C5'   G A  30     9750  14890  10005   5125    746  -2211       C  
+ATOM   2381  C4'   G A  30     132.310  50.952 157.111  1.00 89.42           C  
+ANISOU 2381  C4'   G A  30     9354  14811   9812   5165    709  -2187       C  
+ATOM   2382  O4'   G A  30     131.096  51.634 157.523  1.00 91.27           O  
+ANISOU 2382  O4'   G A  30     9498  15260   9919   5402    673  -2240       O  
+ATOM   2383  C3'   G A  30     132.672  51.587 155.776  1.00 89.51           C  
+ANISOU 2383  C3'   G A  30     9550  14558   9901   5217    574  -2225       C  
+ATOM   2384  O3'   G A  30     133.461  50.729 154.970  1.00 95.23           O  
+ANISOU 2384  O3'   G A  30    10272  15154  10758   4988    610  -2155       O  
+ATOM   2385  C2'   G A  30     131.311  51.916 155.176  1.00 88.22           C  
+ANISOU 2385  C2'   G A  30     9234  14590   9695   5379    514  -2243       C  
+ATOM   2386  O2'   G A  30     130.709  50.757 154.614  1.00 86.04           O  
+ANISOU 2386  O2'   G A  30     8676  14529   9488   5214    593  -2146       O  
+ATOM   2387  C1'   G A  30     130.523  52.312 156.422  1.00 91.90           C  
+ANISOU 2387  C1'   G A  30     9616  15287  10013   5547    550  -2283       C  
+ATOM   2388  N9    G A  30     130.624  53.753 156.696  1.00 89.90           N  
+ANISOU 2388  N9    G A  30     9625  14864   9668   5802    415  -2401       N  
+ATOM   2389  C8    G A  30     131.275  54.292 157.768  1.00 90.44           C  
+ANISOU 2389  C8    G A  30     9877  14822   9664   5867    408  -2454       C  
+ATOM   2390  N7    G A  30     131.241  55.587 157.804  1.00 98.25           N  
+ANISOU 2390  N7    G A  30    11092  15662  10576   6098    264  -2555       N  
+ATOM   2391  C5    G A  30     130.517  55.930 156.670  1.00 98.60           C  
+ANISOU 2391  C5    G A  30    11101  15720  10644   6193    173  -2571       C  
+ATOM   2392  C6    G A  30     130.144  57.211 156.177  1.00103.64           C  
+ANISOU 2392  C6    G A  30    11924  16233  11221   6434     -1  -2664       C  
+ATOM   2393  O6    G A  30     130.393  58.328 156.657  1.00102.86           O  
+ANISOU 2393  O6    G A  30    12068  15981  11034   6616   -117  -2754       O  
+ATOM   2394  N1    G A  30     129.406  57.093 154.999  1.00105.26           N  
+ANISOU 2394  N1    G A  30    12012  16506  11477   6451    -43  -2645       N  
+ATOM   2395  C2    G A  30     129.076  55.907 154.375  1.00 99.05           C  
+ANISOU 2395  C2    G A  30    10964  15882  10787   6261     61  -2548       C  
+ATOM   2396  N2    G A  30     128.362  56.001 153.242  1.00 97.60           N  
+ANISOU 2396  N2    G A  30    10708  15737  10640   6316    -12  -2546       N  
+ATOM   2397  N3    G A  30     129.418  54.712 154.832  1.00 90.91           N  
+ANISOU 2397  N3    G A  30     9762  14968   9811   6033    217  -2459       N  
+ATOM   2398  C4    G A  30     130.130  54.803 155.972  1.00 90.14           C  
+ANISOU 2398  C4    G A  30     9775  14810   9666   6013    266  -2476       C  
+ATOM   2399  P     G A  31     134.666  51.310 154.073  1.00 84.62           P  
+ANISOU 2399  P     G A  31     9233  13420   9500   4968    503  -2188       P  
+ATOM   2400  OP1   G A  31     135.424  50.137 153.559  1.00 75.94           O  
+ANISOU 2400  OP1   G A  31     8067  12272   8516   4709    587  -2103       O  
+ATOM   2401  OP2   G A  31     135.343  52.396 154.839  1.00 92.22           O  
+ANISOU 2401  OP2   G A  31    10470  14172  10398   5096    430  -2269       O  
+ATOM   2402  O5'   G A  31     133.917  52.007 152.854  1.00 95.41           O  
+ANISOU 2402  O5'   G A  31    10628  14749  10875   5126    368  -2224       O  
+ATOM   2403  C5'   G A  31     133.029  51.266 152.028  1.00 90.17           C  
+ANISOU 2403  C5'   G A  31     9717  14288  10255   5072    393  -2166       C  
+ATOM   2404  C4'   G A  31     132.174  52.183 151.200  1.00 87.80           C  
+ANISOU 2404  C4'   G A  31     9460  13977   9924   5283    254  -2223       C  
+ATOM   2405  O4'   G A  31     131.333  52.993 152.060  1.00 92.93           O  
+ANISOU 2405  O4'   G A  31    10092  14774  10442   5502    225  -2292       O  
+ATOM   2406  C3'   G A  31     132.928  53.205 150.371  1.00 88.52           C  
+ANISOU 2406  C3'   G A  31     9876  13710  10047   5367    103  -2277       C  
+ATOM   2407  O3'   G A  31     133.452  52.646 149.183  1.00 93.96           O  
+ANISOU 2407  O3'   G A  31    10588  14261  10851   5222     89  -2222       O  
+ATOM   2408  C2'   G A  31     131.879  54.282 150.142  1.00 92.55           C  
+ANISOU 2408  C2'   G A  31    10419  14276  10471   5627    -24  -2353       C  
+ATOM   2409  O2'   G A  31     130.976  53.880 149.125  1.00 98.93           O  
+ANISOU 2409  O2'   G A  31    11042  15230  11318   5632    -47  -2321       O  
+ATOM   2410  C1'   G A  31     131.137  54.265 151.482  1.00 86.59           C  
+ANISOU 2410  C1'   G A  31     9500  13799   9600   5717     59  -2376       C  
+ATOM   2411  N9    G A  31     131.641  55.290 152.413  1.00 87.18           N  
+ANISOU 2411  N9    G A  31     9817  13722   9587   5853      2  -2456       N  
+ATOM   2412  C8    G A  31     132.371  55.107 153.570  1.00 85.75           C  
+ANISOU 2412  C8    G A  31     9689  13514   9378   5780     83  -2454       C  
+ATOM   2413  N7    G A  31     132.651  56.233 154.180  1.00 96.38           N  
+ANISOU 2413  N7    G A  31    11272  14710  10639   5947    -15  -2537       N  
+ATOM   2414  C5    G A  31     132.073  57.209 153.373  1.00 88.52           C  
+ANISOU 2414  C5    G A  31    10385  13637   9611   6138   -171  -2597       C  
+ATOM   2415  C6    G A  31     132.046  58.616 153.510  1.00 90.37           C  
+ANISOU 2415  C6    G A  31    10878  13703   9754   6364   -338  -2694       C  
+ATOM   2416  O6    G A  31     132.550  59.297 154.409  1.00 91.01           O  
+ANISOU 2416  O6    G A  31    11148  13668   9765   6444   -385  -2749       O  
+ATOM   2417  N1    G A  31     131.344  59.220 152.471  1.00 91.59           N  
+ANISOU 2417  N1    G A  31    11065  13831   9902   6501   -464  -2727       N  
+ATOM   2418  C2    G A  31     130.750  58.556 151.422  1.00 91.07           C  
+ANISOU 2418  C2    G A  31    10807  13883   9912   6432   -435  -2673       C  
+ATOM   2419  N2    G A  31     130.116  59.307 150.505  1.00 92.47           N  
+ANISOU 2419  N2    G A  31    11058  14008  10070   6589   -577  -2717       N  
+ATOM   2420  N3    G A  31     130.771  57.246 151.284  1.00 89.38           N  
+ANISOU 2420  N3    G A  31    10350  13825   9784   6222   -284  -2582       N  
+ATOM   2421  C4    G A  31     131.442  56.645 152.287  1.00 88.19           C  
+ANISOU 2421  C4    G A  31    10167  13704   9639   6085   -159  -2549       C  
+ATOM   2422  P     A A  32     134.680  53.354 148.432  1.00102.84           P  
+ANISOU 2422  P     A A  32    12059  14981  12034   5208    -23  -2241       P  
+ATOM   2423  OP1   A A  32     135.166  52.446 147.356  1.00 94.85           O  
+ANISOU 2423  OP1   A A  32    11003  13901  11134   5029      8  -2168       O  
+ATOM   2424  OP2   A A  32     135.611  53.838 149.486  1.00 95.95           O  
+ANISOU 2424  OP2   A A  32    11381  13951  11125   5201    -10  -2274       O  
+ATOM   2425  O5'   A A  32     134.004  54.616 147.742  1.00 85.90           O  
+ANISOU 2425  O5'   A A  32    10061  12741   9838   5441   -200  -2309       O  
+ATOM   2426  C5'   A A  32     133.027  54.446 146.725  1.00 86.89           C  
+ANISOU 2426  C5'   A A  32    10041  12992   9981   5498   -251  -2296       C  
+ATOM   2427  C4'   A A  32     132.676  55.765 146.093  1.00 83.40           C  
+ANISOU 2427  C4'   A A  32     9814  12384   9492   5708   -434  -2365       C  
+ATOM   2428  O4'   A A  32     131.917  56.565 147.033  1.00 90.92           O  
+ANISOU 2428  O4'   A A  32    10753  13470  10321   5910   -466  -2443       O  
+ATOM   2429  C3'   A A  32     133.868  56.637 145.738  1.00 85.18           C  
+ANISOU 2429  C3'   A A  32    10406  12218   9741   5698   -548  -2379       C  
+ATOM   2430  O3'   A A  32     134.442  56.292 144.489  1.00 87.69           O  
+ANISOU 2430  O3'   A A  32    10808  12353  10156   5578   -583  -2319       O  
+ATOM   2431  C2'   A A  32     133.292  58.040 145.793  1.00 82.50           C  
+ANISOU 2431  C2'   A A  32    10238  11805   9301   5941   -710  -2466       C  
+ATOM   2432  O2'   A A  32     132.550  58.319 144.620  1.00 88.87           O  
+ANISOU 2432  O2'   A A  32    11036  12611  10117   6035   -819  -2472       O  
+ATOM   2433  C1'   A A  32     132.313  57.913 146.957  1.00 89.04           C  
+ANISOU 2433  C1'   A A  32    10837  12960  10032   6054   -626  -2510       C  
+ATOM   2434  N9    A A  32     132.940  58.255 148.239  1.00 89.14           N  
+ANISOU 2434  N9    A A  32    10963  12918   9988   6062   -590  -2544       N  
+ATOM   2435  C8    A A  32     133.451  57.382 149.171  1.00 83.05           C  
+ANISOU 2435  C8    A A  32    10072  12247   9237   5907   -432  -2503       C  
+ATOM   2436  N7    A A  32     133.934  57.978 150.239  1.00 83.61           N  
+ANISOU 2436  N7    A A  32    10294  12234   9239   5964   -446  -2551       N  
+ATOM   2437  C5    A A  32     133.724  59.329 149.982  1.00 85.46           C  
+ANISOU 2437  C5    A A  32    10762  12303   9404   6168   -630  -2627       C  
+ATOM   2438  C6    A A  32     134.019  60.486 150.714  1.00 86.91           C  
+ANISOU 2438  C6    A A  32    11194  12333   9497   6314   -746  -2702       C  
+ATOM   2439  N6    A A  32     134.605  60.454 151.908  1.00 86.69           N  
+ANISOU 2439  N6    A A  32    11212  12295   9431   6281   -687  -2716       N  
+ATOM   2440  N1    A A  32     133.681  61.680 150.172  1.00 93.53           N  
+ANISOU 2440  N1    A A  32    12234  13026  10279   6498   -934  -2765       N  
+ATOM   2441  C2    A A  32     133.091  61.701 148.971  1.00 88.95           C  
+ANISOU 2441  C2    A A  32    11610  12454   9735   6531   -996  -2751       C  
+ATOM   2442  N3    A A  32     132.763  60.681 148.184  1.00 87.67           N  
+ANISOU 2442  N3    A A  32    11224  12428   9660   6409   -901  -2683       N  
+ATOM   2443  C4    A A  32     133.111  59.515 148.755  1.00 90.08           C  
+ANISOU 2443  C4    A A  32    11333  12876  10017   6228   -719  -2623       C  
+ATOM   2444  P     U A  33     136.038  56.298 144.312  1.00 89.82           P  
+ANISOU 2444  P     U A  33    11336  12294  10497   5411   -583  -2274       P  
+ATOM   2445  OP1   U A  33     136.390  55.612 143.036  1.00 91.34           O  
+ANISOU 2445  OP1   U A  33    11524  12399  10784   5282   -580  -2202       O  
+ATOM   2446  OP2   U A  33     136.651  55.835 145.593  1.00 95.94           O  
+ANISOU 2446  OP2   U A  33    12058  13131  11264   5308   -450  -2271       O  
+ATOM   2447  O5'   U A  33     136.351  57.841 144.112  1.00 85.87           O  
+ANISOU 2447  O5'   U A  33    11181  11499   9947   5550   -773  -2323       O  
+ATOM   2448  C5'   U A  33     135.671  58.579 143.109  1.00 85.40           C  
+ANISOU 2448  C5'   U A  33    11209  11376   9865   5691   -926  -2345       C  
+ATOM   2449  C4'   U A  33     135.892  60.056 143.275  1.00 87.25           C  
+ANISOU 2449  C4'   U A  33    11750  11374  10028   5829  -1099  -2402       C  
+ATOM   2450  O4'   U A  33     135.148  60.540 144.423  1.00 99.40           O  
+ANISOU 2450  O4'   U A  33    13211  13096  11459   6000  -1098  -2488       O  
+ATOM   2451  C3'   U A  33     137.318  60.493 143.563  1.00 87.83           C  
+ANISOU 2451  C3'   U A  33    12105  11136  10132   5708  -1134  -2371       C  
+ATOM   2452  O3'   U A  33     138.134  60.518 142.405  1.00 90.93           O  
+ANISOU 2452  O3'   U A  33    12682  11265  10602   5581  -1197  -2293       O  
+ATOM   2453  C2'   U A  33     137.107  61.858 144.195  1.00 94.66           C  
+ANISOU 2453  C2'   U A  33    13171  11904  10892   5892  -1284  -2453       C  
+ATOM   2454  O2'   U A  33     136.765  62.803 143.190  1.00 98.38           O  
+ANISOU 2454  O2'   U A  33    13828  12216  11338   6001  -1468  -2465       O  
+ATOM   2455  C1'   U A  33     135.860  61.593 145.045  1.00 95.62           C  
+ANISOU 2455  C1'   U A  33    13016  12385  10931   6047  -1203  -2526       C  
+ATOM   2456  N1    U A  33     136.204  61.175 146.427  1.00 84.82           N  
+ANISOU 2456  N1    U A  33    11556  11134   9539   5998  -1073  -2541       N  
+ATOM   2457  C2    U A  33     136.519  62.137 147.374  1.00 87.55           C  
+ANISOU 2457  C2    U A  33    12098  11366   9803   6098  -1160  -2602       C  
+ATOM   2458  O2    U A  33     136.530  63.330 147.146  1.00 96.90           O  
+ANISOU 2458  O2    U A  33    13530  12356  10932   6223  -1341  -2646       O  
+ATOM   2459  N3    U A  33     136.816  61.655 148.616  1.00 83.90           N  
+ANISOU 2459  N3    U A  33    11536  11023   9320   6047  -1033  -2611       N  
+ATOM   2460  C4    U A  33     136.844  60.328 148.997  1.00 88.37           C  
+ANISOU 2460  C4    U A  33    11834  11806   9938   5898   -831  -2561       C  
+ATOM   2461  O4    U A  33     137.142  60.024 150.152  1.00 94.26           O  
+ANISOU 2461  O4    U A  33    12524  12635  10653   5861   -736  -2572       O  
+ATOM   2462  C5    U A  33     136.509  59.395 147.970  1.00 81.03           C  
+ANISOU 2462  C5    U A  33    10714  10984   9092   5797   -757  -2499       C  
+ATOM   2463  C6    U A  33     136.211  59.840 146.754  1.00 82.50           C  
+ANISOU 2463  C6    U A  33    10990  11058   9300   5852   -878  -2492       C  
+ATOM   2464  P     G A  34     139.724  60.308 142.523  1.00 93.89           P  
+ANISOU 2464  P     G A  34    13241  11382  11052   5365  -1156  -2218       P  
+ATOM   2465  OP1   G A  34     140.253  60.400 141.138  1.00100.91           O  
+ANISOU 2465  OP1   G A  34    14300  12040  12000   5273  -1236  -2135       O  
+ATOM   2466  OP2   G A  34     139.993  59.119 143.376  1.00 95.47           O  
+ANISOU 2466  OP2   G A  34    13212  11776  11287   5243   -956  -2206       O  
+ATOM   2467  O5'   G A  34     140.236  61.609 143.290  1.00 91.04           O  
+ANISOU 2467  O5'   G A  34    13158  10805  10629   5433  -1293  -2260       O  
+ATOM   2468  C5'   G A  34     140.323  62.864 142.627  1.00 81.57           C  
+ANISOU 2468  C5'   G A  34    12244   9353   9395   5509  -1501  -2260       C  
+ATOM   2469  C4'   G A  34     140.769  63.956 143.565  1.00 84.44           C  
+ANISOU 2469  C4'   G A  34    12833   9556   9695   5568  -1618  -2307       C  
+ATOM   2470  O4'   G A  34     139.775  64.130 144.611  1.00 92.18           O  
+ANISOU 2470  O4'   G A  34    13661  10786  10576   5764  -1594  -2416       O  
+ATOM   2471  C3'   G A  34     142.058  63.728 144.353  1.00 84.21           C  
+ANISOU 2471  C3'   G A  34    12896   9384   9714   5393  -1555  -2264       C  
+ATOM   2472  O3'   G A  34     143.260  63.906 143.626  1.00 83.17           O  
+ANISOU 2472  O3'   G A  34    12991   8948   9661   5205  -1617  -2159       O  
+ATOM   2473  C2'   G A  34     141.894  64.711 145.492  1.00 89.15           C  
+ANISOU 2473  C2'   G A  34    13641   9992  10241   5541  -1658  -2353       C  
+ATOM   2474  O2'   G A  34     142.080  66.039 145.022  1.00 95.93           O  
+ANISOU 2474  O2'   G A  34    14805  10586  11059   5601  -1884  -2353       O  
+ATOM   2475  C1'   G A  34     140.417  64.506 145.818  1.00 93.48           C  
+ANISOU 2475  C1'   G A  34    13936  10877  10707   5752  -1602  -2446       C  
+ATOM   2476  N9    G A  34     140.301  63.413 146.794  1.00 88.18           N  
+ANISOU 2476  N9    G A  34    12993  10468  10044   5705  -1395  -2460       N  
+ATOM   2477  C8    G A  34     139.989  62.095 146.576  1.00 82.10           C  
+ANISOU 2477  C8    G A  34    11931   9929   9333   5613  -1210  -2423       C  
+ATOM   2478  N7    G A  34     140.033  61.380 147.668  1.00 83.19           N  
+ANISOU 2478  N7    G A  34    11893  10254   9460   5572  -1060  -2439       N  
+ATOM   2479  C5    G A  34     140.420  62.282 148.651  1.00 84.44           C  
+ANISOU 2479  C5    G A  34    12244  10291   9550   5646  -1151  -2492       C  
+ATOM   2480  C6    G A  34     140.631  62.095 150.041  1.00 87.98           C  
+ANISOU 2480  C6    G A  34    12638  10840   9952   5649  -1069  -2529       C  
+ATOM   2481  O6    G A  34     140.515  61.045 150.694  1.00 85.61           O  
+ANISOU 2481  O6    G A  34    12097  10768   9663   5576   -888  -2518       O  
+ATOM   2482  N1    G A  34     141.010  63.286 150.673  1.00 93.38           N  
+ANISOU 2482  N1    G A  34    13587  11330  10565   5747  -1228  -2581       N  
+ATOM   2483  C2    G A  34     141.160  64.503 150.043  1.00 95.85           C  
+ANISOU 2483  C2    G A  34    14181  11384  10854   5821  -1443  -2591       C  
+ATOM   2484  N2    G A  34     141.540  65.524 150.824  1.00 87.16           N  
+ANISOU 2484  N2    G A  34    13312  10124   9680   5902  -1584  -2641       N  
+ATOM   2485  N3    G A  34     140.962  64.690 148.746  1.00 93.91           N  
+ANISOU 2485  N3    G A  34    13988  11043  10651   5811  -1518  -2552       N  
+ATOM   2486  C4    G A  34     140.597  63.544 148.125  1.00 87.86           C  
+ANISOU 2486  C4    G A  34    12968  10463   9954   5727  -1362  -2506       C  
+ATOM   2487  P     G A  35     144.597  63.123 144.086  1.00109.62           P  
+ANISOU 2487  P     G A  35    16345  12205  13099   4969  -1488  -2084       P  
+ATOM   2488  OP1   G A  35     145.658  63.575 143.150  1.00113.05           O  
+ANISOU 2488  OP1   G A  35    17044  12314  13595   4806  -1596  -1970       O  
+ATOM   2489  OP2   G A  35     144.319  61.668 144.236  1.00101.71           O  
+ANISOU 2489  OP2   G A  35    15030  11474  12140   4912  -1267  -2084       O  
+ATOM   2490  O5'   G A  35     144.949  63.707 145.533  1.00100.22           O  
+ANISOU 2490  O5'   G A  35    15246  10978  11854   5011  -1527  -2148       O  
+ATOM   2491  C5'   G A  35     145.640  64.944 145.660  1.00104.20           C  
+ANISOU 2491  C5'   G A  35    16066  11189  12336   4995  -1723  -2131       C  
+ATOM   2492  C4'   G A  35     145.836  65.377 147.098  1.00100.45           C  
+ANISOU 2492  C4'   G A  35    15643  10725  11800   5057  -1749  -2204       C  
+ATOM   2493  O4'   G A  35     144.648  65.087 147.883  1.00 98.36           O  
+ANISOU 2493  O4'   G A  35    15145  10779  11448   5257  -1661  -2315       O  
+ATOM   2494  C3'   G A  35     146.957  64.715 147.890  1.00 98.63           C  
+ANISOU 2494  C3'   G A  35    15395  10444  11636   4869  -1636  -2161       C  
+ATOM   2495  O3'   G A  35     148.250  65.213 147.581  1.00100.23           O  
+ANISOU 2495  O3'   G A  35    15857  10323  11905   4679  -1747  -2062       O  
+ATOM   2496  C2'   G A  35     146.536  65.002 149.322  1.00 99.13           C  
+ANISOU 2496  C2'   G A  35    15414  10648  11602   5021  -1635  -2270       C  
+ATOM   2497  O2'   G A  35     146.843  66.343 149.673  1.00 99.40           O  
+ANISOU 2497  O2'   G A  35    15734  10457  11575   5085  -1853  -2295       O  
+ATOM   2498  C1'   G A  35     145.018  64.840 149.225  1.00 97.19           C  
+ANISOU 2498  C1'   G A  35    14951  10700  11276   5241  -1585  -2355       C  
+ATOM   2499  N9    G A  35     144.635  63.467 149.594  1.00 94.78           N  
+ANISOU 2499  N9    G A  35    14320  10695  10998   5202  -1349  -2361       N  
+ATOM   2500  C8    G A  35     144.323  62.406 148.779  1.00 94.60           C  
+ANISOU 2500  C8    G A  35    14080  10821  11040   5125  -1209  -2314       C  
+ATOM   2501  N7    G A  35     144.069  61.311 149.438  1.00 87.53           N  
+ANISOU 2501  N7    G A  35    12922  10184  10150   5089  -1018  -2328       N  
+ATOM   2502  C5    G A  35     144.253  61.676 150.763  1.00 88.79           C  
+ANISOU 2502  C5    G A  35    13133  10360  10245   5145  -1029  -2385       C  
+ATOM   2503  C6    G A  35     144.116  60.905 151.934  1.00 83.76           C  
+ANISOU 2503  C6    G A  35    12298   9951   9576   5135   -872  -2416       C  
+ATOM   2504  O6    G A  35     143.796  59.707 152.000  1.00 78.21           O  
+ANISOU 2504  O6    G A  35    11324   9488   8903   5060   -690  -2393       O  
+ATOM   2505  N1    G A  35     144.395  61.669 153.072  1.00 82.57           N  
+ANISOU 2505  N1    G A  35    12299   9723   9350   5215   -955  -2473       N  
+ATOM   2506  C2    G A  35     144.745  63.007 153.080  1.00 89.99           C  
+ANISOU 2506  C2    G A  35    13542  10401  10249   5295  -1170  -2499       C  
+ATOM   2507  N2    G A  35     144.974  63.578 154.276  1.00 85.16           N  
+ANISOU 2507  N2    G A  35    13044   9752   9559   5370  -1231  -2556       N  
+ATOM   2508  N3    G A  35     144.867  63.733 151.984  1.00 94.24           N  
+ANISOU 2508  N3    G A  35    14264  10727  10817   5294  -1321  -2465       N  
+ATOM   2509  C4    G A  35     144.609  62.999 150.880  1.00 91.31           C  
+ANISOU 2509  C4    G A  35    13747  10427  10518   5219  -1234  -2409       C  
+ATOM   2510  P     G A  36     149.534  64.236 147.582  1.00118.28           P  
+ANISOU 2510  P     G A  36    18112  12521  14309   4412  -1611  -1958       P  
+ATOM   2511  OP1   G A  36     150.745  65.094 147.507  1.00120.64           O  
+ANISOU 2511  OP1   G A  36    18704  12485  14648   4250  -1774  -1867       O  
+ATOM   2512  OP2   G A  36     149.343  63.165 146.571  1.00105.00           O  
+ANISOU 2512  OP2   G A  36    16251  10954  12690   4341  -1464  -1903       O  
+ATOM   2513  O5'   G A  36     149.521  63.543 149.020  1.00100.60           O  
+ANISOU 2513  O5'   G A  36    15697  10482  12045   4437  -1465  -2036       O  
+ATOM   2514  C5'   G A  36     149.749  64.293 150.207  1.00 98.14           C  
+ANISOU 2514  C5'   G A  36    15513  10104  11670   4499  -1563  -2096       C  
+ATOM   2515  C4'   G A  36     149.553  63.442 151.436  1.00 95.88           C  
+ANISOU 2515  C4'   G A  36    15015  10060  11355   4532  -1393  -2166       C  
+ATOM   2516  O4'   G A  36     148.206  62.901 151.456  1.00 97.68           O  
+ANISOU 2516  O4'   G A  36    14978  10614  11520   4704  -1274  -2240       O  
+ATOM   2517  C3'   G A  36     150.445  62.215 151.529  1.00 90.93           C  
+ANISOU 2517  C3'   G A  36    14267   9454  10827   4316  -1217  -2099       C  
+ATOM   2518  O3'   G A  36     151.742  62.522 152.018  1.00 98.18           O  
+ANISOU 2518  O3'   G A  36    15380  10128  11796   4152  -1289  -2045       O  
+ATOM   2519  C2'   G A  36     149.649  61.279 152.435  1.00 88.32           C  
+ANISOU 2519  C2'   G A  36    13648   9466  10443   4411  -1029  -2180       C  
+ATOM   2520  O2'   G A  36     149.812  61.643 153.800  1.00 92.12           O  
+ANISOU 2520  O2'   G A  36    14184   9959  10857   4470  -1059  -2243       O  
+ATOM   2521  C1'   G A  36     148.211  61.607 152.031  1.00 89.05           C  
+ANISOU 2521  C1'   G A  36    13632   9750  10454   4629  -1056  -2244       C  
+ATOM   2522  N9    G A  36     147.602  60.651 151.072  1.00 87.68           N  
+ANISOU 2522  N9    G A  36    13231   9759  10323   4605   -924  -2212       N  
+ATOM   2523  C8    G A  36     147.444  60.851 149.723  1.00 86.13           C  
+ANISOU 2523  C8    G A  36    13093   9465  10167   4594   -991  -2161       C  
+ATOM   2524  N7    G A  36     146.820  59.881 149.118  1.00 84.24           N  
+ANISOU 2524  N7    G A  36    12617   9437   9952   4586   -856  -2148       N  
+ATOM   2525  C5    G A  36     146.524  58.986 150.133  1.00 80.22           C  
+ANISOU 2525  C5    G A  36    11873   9190   9419   4584   -690  -2188       C  
+ATOM   2526  C6    G A  36     145.858  57.733 150.082  1.00 79.47           C  
+ANISOU 2526  C6    G A  36    11464   9398   9334   4558   -507  -2184       C  
+ATOM   2527  O6    G A  36     145.376  57.152 149.103  1.00 87.06           O  
+ANISOU 2527  O6    G A  36    12282  10466  10332   4506   -458  -2134       O  
+ATOM   2528  N1    G A  36     145.766  57.137 151.333  1.00 73.34           N  
+ANISOU 2528  N1    G A  36    10527   8818   8518   4547   -381  -2219       N  
+ATOM   2529  C2    G A  36     146.255  57.681 152.489  1.00 75.56           C  
+ANISOU 2529  C2    G A  36    10940   9015   8755   4571   -425  -2259       C  
+ATOM   2530  N2    G A  36     146.069  56.955 153.600  1.00 76.78           N  
+ANISOU 2530  N2    G A  36    10910   9391   8870   4555   -286  -2284       N  
+ATOM   2531  N3    G A  36     146.884  58.845 152.544  1.00 81.93           N  
+ANISOU 2531  N3    G A  36    12040   9537   9553   4600   -600  -2268       N  
+ATOM   2532  C4    G A  36     146.988  59.446 151.341  1.00 74.19           C  
+ANISOU 2532  C4    G A  36    11216   8361   8612   4600   -726  -2228       C  
+ATOM   2533  P     G A  37     153.056  61.978 151.260  1.00 97.19           P  
+ANISOU 2533  P     G A  37    15309   9816  11803   3852  -1247  -1894       P  
+ATOM   2534  OP1   G A  37     154.181  62.901 151.577  1.00 91.83           O  
+ANISOU 2534  OP1   G A  37    14920   8816  11154   3746  -1426  -1844       O  
+ATOM   2535  OP2   G A  37     152.694  61.712 149.840  1.00 94.17           O  
+ANISOU 2535  OP2   G A  37    14843   9482  11456   3785  -1211  -1808       O  
+ATOM   2536  O5'   G A  37     153.329  60.553 151.922  1.00 85.01           O  
+ANISOU 2536  O5'   G A  37    13485   8519  10296   3687  -1007  -1867       O  
+ATOM   2537  C5'   G A  37     153.233  60.368 153.329  1.00 82.63           C  
+ANISOU 2537  C5'   G A  37    13139   8318   9937   3793   -959  -1974       C  
+ATOM   2538  C4'   G A  37     152.928  58.933 153.691  1.00 80.41           C  
+ANISOU 2538  C4'   G A  37    12536   8351   9666   3708   -719  -1966       C  
+ATOM   2539  O4'   G A  37     151.597  58.579 153.207  1.00 80.91           O  
+ANISOU 2539  O4'   G A  37    12405   8659   9678   3877   -643  -2022       O  
+ATOM   2540  C3'   G A  37     153.893  57.881 153.123  1.00 83.41           C  
+ANISOU 2540  C3'   G A  37    12788   8744  10159   3366   -585  -1806       C  
+ATOM   2541  O3'   G A  37     154.140  56.868 154.099  1.00 90.89           O  
+ANISOU 2541  O3'   G A  37    13562   9860  11111   3273   -429  -1814       O  
+ATOM   2542  C2'   G A  37     153.098  57.280 151.967  1.00 81.52           C  
+ANISOU 2542  C2'   G A  37    12367   8673   9933   3361   -497  -1767       C  
+ATOM   2543  O2'   G A  37     153.455  55.957 151.625  1.00 81.89           O  
+ANISOU 2543  O2'   G A  37    12198   8868  10048   3127   -320  -1667       O  
+ATOM   2544  C1'   G A  37     151.669  57.361 152.503  1.00 84.02           C  
+ANISOU 2544  C1'   G A  37    12568   9212  10144   3661   -476  -1915       C  
+ATOM   2545  N9    G A  37     150.636  57.286 151.456  1.00 87.49           N  
+ANISOU 2545  N9    G A  37    12901   9773  10568   3763   -469  -1920       N  
+ATOM   2546  C8    G A  37     149.564  56.418 151.456  1.00 87.92           C  
+ANISOU 2546  C8    G A  37    12682  10134  10590   3838   -332  -1958       C  
+ATOM   2547  N7    G A  37     148.823  56.492 150.380  1.00 87.64           N  
+ANISOU 2547  N7    G A  37    12598  10147  10555   3904   -361  -1946       N  
+ATOM   2548  C5    G A  37     149.446  57.457 149.600  1.00 82.76           C  
+ANISOU 2548  C5    G A  37    12241   9237   9968   3869   -520  -1895       C  
+ATOM   2549  C6    G A  37     149.091  57.965 148.316  1.00 90.05           C  
+ANISOU 2549  C6    G A  37    13248  10066  10900   3912   -621  -1860       C  
+ATOM   2550  O6    G A  37     148.134  57.672 147.583  1.00 97.81           O  
+ANISOU 2550  O6    G A  37    14092  11203  11867   3996   -594  -1872       O  
+ATOM   2551  N1    G A  37     149.991  58.933 147.892  1.00 96.14           N  
+ANISOU 2551  N1    G A  37    14305  10525  11701   3841   -776  -1799       N  
+ATOM   2552  C2    G A  37     151.091  59.352 148.600  1.00 94.95           C  
+ANISOU 2552  C2    G A  37    14327  10176  11574   3736   -833  -1774       C  
+ATOM   2553  N2    G A  37     151.830  60.296 147.998  1.00 98.59           N  
+ANISOU 2553  N2    G A  37    15049  10346  12064   3662   -995  -1700       N  
+ATOM   2554  N3    G A  37     151.440  58.891 149.795  1.00 85.35           N  
+ANISOU 2554  N3    G A  37    13035   9039  10353   3699   -746  -1811       N  
+ATOM   2555  C4    G A  37     150.577  57.948 150.240  1.00 82.12           C  
+ANISOU 2555  C4    G A  37    12356   8935   9910   3773   -588  -1873       C  
+ATOM   2556  P     C A  38     155.562  56.121 154.170  1.00 92.71           P  
+ANISOU 2556  P     C A  38    13767  10012  11446   2945   -351  -1681       P  
+ATOM   2557  OP1   C A  38     156.553  57.028 154.793  1.00 92.92           O  
+ANISOU 2557  OP1   C A  38    14044   9775  11488   2909   -502  -1677       O  
+ATOM   2558  OP2   C A  38     155.853  55.508 152.850  1.00 91.33           O  
+ANISOU 2558  OP2   C A  38    13499   9853  11350   2748   -281  -1549       O  
+ATOM   2559  O5'   C A  38     155.300  54.927 155.182  1.00 80.79           O  
+ANISOU 2559  O5'   C A  38    12023   8763   9911   2924   -169  -1723       O  
+ATOM   2560  C5'   C A  38     155.018  55.191 156.542  1.00 75.90           C  
+ANISOU 2560  C5'   C A  38    11436   8194   9207   3092   -184  -1843       C  
+ATOM   2561  C4'   C A  38     154.078  54.160 157.115  1.00 76.07           C  
+ANISOU 2561  C4'   C A  38    11192   8542   9169   3164    -11  -1898       C  
+ATOM   2562  O4'   C A  38     152.729  54.391 156.634  1.00 86.37           O  
+ANISOU 2562  O4'   C A  38    12406  10003  10405   3385    -13  -1968       O  
+ATOM   2563  C3'   C A  38     154.357  52.708 156.755  1.00 72.91           C  
+ANISOU 2563  C3'   C A  38    10561   8298   8843   2918    163  -1792       C  
+ATOM   2564  O3'   C A  38     155.397  52.152 157.541  1.00 77.57           O  
+ANISOU 2564  O3'   C A  38    11154   8843   9474   2736    216  -1749       O  
+ATOM   2565  C2'   C A  38     153.001  52.051 157.000  1.00 76.99           C  
+ANISOU 2565  C2'   C A  38    10839   9131   9283   3061    282  -1858       C  
+ATOM   2566  O2'   C A  38     152.802  51.823 158.389  1.00 82.22           O  
+ANISOU 2566  O2'   C A  38    11446   9927   9867   3149    342  -1936       O  
+ATOM   2567  C1'   C A  38     152.035  53.158 156.567  1.00 81.22           C  
+ANISOU 2567  C1'   C A  38    11466   9644   9751   3331    162  -1946       C  
+ATOM   2568  N1    C A  38     151.491  52.960 155.199  1.00 77.69           N  
+ANISOU 2568  N1    C A  38    10933   9244   9344   3304    170  -1890       N  
+ATOM   2569  C2    C A  38     150.468  52.016 155.043  1.00 81.60           C  
+ANISOU 2569  C2    C A  38    11160  10030   9815   3325    299  -1892       C  
+ATOM   2570  O2    C A  38     150.072  51.364 156.024  1.00 82.66           O  
+ANISOU 2570  O2    C A  38    11135  10376   9898   3353    408  -1931       O  
+ATOM   2571  N3    C A  38     149.935  51.821 153.816  1.00 78.68           N  
+ANISOU 2571  N3    C A  38    10712   9705   9478   3307    297  -1846       N  
+ATOM   2572  C4    C A  38     150.368  52.514 152.761  1.00 74.64           C  
+ANISOU 2572  C4    C A  38    10375   8970   9014   3273    183  -1799       C  
+ATOM   2573  N4    C A  38     149.797  52.266 151.574  1.00 69.90           N  
+ANISOU 2573  N4    C A  38     9691   8428   8439   3261    186  -1756       N  
+ATOM   2574  C5    C A  38     151.401  53.491 152.888  1.00 74.09           C  
+ANISOU 2574  C5    C A  38    10575   8609   8968   3246     54  -1788       C  
+ATOM   2575  C6    C A  38     151.920  53.682 154.114  1.00 73.75           C  
+ANISOU 2575  C6    C A  38    10607   8518   8898   3262     48  -1835       C  
+ATOM   2576  P     G A  39     156.428  51.062 156.952  1.00 77.31           P  
+ANISOU 2576  P     G A  39    11026   8791   9557   2421    314  -1605       P  
+ATOM   2577  OP1   G A  39     157.225  50.532 158.091  1.00 83.94           O  
+ANISOU 2577  OP1   G A  39    11855   9632  10408   2307    367  -1601       O  
+ATOM   2578  OP2   G A  39     157.112  51.624 155.761  1.00 75.84           O  
+ANISOU 2578  OP2   G A  39    10977   8394   9447   2313    221  -1513       O  
+ATOM   2579  O5'   G A  39     155.506  49.848 156.526  1.00 84.14           O  
+ANISOU 2579  O5'   G A  39    11622   9935  10413   2394    468  -1588       O  
+ATOM   2580  C5'   G A  39     155.410  49.450 155.171  1.00 73.56           C  
+ANISOU 2580  C5'   G A  39    10214   8606   9130   2295    493  -1505       C  
+ATOM   2581  C4'   G A  39     154.045  48.885 154.890  1.00 70.39           C  
+ANISOU 2581  C4'   G A  39     9611   8457   8679   2403    570  -1543       C  
+ATOM   2582  O4'   G A  39     153.155  49.946 154.459  1.00 73.14           O  
+ANISOU 2582  O4'   G A  39    10036   8781   8971   2632    466  -1614       O  
+ATOM   2583  C3'   G A  39     153.980  47.860 153.775  1.00 64.49           C  
+ANISOU 2583  C3'   G A  39     8719   7793   7990   2242    648  -1450       C  
+ATOM   2584  O3'   G A  39     154.332  46.571 154.224  1.00 62.61           O  
+ANISOU 2584  O3'   G A  39     8334   7675   7781   2069    770  -1403       O  
+ATOM   2585  C2'   G A  39     152.538  47.964 153.317  1.00 69.98           C  
+ANISOU 2585  C2'   G A  39     9299   8661   8629   2420    645  -1505       C  
+ATOM   2586  O2'   G A  39     151.689  47.259 154.210  1.00 74.64           O  
+ANISOU 2586  O2'   G A  39     9694   9506   9161   2479    743  -1555       O  
+ATOM   2587  C1'   G A  39     152.288  49.468 153.460  1.00 72.69           C  
+ANISOU 2587  C1'   G A  39     9834   8866   8920   2644    506  -1589       C  
+ATOM   2588  N9    G A  39     152.615  50.172 152.213  1.00 72.78           N  
+ANISOU 2588  N9    G A  39     9998   8682   8975   2624    401  -1537       N  
+ATOM   2589  C8    G A  39     153.683  50.995 151.935  1.00 71.68           C  
+ANISOU 2589  C8    G A  39    10083   8273   8878   2554    296  -1490       C  
+ATOM   2590  N7    G A  39     153.673  51.444 150.700  1.00 69.17           N  
+ANISOU 2590  N7    G A  39     9850   7847   8586   2546    224  -1438       N  
+ATOM   2591  C5    G A  39     152.532  50.867 150.139  1.00 63.27           C  
+ANISOU 2591  C5    G A  39     8922   7304   7812   2619    283  -1458       C  
+ATOM   2592  C6    G A  39     151.970  50.963 148.840  1.00 61.25           C  
+ANISOU 2592  C6    G A  39     8656   7053   7563   2651    245  -1427       C  
+ATOM   2593  O6    G A  39     152.390  51.611 147.864  1.00 62.36           O  
+ANISOU 2593  O6    G A  39     8954   7012   7728   2619    154  -1369       O  
+ATOM   2594  N1    G A  39     150.801  50.203 148.736  1.00 59.02           N  
+ANISOU 2594  N1    G A  39     8153   7022   7251   2721    322  -1463       N  
+ATOM   2595  C2    G A  39     150.236  49.446 149.735  1.00 61.92           C  
+ANISOU 2595  C2    G A  39     8328   7614   7584   2749    425  -1513       C  
+ATOM   2596  N2    G A  39     149.110  48.771 149.454  1.00 59.25           N  
+ANISOU 2596  N2    G A  39     7782   7506   7223   2800    481  -1528       N  
+ATOM   2597  N3    G A  39     150.741  49.356 150.943  1.00 63.14           N  
+ANISOU 2597  N3    G A  39     8493   7770   7726   2723    466  -1541       N  
+ATOM   2598  C4    G A  39     151.875  50.079 151.063  1.00 69.48           C  
+ANISOU 2598  C4    G A  39     9513   8326   8560   2662    390  -1516       C  
+ATOM   2599  P     G A  40     155.144  45.579 153.259  1.00 61.46           P  
+ANISOU 2599  P     G A  40     8142   7488   7723   1826    826  -1284       P  
+ATOM   2600  OP1   G A  40     155.361  44.350 154.077  1.00 59.01           O  
+ANISOU 2600  OP1   G A  40     7691   7310   7419   1696    937  -1266       O  
+ATOM   2601  OP2   G A  40     156.295  46.277 152.613  1.00 54.18           O  
+ANISOU 2601  OP2   G A  40     7408   6320   6860   1741    747  -1219       O  
+ATOM   2602  O5'   G A  40     154.086  45.232 152.123  1.00 72.46           O  
+ANISOU 2602  O5'   G A  40     9416   9007   9106   1872    837  -1271       O  
+ATOM   2603  C5'   G A  40     152.923  44.480 152.433  1.00 67.05           C  
+ANISOU 2603  C5'   G A  40     8529   8570   8378   1926    908  -1306       C  
+ATOM   2604  C4'   G A  40     151.996  44.372 151.249  1.00 63.41           C  
+ANISOU 2604  C4'   G A  40     7991   8189   7915   1977    886  -1292       C  
+ATOM   2605  O4'   G A  40     151.576  45.692 150.816  1.00 62.85           O  
+ANISOU 2605  O4'   G A  40     8048   8020   7812   2168    777  -1345       O  
+ATOM   2606  C3'   G A  40     152.568  43.730 149.991  1.00 60.40           C  
+ANISOU 2606  C3'   G A  40     7622   7729   7598   1809    893  -1196       C  
+ATOM   2607  O3'   G A  40     152.536  42.313 150.054  1.00 55.19           O  
+ANISOU 2607  O3'   G A  40     6805   7205   6960   1654    982  -1149       O  
+ATOM   2608  C2'   G A  40     151.650  44.271 148.908  1.00 63.71           C  
+ANISOU 2608  C2'   G A  40     8046   8163   7998   1938    822  -1211       C  
+ATOM   2609  O2'   G A  40     150.456  43.510 148.887  1.00 66.99           O  
+ANISOU 2609  O2'   G A  40     8258   8809   8386   1971    864  -1229       O  
+ATOM   2610  C1'   G A  40     151.331  45.685 149.429  1.00 66.43           C  
+ANISOU 2610  C1'   G A  40     8511   8436   8291   2150    737  -1298       C  
+ATOM   2611  N9    G A  40     152.189  46.694 148.782  1.00 70.69           N  
+ANISOU 2611  N9    G A  40     9277   8724   8859   2146    642  -1266       N  
+ATOM   2612  C8    G A  40     153.358  47.240 149.256  1.00 65.76           C  
+ANISOU 2612  C8    G A  40     8814   7912   8260   2081    610  -1245       C  
+ATOM   2613  N7    G A  40     153.913  48.078 148.424  1.00 57.73           N  
+ANISOU 2613  N7    G A  40     7972   6697   7265   2071    519  -1200       N  
+ATOM   2614  C5    G A  40     153.070  48.074 147.324  1.00 59.70           C  
+ANISOU 2614  C5    G A  40     8179   7003   7499   2139    492  -1195       C  
+ATOM   2615  C6    G A  40     153.158  48.791 146.102  1.00 59.72           C  
+ANISOU 2615  C6    G A  40     8319   6864   7509   2161    401  -1149       C  
+ATOM   2616  O6    G A  40     154.028  49.593 145.742  1.00 62.16           O  
+ANISOU 2616  O6    G A  40     8814   6964   7838   2114    326  -1096       O  
+ATOM   2617  N1    G A  40     152.089  48.495 145.259  1.00 60.41           N  
+ANISOU 2617  N1    G A  40     8305   7076   7574   2239    398  -1163       N  
+ATOM   2618  C2    G A  40     151.064  47.620 145.557  1.00 69.05           C  
+ANISOU 2618  C2    G A  40     9184   8406   8647   2282    469  -1208       C  
+ATOM   2619  N2    G A  40     150.123  47.468 144.602  1.00 70.94           N  
+ANISOU 2619  N2    G A  40     9352   8732   8871   2350    440  -1210       N  
+ATOM   2620  N3    G A  40     150.972  46.943 146.700  1.00 70.25           N  
+ANISOU 2620  N3    G A  40     9202   8698   8792   2252    556  -1243       N  
+ATOM   2621  C4    G A  40     152.005  47.219 147.526  1.00 68.62           C  
+ANISOU 2621  C4    G A  40     9099   8369   8603   2186    564  -1236       C  
+ATOM   2622  P     A A  41     153.853  41.410 149.875  1.00 58.17           P  
+ANISOU 2622  P     A A  41     7216   7485   7400   1430   1033  -1065       P  
+ATOM   2623  OP1   A A  41     153.786  40.347 150.910  1.00 61.58           O  
+ANISOU 2623  OP1   A A  41     7514   8060   7825   1341   1115  -1067       O  
+ATOM   2624  OP2   A A  41     155.066  42.240 149.717  1.00 53.94           O  
+ANISOU 2624  OP2   A A  41     6869   6728   6897   1399    988  -1037       O  
+ATOM   2625  O5'   A A  41     153.628  40.666 148.485  1.00 67.22           O  
+ANISOU 2625  O5'   A A  41     8314   8656   8571   1353   1031  -1004       O  
+ATOM   2626  C5'   A A  41     153.615  41.403 147.267  1.00 65.49           C  
+ANISOU 2626  C5'   A A  41     8202   8326   8356   1412    960   -984       C  
+ATOM   2627  C4'   A A  41     153.225  40.553 146.081  1.00 54.05           C  
+ANISOU 2627  C4'   A A  41     6686   6936   6916   1350    962   -937       C  
+ATOM   2628  O4'   A A  41     153.444  41.332 144.880  1.00 54.23           O  
+ANISOU 2628  O4'   A A  41     6843   6822   6940   1396    895   -907       O  
+ATOM   2629  C3'   A A  41     154.030  39.268 145.897  1.00 52.51           C  
+ANISOU 2629  C3'   A A  41     6456   6740   6755   1164   1023   -872       C  
+ATOM   2630  O3'   A A  41     153.250  38.341 145.156  1.00 57.34           O  
+ANISOU 2630  O3'   A A  41     6962   7464   7360   1132   1018   -855       O  
+ATOM   2631  C2'   A A  41     155.159  39.723 144.990  1.00 52.64           C  
+ANISOU 2631  C2'   A A  41     6630   6576   6795   1115   1003   -811       C  
+ATOM   2632  O2'   A A  41     155.725  38.674 144.241  1.00 57.81           O  
+ANISOU 2632  O2'   A A  41     7273   7225   7466    989   1036   -749       O  
+ATOM   2633  C1'   A A  41     154.436  40.713 144.082  1.00 55.90           C  
+ANISOU 2633  C1'   A A  41     7109   6950   7181   1254    922   -827       C  
+ATOM   2634  N9    A A  41     155.301  41.765 143.540  1.00 55.65           N  
+ANISOU 2634  N9    A A  41     7252   6735   7157   1265    878   -787       N  
+ATOM   2635  C8    A A  41     156.513  42.206 144.015  1.00 56.02           C  
+ANISOU 2635  C8    A A  41     7401   6653   7231   1195    890   -753       C  
+ATOM   2636  N7    A A  41     157.040  43.167 143.290  1.00 60.01           N  
+ANISOU 2636  N7    A A  41     8054   7011   7738   1211    833   -706       N  
+ATOM   2637  C5    A A  41     156.107  43.375 142.273  1.00 60.14           C  
+ANISOU 2637  C5    A A  41     8074   7057   7721   1306    781   -716       C  
+ATOM   2638  C6    A A  41     156.047  44.260 141.176  1.00 59.15           C  
+ANISOU 2638  C6    A A  41     8076   6826   7574   1366    705   -680       C  
+ATOM   2639  N6    A A  41     156.981  45.165 140.867  1.00 60.37           N  
+ANISOU 2639  N6    A A  41     8387   6814   7738   1330    664   -616       N  
+ATOM   2640  N1    A A  41     154.969  44.180 140.370  1.00 60.28           N  
+ANISOU 2640  N1    A A  41     8180   7040   7685   1460    664   -706       N  
+ATOM   2641  C2    A A  41     154.012  43.292 140.645  1.00 58.51           C  
+ANISOU 2641  C2    A A  41     7793   6984   7453   1485    695   -759       C  
+ATOM   2642  N3    A A  41     153.948  42.427 141.648  1.00 59.47           N  
+ANISOU 2642  N3    A A  41     7782   7220   7592   1427    765   -789       N  
+ATOM   2643  C4    A A  41     155.033  42.518 142.427  1.00 57.23           C  
+ANISOU 2643  C4    A A  41     7548   6859   7336   1342    807   -768       C  
+ATOM   2644  P     A A  42     152.637  37.004 145.795  1.00 65.61           P  
+ANISOU 2644  P     A A  42     7832   8689   8406   1043   1063   -856       P  
+ATOM   2645  OP1   A A  42     152.259  37.178 147.206  1.00 61.47           O  
+ANISOU 2645  OP1   A A  42     7226   8269   7863   1084   1101   -904       O  
+ATOM   2646  OP2   A A  42     153.583  35.912 145.426  1.00 71.35           O  
+ANISOU 2646  OP2   A A  42     8588   9360   9162    882   1093   -797       O  
+ATOM   2647  O5'   A A  42     151.352  36.784 144.876  1.00 78.59           O  
+ANISOU 2647  O5'   A A  42     9387  10443  10030   1102   1006   -860       O  
+ATOM   2648  C5'   A A  42     150.047  37.224 145.238  1.00 59.51           C  
+ANISOU 2648  C5'   A A  42     6854   8175   7583   1231    982   -910       C  
+ATOM   2649  C4'   A A  42     149.829  38.714 145.090  1.00 62.35           C  
+ANISOU 2649  C4'   A A  42     7310   8461   7919   1412    933   -961       C  
+ATOM   2650  O4'   A A  42     149.651  39.101 143.683  1.00 59.96           O  
+ANISOU 2650  O4'   A A  42     7091   8075   7616   1463    860   -942       O  
+ATOM   2651  C3'   A A  42     148.576  39.209 145.818  1.00 63.98           C  
+ANISOU 2651  C3'   A A  42     7387   8839   8083   1566    924  -1027       C  
+ATOM   2652  O3'   A A  42     148.821  40.473 146.411  1.00 73.23           O  
+ANISOU 2652  O3'   A A  42     8667   9926   9230   1707    907  -1085       O  
+ATOM   2653  C2'   A A  42     147.572  39.370 144.684  1.00 60.29           C  
+ANISOU 2653  C2'   A A  42     6879   8422   7605   1652    848  -1030       C  
+ATOM   2654  O2'   A A  42     146.503  40.244 144.946  1.00 68.62           O  
+ANISOU 2654  O2'   A A  42     7872   9583   8618   1848    809  -1097       O  
+ATOM   2655  C1'   A A  42     148.467  39.876 143.570  1.00 55.71           C  
+ANISOU 2655  C1'   A A  42     6500   7623   7044   1638    801   -996       C  
+ATOM   2656  N9    A A  42     147.838  39.742 142.250  1.00 61.04           N  
+ANISOU 2656  N9    A A  42     7171   8304   7716   1663    731   -975       N  
+ATOM   2657  C8    A A  42     147.382  38.594 141.644  1.00 61.68           C  
+ANISOU 2657  C8    A A  42     7150   8477   7810   1562    721   -935       C  
+ATOM   2658  N7    A A  42     146.802  38.783 140.484  1.00 57.36           N  
+ANISOU 2658  N7    A A  42     6628   7915   7252   1624    642   -929       N  
+ATOM   2659  C5    A A  42     146.848  40.156 140.315  1.00 62.30           C  
+ANISOU 2659  C5    A A  42     7377   8437   7856   1779    598   -967       C  
+ATOM   2660  C6    A A  42     146.395  40.994 139.274  1.00 61.63           C  
+ANISOU 2660  C6    A A  42     7383   8284   7750   1907    505   -979       C  
+ATOM   2661  N6    A A  42     145.778  40.550 138.169  1.00 61.90           N  
+ANISOU 2661  N6    A A  42     7387   8351   7779   1901    443   -956       N  
+ATOM   2662  N1    A A  42     146.603  42.320 139.408  1.00 59.75           N  
+ANISOU 2662  N1    A A  42     7278   7932   7493   2042    468  -1015       N  
+ATOM   2663  C2    A A  42     147.211  42.761 140.514  1.00 58.41           C  
+ANISOU 2663  C2    A A  42     7147   7721   7326   2048    518  -1040       C  
+ATOM   2664  N3    A A  42     147.683  42.075 141.549  1.00 57.78           N  
+ANISOU 2664  N3    A A  42     6989   7699   7264   1939    608  -1034       N  
+ATOM   2665  C4    A A  42     147.478  40.759 141.394  1.00 60.97           C  
+ANISOU 2665  C4    A A  42     7261   8218   7687   1804    648   -995       C  
+ATOM   2666  P     A A  43     148.476  40.674 147.958  1.00 60.83           P  
+ANISOU 2666  P     A A  43     7008   8486   7619   1784    960  -1146       P  
+ATOM   2667  OP1   A A  43     149.771  40.900 148.662  1.00 57.08           O  
+ANISOU 2667  OP1   A A  43     6670   7855   7163   1713    991  -1140       O  
+ATOM   2668  OP2   A A  43     147.555  39.582 148.367  1.00 74.00           O  
+ANISOU 2668  OP2   A A  43     8451  10394   9273   1723   1011  -1130       O  
+ATOM   2669  O5'   A A  43     147.640  42.018 147.998  1.00 64.01           O  
+ANISOU 2669  O5'   A A  43     7445   8908   7970   2033    891  -1229       O  
+ATOM   2670  C5'   A A  43     146.323  42.084 147.482  1.00 63.15           C  
+ANISOU 2670  C5'   A A  43     7207   8955   7832   2152    851  -1253       C  
+ATOM   2671  C4'   A A  43     145.854  43.507 147.473  1.00 68.43           C  
+ANISOU 2671  C4'   A A  43     7970   9576   8454   2395    772  -1334       C  
+ATOM   2672  O4'   A A  43     145.762  43.965 148.846  1.00 80.51           O  
+ANISOU 2672  O4'   A A  43     9480  11179   9930   2509    810  -1404       O  
+ATOM   2673  C3'   A A  43     146.795  44.470 146.773  1.00 66.92           C  
+ANISOU 2673  C3'   A A  43     8034   9107   8286   2413    693  -1326       C  
+ATOM   2674  O3'   A A  43     146.032  45.555 146.257  1.00 74.13           O  
+ANISOU 2674  O3'   A A  43     9008   9997   9162   2627    593  -1384       O  
+ATOM   2675  C2'   A A  43     147.703  44.936 147.912  1.00 70.44           C  
+ANISOU 2675  C2'   A A  43     8593   9448   8723   2411    720  -1355       C  
+ATOM   2676  O2'   A A  43     148.330  46.187 147.723  1.00 67.44           O  
+ANISOU 2676  O2'   A A  43     8444   8840   8340   2499    629  -1378       O  
+ATOM   2677  C1'   A A  43     146.750  44.945 149.107  1.00 76.93           C  
+ANISOU 2677  C1'   A A  43     9257  10495   9479   2552    764  -1432       C  
+ATOM   2678  N9    A A  43     147.406  44.534 150.348  1.00 75.88           N  
+ANISOU 2678  N9    A A  43     9109  10381   9339   2464    846  -1433       N  
+ATOM   2679  C8    A A  43     147.413  43.257 150.850  1.00 73.74           C  
+ANISOU 2679  C8    A A  43     8673  10262   9083   2299    947  -1385       C  
+ATOM   2680  N7    A A  43     148.065  43.136 151.978  1.00 74.20           N  
+ANISOU 2680  N7    A A  43     8761  10304   9129   2250   1001  -1397       N  
+ATOM   2681  C5    A A  43     148.517  44.425 152.232  1.00 71.25           C  
+ANISOU 2681  C5    A A  43     8585   9754   8733   2393    927  -1458       C  
+ATOM   2682  C6    A A  43     149.274  44.952 153.291  1.00 70.42           C  
+ANISOU 2682  C6    A A  43     8607   9544   8606   2421    925  -1499       C  
+ATOM   2683  N6    A A  43     149.721  44.212 154.308  1.00 66.00           N  
+ANISOU 2683  N6    A A  43     7985   9049   8042   2307   1011  -1484       N  
+ATOM   2684  N1    A A  43     149.553  46.277 153.256  1.00 70.91           N  
+ANISOU 2684  N1    A A  43     8872   9422   8649   2570    820  -1556       N  
+ATOM   2685  C2    A A  43     149.098  47.000 152.213  1.00 67.66           C  
+ANISOU 2685  C2    A A  43     8529   8940   8239   2681    729  -1567       C  
+ATOM   2686  N3    A A  43     148.367  46.631 151.163  1.00 56.83           N  
+ANISOU 2686  N3    A A  43     7051   7659   6885   2676    725  -1535       N  
+ATOM   2687  C4    A A  43     148.110  45.309 151.240  1.00 69.38           C  
+ANISOU 2687  C4    A A  43     8437   9430   8493   2526    828  -1481       C  
+ATOM   2688  P     G A  44     146.267  46.043 144.749  1.00 66.79           P  
+ANISOU 2688  P     G A  44     8235   8883   8259   2623    496  -1341       P  
+ATOM   2689  OP1   G A  44     147.714  45.856 144.446  1.00 63.89           O  
+ANISOU 2689  OP1   G A  44     8022   8311   7941   2432    518  -1262       O  
+ATOM   2690  OP2   G A  44     145.597  47.359 144.595  1.00 67.80           O  
+ANISOU 2690  OP2   G A  44     8459   8966   8338   2868    385  -1420       O  
+ATOM   2691  O5'   G A  44     145.425  45.019 143.871  1.00 67.98           O  
+ANISOU 2691  O5'   G A  44     8210   9195   8426   2555    508  -1299       O  
+ATOM   2692  C5'   G A  44     144.014  45.113 143.813  1.00 70.70           C  
+ANISOU 2692  C5'   G A  44     8393   9736   8733   2714    474  -1351       C  
+ATOM   2693  C4'   G A  44     143.503  44.810 142.430  1.00 68.26           C  
+ANISOU 2693  C4'   G A  44     8064   9429   8443   2691    409  -1309       C  
+ATOM   2694  O4'   G A  44     144.368  43.837 141.802  1.00 67.93           O  
+ANISOU 2694  O4'   G A  44     8061   9300   8451   2461    449  -1218       O  
+ATOM   2695  C3'   G A  44     142.119  44.183 142.380  1.00 72.11           C  
+ANISOU 2695  C3'   G A  44     8302  10180   8918   2739    408  -1322       C  
+ATOM   2696  O3'   G A  44     141.096  45.162 142.414  1.00 66.48           O  
+ANISOU 2696  O3'   G A  44     7557   9547   8155   2989    334  -1402       O  
+ATOM   2697  C2'   G A  44     142.152  43.367 141.087  1.00 75.25           C  
+ANISOU 2697  C2'   G A  44     8700  10536   9356   2593    374  -1245       C  
+ATOM   2698  O2'   G A  44     141.902  44.192 139.964  1.00 78.99           O  
+ANISOU 2698  O2'   G A  44     9306  10891   9817   2713    263  -1257       O  
+ATOM   2699  C1'   G A  44     143.611  42.937 141.027  1.00 69.72           C  
+ANISOU 2699  C1'   G A  44     8148   9651   8691   2399    431  -1182       C  
+ATOM   2700  N9    G A  44     143.852  41.577 141.538  1.00 71.36           N  
+ANISOU 2700  N9    G A  44     8219   9965   8928   2202    521  -1132       N  
+ATOM   2701  C8    G A  44     144.713  41.303 142.567  1.00 65.05           C  
+ANISOU 2701  C8    G A  44     7437   9140   8139   2105    610  -1125       C  
+ATOM   2702  N7    G A  44     144.823  40.038 142.832  1.00 62.51           N  
+ANISOU 2702  N7    G A  44     6999   8910   7843   1931    670  -1075       N  
+ATOM   2703  C5    G A  44     143.973  39.438 141.917  1.00 62.75           C  
+ANISOU 2703  C5    G A  44     6930   9031   7880   1907    613  -1047       C  
+ATOM   2704  C6    G A  44     143.683  38.067 141.740  1.00 58.53           C  
+ANISOU 2704  C6    G A  44     6263   8605   7370   1741    624   -990       C  
+ATOM   2705  O6    G A  44     144.135  37.113 142.381  1.00 57.76           O  
+ANISOU 2705  O6    G A  44     6111   8544   7291   1584    689   -954       O  
+ATOM   2706  N1    G A  44     142.779  37.863 140.701  1.00 58.73           N  
+ANISOU 2706  N1    G A  44     6230   8689   7397   1770    536   -977       N  
+ATOM   2707  C2    G A  44     142.221  38.852 139.937  1.00 59.57           C  
+ANISOU 2707  C2    G A  44     6393   8758   7482   1942    453  -1015       C  
+ATOM   2708  N2    G A  44     141.367  38.421 139.003  1.00 61.06           N  
+ANISOU 2708  N2    G A  44     6506   9016   7677   1937    369   -993       N  
+ATOM   2709  N3    G A  44     142.479  40.143 140.092  1.00 64.85           N  
+ANISOU 2709  N3    G A  44     7190   9325   8127   2102    442  -1069       N  
+ATOM   2710  C4    G A  44     143.367  40.366 141.093  1.00 68.42           C  
+ANISOU 2710  C4    G A  44     7706   9714   8578   2073    522  -1082       C  
+ATOM   2711  P     C A  45     139.731  44.924 143.232  1.00 77.83           P  
+ANISOU 2711  P     C A  45     8715  11306   9550   3115    369  -1452       P  
+ATOM   2712  OP1   C A  45     138.966  46.195 143.169  1.00 76.52           O  
+ANISOU 2712  OP1   C A  45     8592  11153   9328   3402    277  -1546       O  
+ATOM   2713  OP2   C A  45     139.988  44.270 144.534  1.00 74.09           O  
+ANISOU 2713  OP2   C A  45     8120  10962   9068   3019    491  -1445       O  
+ATOM   2714  O5'   C A  45     138.955  43.845 142.367  1.00 85.96           O  
+ANISOU 2714  O5'   C A  45     9562  12483  10617   2995    350  -1385       O  
+ATOM   2715  C5'   C A  45     138.599  44.103 141.020  1.00 78.88           C  
+ANISOU 2715  C5'   C A  45     8736  11501   9733   3039    239  -1373       C  
+ATOM   2716  C4'   C A  45     138.048  42.858 140.385  1.00 67.61           C  
+ANISOU 2716  C4'   C A  45     7138  10205   8345   2876    232  -1300       C  
+ATOM   2717  O4'   C A  45     139.119  41.904 140.203  1.00 61.17           O  
+ANISOU 2717  O4'   C A  45     6403   9264   7574   2629    287  -1223       O  
+ATOM   2718  C3'   C A  45     137.036  42.111 141.233  1.00 69.27           C  
+ANISOU 2718  C3'   C A  45     7045  10728   8545   2857    290  -1292       C  
+ATOM   2719  O3'   C A  45     135.736  42.667 141.165  1.00 72.37           O  
+ANISOU 2719  O3'   C A  45     7285  11310   8902   3066    229  -1344       O  
+ATOM   2720  C2'   C A  45     137.146  40.682 140.718  1.00 65.32           C  
+ANISOU 2720  C2'   C A  45     6466  10254   8100   2598    297  -1195       C  
+ATOM   2721  O2'   C A  45     136.427  40.532 139.502  1.00 71.17           O  
+ANISOU 2721  O2'   C A  45     7178  11007   8858   2612    185  -1173       O  
+ATOM   2722  C1'   C A  45     138.638  40.590 140.409  1.00 60.39           C  
+ANISOU 2722  C1'   C A  45     6092   9351   7501   2463    325  -1165       C  
+ATOM   2723  N1    C A  45     139.424  39.962 141.496  1.00 67.84           N  
+ANISOU 2723  N1    C A  45     7016  10307   8455   2316    440  -1139       N  
+ATOM   2724  C2    C A  45     139.429  38.569 141.625  1.00 69.23           C  
+ANISOU 2724  C2    C A  45     7066  10575   8664   2096    477  -1065       C  
+ATOM   2725  O2    C A  45     138.754  37.865 140.857  1.00 66.40           O  
+ANISOU 2725  O2    C A  45     6609  10292   8326   2024    410  -1021       O  
+ATOM   2726  N3    C A  45     140.163  38.014 142.613  1.00 69.62           N  
+ANISOU 2726  N3    C A  45     7107  10625   8719   1966    576  -1043       N  
+ATOM   2727  C4    C A  45     140.886  38.768 143.438  1.00 63.23           C  
+ANISOU 2727  C4    C A  45     6407   9731   7887   2042    638  -1091       C  
+ATOM   2728  N4    C A  45     141.596  38.140 144.379  1.00 59.33           N  
+ANISOU 2728  N4    C A  45     5901   9241   7401   1905    728  -1065       N  
+ATOM   2729  C5    C A  45     140.911  40.188 143.331  1.00 65.25           C  
+ANISOU 2729  C5    C A  45     6797   9886   8110   2260    597  -1166       C  
+ATOM   2730  C6    C A  45     140.173  40.729 142.353  1.00 69.91           C  
+ANISOU 2730  C6    C A  45     7395  10473   8692   2389    498  -1187       C  
+ATOM   2731  P     C A  46     134.828  42.704 142.483  1.00 87.10           P  
+ANISOU 2731  P     C A  46     8893  13486  10716   3184    307  -1385       P  
+ATOM   2732  OP1   C A  46     133.654  43.575 142.222  1.00 86.33           O  
+ANISOU 2732  OP1   C A  46     8702  13525  10574   3450    224  -1455       O  
+ATOM   2733  OP2   C A  46     135.700  43.028 143.634  1.00 88.26           O  
+ANISOU 2733  OP2   C A  46     9140  13563  10832   3194    404  -1420       O  
+ATOM   2734  O5'   C A  46     134.345  41.195 142.637  1.00 64.10           O  
+ANISOU 2734  O5'   C A  46     5726  10789   7841   2948    355  -1285       O  
+ATOM   2735  C5'   C A  46     133.728  40.530 141.549  1.00 64.27           C  
+ANISOU 2735  C5'   C A  46     5661  10850   7907   2850    264  -1225       C  
+ATOM   2736  C4'   C A  46     133.619  39.046 141.790  1.00 67.01           C  
+ANISOU 2736  C4'   C A  46     5834  11333   8296   2581    308  -1122       C  
+ATOM   2737  O4'   C A  46     134.922  38.417 141.744  1.00 64.96           O  
+ANISOU 2737  O4'   C A  46     5760  10849   8071   2374    351  -1078       O  
+ATOM   2738  C3'   C A  46     133.076  38.622 143.138  1.00 72.25           C  
+ANISOU 2738  C3'   C A  46     6243  12285   8925   2558    415  -1103       C  
+ATOM   2739  O3'   C A  46     131.678  38.757 143.231  1.00 70.73           O  
+ANISOU 2739  O3'   C A  46     5782  12386   8705   2684    386  -1107       O  
+ATOM   2740  C2'   C A  46     133.546  37.179 143.233  1.00 70.82           C  
+ANISOU 2740  C2'   C A  46     6024  12091   8794   2246    448   -997       C  
+ATOM   2741  O2'   C A  46     132.712  36.341 142.449  1.00 73.06           O  
+ANISOU 2741  O2'   C A  46     6155  12484   9120   2123    355   -922       O  
+ATOM   2742  C1'   C A  46     134.915  37.264 142.561  1.00 65.73           C  
+ANISOU 2742  C1'   C A  46     5695  11096   8182   2171    429  -1006       C  
+ATOM   2743  N1    C A  46     136.016  37.342 143.547  1.00 63.90           N  
+ANISOU 2743  N1    C A  46     5582  10761   7935   2127    540  -1024       N  
+ATOM   2744  C2    C A  46     136.429  36.141 144.140  1.00 64.39           C  
+ANISOU 2744  C2    C A  46     5579  10864   8020   1889    605   -948       C  
+ATOM   2745  O2    C A  46     135.867  35.077 143.830  1.00 73.81           O  
+ANISOU 2745  O2    C A  46     6627  12172   9245   1723    563   -868       O  
+ATOM   2746  N3    C A  46     137.430  36.157 145.043  1.00 59.38           N  
+ANISOU 2746  N3    C A  46     5050  10139   7374   1842    701   -961       N  
+ATOM   2747  C4    C A  46     138.012  37.312 145.352  1.00 60.12           C  
+ANISOU 2747  C4    C A  46     5306  10103   7436   2015    729  -1044       C  
+ATOM   2748  N4    C A  46     139.005  37.271 146.243  1.00 63.79           N  
+ANISOU 2748  N4    C A  46     5868  10476   7891   1954    815  -1052       N  
+ATOM   2749  C5    C A  46     137.617  38.550 144.768  1.00 60.10           C  
+ANISOU 2749  C5    C A  46     5380  10047   7408   2252    659  -1120       C  
+ATOM   2750  C6    C A  46     136.623  38.520 143.872  1.00 60.81           C  
+ANISOU 2750  C6    C A  46     5366  10230   7509   2304    568  -1108       C  
+ATOM   2751  P     U A  47     131.022  39.073 144.651  1.00 81.15           P  
+ANISOU 2751  P     U A  47     6876  14011   9947   2825    497  -1140       P  
+ATOM   2752  OP1   U A  47     129.557  39.190 144.432  1.00 75.56           O  
+ANISOU 2752  OP1   U A  47     5894  13595   9219   2953    443  -1135       O  
+ATOM   2753  OP2   U A  47     131.798  40.189 145.256  1.00 82.27           O  
+ANISOU 2753  OP2   U A  47     7230  13994  10035   3015    549  -1245       O  
+ATOM   2754  O5'   U A  47     131.330  37.761 145.503  1.00 78.34           O  
+ANISOU 2754  O5'   U A  47     6394  13763   9608   2543    598  -1037       O  
+ATOM   2755  C5'   U A  47     130.692  36.531 145.192  1.00 75.59           C  
+ANISOU 2755  C5'   U A  47     5840  13571   9308   2314    559   -920       C  
+ATOM   2756  C4'   U A  47     131.232  35.393 146.026  1.00 74.25           C  
+ANISOU 2756  C4'   U A  47     5625  13436   9152   2051    648   -831       C  
+ATOM   2757  O4'   U A  47     132.666  35.276 145.863  1.00 67.49           O  
+ANISOU 2757  O4'   U A  47     5065  12250   8327   1947    663   -847       O  
+ATOM   2758  C3'   U A  47     131.039  35.514 147.525  1.00 73.28           C  
+ANISOU 2758  C3'   U A  47     5342  13549   8950   2112    790   -840       C  
+ATOM   2759  O3'   U A  47     129.746  35.119 147.921  1.00 73.45           O  
+ANISOU 2759  O3'   U A  47     5024  13941   8944   2103    805   -773       O  
+ATOM   2760  C2'   U A  47     132.116  34.599 148.082  1.00 69.87           C  
+ANISOU 2760  C2'   U A  47     5024  12980   8544   1863    856   -780       C  
+ATOM   2761  O2'   U A  47     131.652  33.258 148.066  1.00 68.37           O  
+ANISOU 2761  O2'   U A  47     4650  12935   8394   1594    831   -648       O  
+ATOM   2762  C1'   U A  47     133.240  34.767 147.050  1.00 69.59           C  
+ANISOU 2762  C1'   U A  47     5312  12560   8569   1825    781   -817       C  
+ATOM   2763  N1    U A  47     134.291  35.707 147.502  1.00 69.98           N  
+ANISOU 2763  N1    U A  47     5598  12404   8586   1966    842   -913       N  
+ATOM   2764  C2    U A  47     135.300  35.234 148.329  1.00 70.53           C  
+ANISOU 2764  C2    U A  47     5765  12379   8655   1826    930   -893       C  
+ATOM   2765  O2    U A  47     135.384  34.069 148.708  1.00 72.32           O  
+ANISOU 2765  O2    U A  47     5899  12676   8903   1593    959   -801       O  
+ATOM   2766  N3    U A  47     136.228  36.182 148.699  1.00 62.28           N  
+ANISOU 2766  N3    U A  47     4938  11143   7583   1964    970   -982       N  
+ATOM   2767  C4    U A  47     136.250  37.512 148.335  1.00 62.02           C  
+ANISOU 2767  C4    U A  47     5041  11000   7524   2216    928  -1084       C  
+ATOM   2768  O4    U A  47     137.159  38.238 148.731  1.00 61.17           O  
+ANISOU 2768  O4    U A  47     5134  10711   7398   2300    958  -1148       O  
+ATOM   2769  C5    U A  47     135.184  37.915 147.481  1.00 63.45           C  
+ANISOU 2769  C5    U A  47     5120  11283   7706   2351    838  -1100       C  
+ATOM   2770  C6    U A  47     134.265  37.022 147.107  1.00 68.27           C  
+ANISOU 2770  C6    U A  47     5509  12087   8343   2227    802  -1018       C  
+ATOM   2771  P     A A  48     128.787  36.163 148.652  1.00 74.71           P  
+ANISOU 2771  P     A A  48     4990  14395   9003   2416    869   -851       P  
+ATOM   2772  OP1   A A  48     127.464  35.511 148.840  1.00 77.83           O  
+ANISOU 2772  OP1   A A  48     5059  15123   9389   2321    861   -743       O  
+ATOM   2773  OP2   A A  48     128.898  37.449 147.923  1.00 77.56           O  
+ANISOU 2773  OP2   A A  48     5546  14569   9355   2691    794   -980       O  
+ATOM   2774  O5'   A A  48     129.482  36.376 150.066  1.00 96.70           O  
+ANISOU 2774  O5'   A A  48     7853  17177  11711   2446   1015   -886       O  
+ATOM   2775  C5'   A A  48     129.562  35.315 151.008  1.00 92.75           C  
+ANISOU 2775  C5'   A A  48     7249  16793  11200   2197   1100   -774       C  
+ATOM   2776  C4'   A A  48     129.332  35.792 152.421  1.00 88.34           C  
+ANISOU 2776  C4'   A A  48     6698  16332  10533   2297   1203   -795       C  
+ATOM   2777  O4'   A A  48     130.336  36.792 152.752  1.00 87.26           O  
+ANISOU 2777  O4'   A A  48     6826  15968  10361   2483   1236   -924       O  
+ATOM   2778  C3'   A A  48     127.970  36.435 152.688  1.00 84.69           C  
+ANISOU 2778  C3'   A A  48     6083  16099   9996   2482   1191   -805       C  
+ATOM   2779  O3'   A A  48     127.464  36.032 153.963  1.00 79.04           O  
+ANISOU 2779  O3'   A A  48     5239  15590   9201   2404   1284   -731       O  
+ATOM   2780  C2'   A A  48     128.278  37.931 152.706  1.00 84.16           C  
+ANISOU 2780  C2'   A A  48     6229  15874   9872   2804   1175   -965       C  
+ATOM   2781  O2'   A A  48     127.412  38.678 153.531  1.00 84.84           O  
+ANISOU 2781  O2'   A A  48     6254  16132   9848   2999   1207  -1002       O  
+ATOM   2782  C1'   A A  48     129.708  37.961 153.237  1.00 83.16           C  
+ANISOU 2782  C1'   A A  48     6334  15512   9749   2755   1238  -1010       C  
+ATOM   2783  N9    A A  48     130.490  39.121 152.790  1.00 79.25           N  
+ANISOU 2783  N9    A A  48     6105  14751   9256   2974   1189  -1148       N  
+ATOM   2784  C8    A A  48     130.121  40.064 151.867  1.00 76.48           C  
+ANISOU 2784  C8    A A  48     5820  14326   8912   3191   1087  -1232       C  
+ATOM   2785  N7    A A  48     131.026  40.994 151.679  1.00 73.86           N  
+ANISOU 2785  N7    A A  48     5757  13726   8578   3343   1055  -1340       N  
+ATOM   2786  C5    A A  48     132.056  40.654 152.546  1.00 72.00           C  
+ANISOU 2786  C5    A A  48     5633  13389   8335   3221   1144  -1330       C  
+ATOM   2787  C6    A A  48     133.307  41.249 152.827  1.00 70.42           C  
+ANISOU 2787  C6    A A  48     5706  12917   8132   3277   1155  -1409       C  
+ATOM   2788  N6    A A  48     133.765  42.357 152.237  1.00 70.03           N  
+ANISOU 2788  N6    A A  48     5888  12632   8088   3469   1070  -1512       N  
+ATOM   2789  N1    A A  48     134.104  40.645 153.741  1.00 72.48           N  
+ANISOU 2789  N1    A A  48     6004  13149   8387   3116   1249  -1372       N  
+ATOM   2790  C2    A A  48     133.660  39.522 154.333  1.00 76.00           C  
+ANISOU 2790  C2    A A  48     6234  13817   8826   2913   1325  -1261       C  
+ATOM   2791  N3    A A  48     132.503  38.878 154.157  1.00 75.59           N  
+ANISOU 2791  N3    A A  48     5924  14022   8776   2833   1320  -1173       N  
+ATOM   2792  C4    A A  48     131.739  39.496 153.235  1.00 72.32           C  
+ANISOU 2792  C4    A A  48     5469  13637   8370   2997   1227  -1215       C  
+ATOM   2793  P     A A  49     125.944  35.514 154.089  1.00104.50           P  
+ANISOU 2793  P     A A  49     8163  19143  12400   2333   1273   -615       P  
+ATOM   2794  OP1   A A  49     125.062  36.314 153.200  1.00104.34           O  
+ANISOU 2794  OP1   A A  49     8078  19184  12383   2546   1182   -676       O  
+ATOM   2795  OP2   A A  49     125.618  35.442 155.539  1.00108.19           O  
+ANISOU 2795  OP2   A A  49     8564  19784  12758   2332   1383   -578       O  
+ATOM   2796  O5'   A A  49     125.988  34.048 153.469  1.00 96.88           O  
+ANISOU 2796  O5'   A A  49     7073  18195  11543   1988   1224   -469       O  
+ATOM   2797  C5'   A A  49     127.058  33.156 153.760  1.00 87.68           C  
+ANISOU 2797  C5'   A A  49     6006  16887  10420   1751   1262   -416       C  
+ATOM   2798  C4'   A A  49     127.044  31.959 152.845  1.00 87.69           C  
+ANISOU 2798  C4'   A A  49     5913  16875  10531   1470   1170   -301       C  
+ATOM   2799  O4'   A A  49     125.700  31.394 152.799  1.00 93.89           O  
+ANISOU 2799  O4'   A A  49     6442  17916  11316   1362   1125   -179       O  
+ATOM   2800  C3'   A A  49     127.437  32.231 151.392  1.00 89.20           C  
+ANISOU 2800  C3'   A A  49     6187  16894  10809   1532   1058   -368       C  
+ATOM   2801  O3'   A A  49     128.082  31.066 150.874  1.00 79.55           O  
+ANISOU 2801  O3'   A A  49     4982  15570   9675   1247   1004   -284       O  
+ATOM   2802  C2'   A A  49     126.078  32.377 150.715  1.00 94.67           C  
+ANISOU 2802  C2'   A A  49     6678  17778  11516   1597    966   -333       C  
+ATOM   2803  O2'   A A  49     126.097  32.154 149.321  1.00101.05           O  
+ANISOU 2803  O2'   A A  49     7477  18499  12418   1553    830   -332       O  
+ATOM   2804  C1'   A A  49     125.274  31.312 151.457  1.00 95.43           C  
+ANISOU 2804  C1'   A A  49     6566  18099  11595   1352    992   -171       C  
+ATOM   2805  N9    A A  49     123.814  31.464 151.414  1.00105.42           N  
+ANISOU 2805  N9    A A  49     7604  19619  12831   1415    958   -119       N  
+ATOM   2806  C8    A A  49     123.062  32.465 150.844  1.00110.23           C  
+ANISOU 2806  C8    A A  49     8165  20297  13422   1676    909   -203       C  
+ATOM   2807  N7    A A  49     121.765  32.293 150.964  1.00112.74           N  
+ANISOU 2807  N7    A A  49     8252  20869  13716   1658    889   -121       N  
+ATOM   2808  C5    A A  49     121.646  31.090 151.656  1.00113.39           C  
+ANISOU 2808  C5    A A  49     8226  21054  13801   1361    926     32       C  
+ATOM   2809  C6    A A  49     120.529  30.346 152.102  1.00116.74           C  
+ANISOU 2809  C6    A A  49     8411  21737  14207   1194    926    181       C  
+ATOM   2810  N6    A A  49     119.255  30.717 151.913  1.00115.45           N  
+ANISOU 2810  N6    A A  49     8050  21797  14017   1308    895    200       N  
+ATOM   2811  N1    A A  49     120.769  29.187 152.761  1.00117.25           N  
+ANISOU 2811  N1    A A  49     8451  21820  14280    900    957    313       N  
+ATOM   2812  C2    A A  49     122.041  28.811 152.950  1.00112.56           C  
+ANISOU 2812  C2    A A  49     8053  21003  13711    788    986    293       C  
+ATOM   2813  N3    A A  49     123.167  29.421 152.584  1.00111.69           N  
+ANISOU 2813  N3    A A  49     8164  20652  13621    923    996    159       N  
+ATOM   2814  C4    A A  49     122.901  30.568 151.932  1.00110.32           C  
+ANISOU 2814  C4    A A  49     8014  20464  13439   1210    964     33       C  
+ATOM   2815  P     G A  50     129.585  31.113 150.316  1.00106.80           P  
+ANISOU 2815  P     G A  50     8749  18647  13181   1217    981   -360       P  
+ATOM   2816  OP1   G A  50     130.077  32.508 150.251  1.00104.58           O  
+ANISOU 2816  OP1   G A  50     8665  18208  12861   1523   1013   -518       O  
+ATOM   2817  OP2   G A  50     129.610  30.256 149.099  1.00102.78           O  
+ANISOU 2817  OP2   G A  50     8308  17970  12773   1004    828   -288       O  
+ATOM   2818  O5'   G A  50     130.457  30.440 151.465  1.00 93.54           O  
+ANISOU 2818  O5'   G A  50     7137  16931  11475   1041   1092   -314       O  
+ATOM   2819  C5'   G A  50     130.091  29.199 152.044  1.00 88.09           C  
+ANISOU 2819  C5'   G A  50     6257  16427  10787    765   1108   -164       C  
+ATOM   2820  C4'   G A  50     131.133  28.743 153.033  1.00 83.86           C  
+ANISOU 2820  C4'   G A  50     5858  15778  10225    638   1203   -151       C  
+ATOM   2821  O4'   G A  50     132.462  28.906 152.458  1.00 85.93           O  
+ANISOU 2821  O4'   G A  50     6464  15643  10543    637   1163   -232       O  
+ATOM   2822  C3'   G A  50     131.215  29.530 154.333  1.00 82.18           C  
+ANISOU 2822  C3'   G A  50     5710  15604   9909    817   1331   -215       C  
+ATOM   2823  O3'   G A  50     130.212  29.197 155.279  1.00 89.29           O  
+ANISOU 2823  O3'   G A  50     6443  16736  10744    759   1372   -120       O  
+ATOM   2824  C2'   G A  50     132.623  29.215 154.799  1.00 83.97           C  
+ANISOU 2824  C2'   G A  50     6135  15625  10145    717   1390   -241       C  
+ATOM   2825  O2'   G A  50     132.677  27.882 155.280  1.00 88.98           O  
+ANISOU 2825  O2'   G A  50     6714  16298  10796    411   1384   -101       O  
+ATOM   2826  C1'   G A  50     133.378  29.284 153.475  1.00 84.38           C  
+ANISOU 2826  C1'   G A  50     6404  15363  10291    705   1281   -295       C  
+ATOM   2827  N9    G A  50     133.814  30.672 153.234  1.00 78.95           N  
+ANISOU 2827  N9    G A  50     5895  14520   9582    997   1298   -447       N  
+ATOM   2828  C8    G A  50     133.186  31.590 152.430  1.00 82.44           C  
+ANISOU 2828  C8    G A  50     6313  14983  10026   1215   1238   -519       C  
+ATOM   2829  N7    G A  50     133.757  32.762 152.432  1.00 76.51           N  
+ANISOU 2829  N7    G A  50     5753  14068   9249   1449   1260   -647       N  
+ATOM   2830  C5    G A  50     134.804  32.616 153.321  1.00 67.81           C  
+ANISOU 2830  C5    G A  50     4796  12843   8125   1383   1344   -661       C  
+ATOM   2831  C6    G A  50     135.772  33.565 153.727  1.00 69.09           C  
+ANISOU 2831  C6    G A  50     5189  12805   8258   1546   1388   -772       C  
+ATOM   2832  O6    G A  50     135.887  34.741 153.369  1.00 71.99           O  
+ANISOU 2832  O6    G A  50     5686  13057   8610   1781   1359   -880       O  
+ATOM   2833  N1    G A  50     136.677  33.016 154.628  1.00 68.84           N  
+ANISOU 2833  N1    G A  50     5243  12696   8215   1400   1461   -745       N  
+ATOM   2834  C2    G A  50     136.643  31.724 155.095  1.00 68.42           C  
+ANISOU 2834  C2    G A  50     5075  12747   8175   1138   1489   -626       C  
+ATOM   2835  N2    G A  50     137.613  31.415 155.977  1.00 62.76           N  
+ANISOU 2835  N2    G A  50     4479  11926   7441   1044   1556   -624       N  
+ATOM   2836  N3    G A  50     135.731  30.826 154.726  1.00 72.08           N  
+ANISOU 2836  N3    G A  50     5328  13395   8664    978   1443   -517       N  
+ATOM   2837  C4    G A  50     134.852  31.336 153.837  1.00 70.80           C  
+ANISOU 2837  C4    G A  50     5073  13311   8517   1111   1371   -541       C  
+ATOM   2838  P     G A  51     129.712  30.311 156.323  1.00 89.90           P  
+ANISOU 2838  P     G A  51     6513  16942  10704   1031   1468   -198       P  
+ATOM   2839  OP1   G A  51     128.604  29.741 157.136  1.00 94.86           O  
+ANISOU 2839  OP1   G A  51     6935  17836  11272    926   1498    -75       O  
+ATOM   2840  OP2   G A  51     129.534  31.582 155.577  1.00 95.99           O  
+ANISOU 2840  OP2   G A  51     7337  17662  11472   1327   1432   -334       O  
+ATOM   2841  O5'   G A  51     130.956  30.525 157.286  1.00 88.09           O  
+ANISOU 2841  O5'   G A  51     6497  16540  10431   1056   1563   -264       O  
+ATOM   2842  C5'   G A  51     131.463  29.440 158.041  1.00 87.12           C  
+ANISOU 2842  C5'   G A  51     6393  16398  10310    802   1602   -164       C  
+ATOM   2843  C4'   G A  51     132.766  29.784 158.711  1.00 82.23           C  
+ANISOU 2843  C4'   G A  51     5999  15577   9666    855   1674   -250       C  
+ATOM   2844  O4'   G A  51     133.771  30.172 157.730  1.00 87.03           O  
+ANISOU 2844  O4'   G A  51     6776  15944  10347    913   1634   -346       O  
+ATOM   2845  C3'   G A  51     132.742  30.959 159.662  1.00 80.16           C  
+ANISOU 2845  C3'   G A  51     5814  15343   9300   1125   1752   -358       C  
+ATOM   2846  O3'   G A  51     132.110  30.683 160.899  1.00 90.19           O  
+ANISOU 2846  O3'   G A  51     6976  16815  10477   1093   1820   -287       O  
+ATOM   2847  C2'   G A  51     134.223  31.301 159.763  1.00 84.04           C  
+ANISOU 2847  C2'   G A  51     6556  15562   9813   1161   1780   -454       C  
+ATOM   2848  O2'   G A  51     134.913  30.341 160.550  1.00 86.65           O  
+ANISOU 2848  O2'   G A  51     6934  15846  10143    939   1825   -378       O  
+ATOM   2849  C1'   G A  51     134.648  31.131 158.307  1.00 83.29           C  
+ANISOU 2849  C1'   G A  51     6502  15317   9827   1105   1697   -471       C  
+ATOM   2850  N9    G A  51     134.484  32.413 157.597  1.00 82.53           N  
+ANISOU 2850  N9    G A  51     6471  15160   9728   1387   1660   -599       N  
+ATOM   2851  C8    G A  51     133.462  32.753 156.738  1.00 85.79           C  
+ANISOU 2851  C8    G A  51     6750  15690  10157   1489   1591   -602       C  
+ATOM   2852  N7    G A  51     133.551  33.972 156.283  1.00 81.60           N  
+ANISOU 2852  N7    G A  51     6333  15056   9613   1753   1562   -729       N  
+ATOM   2853  C5    G A  51     134.691  34.469 156.896  1.00 73.74           C  
+ANISOU 2853  C5    G A  51     5559  13866   8593   1822   1613   -811       C  
+ATOM   2854  C6    G A  51     135.274  35.746 156.787  1.00 67.72           C  
+ANISOU 2854  C6    G A  51     5007  12913   7809   2070   1597   -951       C  
+ATOM   2855  O6    G A  51     134.886  36.699 156.103  1.00 79.89           O  
+ANISOU 2855  O6    G A  51     6588  14419   9349   2283   1533  -1032       O  
+ATOM   2856  N1    G A  51     136.409  35.843 157.574  1.00 66.39           N  
+ANISOU 2856  N1    G A  51     5021  12581   7622   2047   1654   -990       N  
+ATOM   2857  C2    G A  51     136.925  34.850 158.365  1.00 65.65           C  
+ANISOU 2857  C2    G A  51     4912  12505   7528   1824   1720   -910       C  
+ATOM   2858  N2    G A  51     138.044  35.178 159.031  1.00 64.42           N  
+ANISOU 2858  N2    G A  51     4954  12169   7353   1851   1760   -971       N  
+ATOM   2859  N3    G A  51     136.386  33.643 158.484  1.00 66.18           N  
+ANISOU 2859  N3    G A  51     4791  12743   7612   1592   1734   -778       N  
+ATOM   2860  C4    G A  51     135.278  33.530 157.723  1.00 73.06           C  
+ANISOU 2860  C4    G A  51     5483  13774   8504   1603   1677   -735       C  
+ATOM   2861  P     G A  52     131.076  31.753 161.518  1.00 93.59           P  
+ANISOU 2861  P     G A  52     7319  17450  10794   1370   1859   -347       P  
+ATOM   2862  OP1   G A  52     130.615  31.244 162.840  1.00 92.52           O  
+ANISOU 2862  OP1   G A  52     7080  17510  10563   1288   1936   -258       O  
+ATOM   2863  OP2   G A  52     130.036  32.035 160.487  1.00 77.62           O  
+ANISOU 2863  OP2   G A  52     5144  15547   8803   1452   1786   -343       O  
+ATOM   2864  O5'   G A  52     131.983  33.062 161.734  1.00 90.40           O  
+ANISOU 2864  O5'   G A  52     7156  16837  10353   1638   1881   -520       O  
+ATOM   2865  C5'   G A  52     133.200  32.994 162.470  1.00 81.42           C  
+ANISOU 2865  C5'   G A  52     6210  15521   9207   1592   1932   -556       C  
+ATOM   2866  C4'   G A  52     134.066  34.220 162.297  1.00 83.28           C  
+ANISOU 2866  C4'   G A  52     6679  15524   9439   1826   1918   -715       C  
+ATOM   2867  O4'   G A  52     134.332  34.495 160.895  1.00 91.82           O  
+ANISOU 2867  O4'   G A  52     7817  16453  10616   1859   1838   -763       O  
+ATOM   2868  C3'   G A  52     133.497  35.523 162.822  1.00 80.60           C  
+ANISOU 2868  C3'   G A  52     6370  15260   8994   2135   1924   -821       C  
+ATOM   2869  O3'   G A  52     133.602  35.620 164.233  1.00 85.49           O  
+ANISOU 2869  O3'   G A  52     7023  15951   9509   2175   1999   -825       O  
+ATOM   2870  C2'   G A  52     134.319  36.563 162.073  1.00 78.28           C  
+ANISOU 2870  C2'   G A  52     6300  14697   8745   2312   1863   -957       C  
+ATOM   2871  O2'   G A  52     135.601  36.695 162.657  1.00 75.08           O  
+ANISOU 2871  O2'   G A  52     6108  14078   8340   2292   1894  -1009       O  
+ATOM   2872  C1'   G A  52     134.481  35.892 160.704  1.00 84.75           C  
+ANISOU 2872  C1'   G A  52     7073  15439   9690   2148   1805   -906       C  
+ATOM   2873  N9    G A  52     133.448  36.358 159.757  1.00 80.03           N  
+ANISOU 2873  N9    G A  52     6357  14946   9104   2280   1736   -923       N  
+ATOM   2874  C8    G A  52     132.346  35.651 159.347  1.00 81.14           C  
+ANISOU 2874  C8    G A  52     6255  15312   9264   2168   1716   -818       C  
+ATOM   2875  N7    G A  52     131.590  36.315 158.519  1.00 82.22           N  
+ANISOU 2875  N7    G A  52     6334  15498   9406   2335   1648   -865       N  
+ATOM   2876  C5    G A  52     132.227  37.544 158.373  1.00 78.75           C  
+ANISOU 2876  C5    G A  52     6123  14848   8950   2571   1616  -1008       C  
+ATOM   2877  C6    G A  52     131.864  38.682 157.591  1.00 81.40           C  
+ANISOU 2877  C6    G A  52     6526  15121   9282   2823   1533  -1111       C  
+ATOM   2878  O6    G A  52     130.872  38.838 156.848  1.00 81.79           O  
+ANISOU 2878  O6    G A  52     6436  15299   9341   2896   1473  -1101       O  
+ATOM   2879  N1    G A  52     132.794  39.710 157.740  1.00 73.59           N  
+ANISOU 2879  N1    G A  52     5804  13883   8274   2994   1512  -1234       N  
+ATOM   2880  C2    G A  52     133.915  39.664 158.526  1.00 73.02           C  
+ANISOU 2880  C2    G A  52     5900  13652   8191   2935   1566  -1256       C  
+ATOM   2881  N2    G A  52     134.672  40.775 158.515  1.00 72.48           N  
+ANISOU 2881  N2    G A  52     6085  13346   8109   3119   1520  -1376       N  
+ATOM   2882  N3    G A  52     134.260  38.610 159.257  1.00 73.04           N  
+ANISOU 2882  N3    G A  52     5836  13720   8197   2710   1648  -1166       N  
+ATOM   2883  C4    G A  52     133.376  37.591 159.136  1.00 74.81           C  
+ANISOU 2883  C4    G A  52     5810  14177   8436   2538   1669  -1044       C  
+ATOM   2884  P     U A  53     132.395  36.221 165.115  1.00 99.37           P  
+ANISOU 2884  P     U A  53     8650  17979  11128   2375   2034   -837       P  
+ATOM   2885  OP1   U A  53     132.693  35.845 166.521  1.00 97.26           O  
+ANISOU 2885  OP1   U A  53     8403  17776  10775   2311   2119   -801       O  
+ATOM   2886  OP2   U A  53     131.077  35.858 164.521  1.00 99.13           O  
+ANISOU 2886  OP2   U A  53     8369  18191  11105   2339   2010   -753       O  
+ATOM   2887  O5'   U A  53     132.604  37.797 164.993  1.00 77.70           O  
+ANISOU 2887  O5'   U A  53     6094  15090   8338   2704   1983  -1007       O  
+ATOM   2888  C5'   U A  53     133.851  38.358 165.361  1.00 76.01           C  
+ANISOU 2888  C5'   U A  53     6140  14615   8126   2770   1979  -1103       C  
+ATOM   2889  C4'   U A  53     134.125  39.663 164.667  1.00 77.24           C  
+ANISOU 2889  C4'   U A  53     6479  14574   8296   3014   1890  -1242       C  
+ATOM   2890  O4'   U A  53     134.123  39.500 163.227  1.00 85.17           O  
+ANISOU 2890  O4'   U A  53     7459  15486   9415   2952   1824  -1230       O  
+ATOM   2891  C3'   U A  53     133.118  40.768 164.890  1.00 80.99           C  
+ANISOU 2891  C3'   U A  53     6922  15187   8663   3304   1854  -1320       C  
+ATOM   2892  O3'   U A  53     133.223  41.365 166.161  1.00 82.82           O  
+ANISOU 2892  O3'   U A  53     7247  15449   8772   3456   1886  -1380       O  
+ATOM   2893  C2'   U A  53     133.426  41.715 163.743  1.00 84.50           C  
+ANISOU 2893  C2'   U A  53     7528  15408   9172   3456   1745  -1421       C  
+ATOM   2894  O2'   U A  53     134.605  42.465 164.003  1.00 83.63           O  
+ANISOU 2894  O2'   U A  53     7698  15013   9063   3543   1709  -1522       O  
+ATOM   2895  C1'   U A  53     133.727  40.720 162.621  1.00 87.25           C  
+ANISOU 2895  C1'   U A  53     7801  15692   9659   3212   1738  -1336       C  
+ATOM   2896  N1    U A  53     132.535  40.501 161.774  1.00 84.69           N  
+ANISOU 2896  N1    U A  53     7260  15563   9357   3217   1705  -1284       N  
+ATOM   2897  C2    U A  53     132.227  41.528 160.895  1.00 81.80           C  
+ANISOU 2897  C2    U A  53     6969  15112   8999   3431   1608  -1376       C  
+ATOM   2898  O2    U A  53     132.890  42.551 160.787  1.00 81.05           O  
+ANISOU 2898  O2    U A  53     7110  14788   8897   3599   1547  -1489       O  
+ATOM   2899  N3    U A  53     131.116  41.306 160.132  1.00 78.48           N  
+ANISOU 2899  N3    U A  53     6344  14879   8598   3435   1575  -1328       N  
+ATOM   2900  C4    U A  53     130.304  40.190 160.167  1.00 81.93           C  
+ANISOU 2900  C4    U A  53     6513  15569   9048   3242   1625  -1196       C  
+ATOM   2901  O4    U A  53     129.333  40.125 159.420  1.00 84.84           O  
+ANISOU 2901  O4    U A  53     6715  16085   9436   3267   1580  -1164       O  
+ATOM   2902  C5    U A  53     130.680  39.183 161.107  1.00 79.78           C  
+ANISOU 2902  C5    U A  53     6186  15364   8764   3022   1719  -1102       C  
+ATOM   2903  C6    U A  53     131.759  39.371 161.870  1.00 82.40           C  
+ANISOU 2903  C6    U A  53     6714  15520   9074   3021   1757  -1151       C  
+ATOM   2904  P     C A  54     131.894  41.841 166.920  1.00 97.82           P  
+ANISOU 2904  P     C A  54     8991  17654  10523   3658   1910  -1389       P  
+ATOM   2905  OP1   C A  54     132.316  42.303 168.274  1.00 95.35           O  
+ANISOU 2905  OP1   C A  54     8810  17325  10095   3774   1947  -1447       O  
+ATOM   2906  OP2   C A  54     130.886  40.750 166.797  1.00 98.83           O  
+ANISOU 2906  OP2   C A  54     8821  18069  10661   3479   1969  -1247       O  
+ATOM   2907  O5'   C A  54     131.362  43.071 166.049  1.00 94.42           O  
+ANISOU 2907  O5'   C A  54     8623  17169  10083   3925   1800  -1497       O  
+ATOM   2908  C5'   C A  54     132.116  44.267 165.921  1.00 91.78           C  
+ANISOU 2908  C5'   C A  54     8569  16561   9743   4122   1709  -1634       C  
+ATOM   2909  C4'   C A  54     131.533  45.189 164.874  1.00 93.30           C  
+ANISOU 2909  C4'   C A  54     8789  16711   9948   4320   1599  -1708       C  
+ATOM   2910  O4'   C A  54     131.592  44.571 163.555  1.00 94.28           O  
+ANISOU 2910  O4'   C A  54     8839  16770  10211   4151   1574  -1648       O  
+ATOM   2911  C3'   C A  54     130.066  45.570 165.015  1.00 98.14           C  
+ANISOU 2911  C3'   C A  54     9212  17625  10454   4507   1594  -1712       C  
+ATOM   2912  O3'   C A  54     129.808  46.528 166.027  1.00102.69           O  
+ANISOU 2912  O3'   C A  54     9878  18260  10879   4761   1579  -1803       O  
+ATOM   2913  C2'   C A  54     129.744  46.062 163.610  1.00 98.50           C  
+ANISOU 2913  C2'   C A  54     9274  17575  10574   4588   1488  -1751       C  
+ATOM   2914  O2'   C A  54     130.318  47.342 163.387  1.00 98.31           O  
+ANISOU 2914  O2'   C A  54     9533  17286  10535   4802   1373  -1885       O  
+ATOM   2915  C1'   C A  54     130.509  45.038 162.766  1.00 92.97           C  
+ANISOU 2915  C1'   C A  54     8561  16731  10034   4299   1508  -1668       C  
+ATOM   2916  N1    C A  54     129.620  43.905 162.408  1.00 88.75           N  
+ANISOU 2916  N1    C A  54     7725  16457   9538   4112   1567  -1537       N  
+ATOM   2917  C2    C A  54     128.647  44.132 161.426  1.00 85.21           C  
+ANISOU 2917  C2    C A  54     7148  16117   9110   4199   1502  -1537       C  
+ATOM   2918  O2    C A  54     128.590  45.235 160.865  1.00 85.65           O  
+ANISOU 2918  O2    C A  54     7348  16041   9153   4422   1400  -1645       O  
+ATOM   2919  N3    C A  54     127.789  43.143 161.095  1.00 85.94           N  
+ANISOU 2919  N3    C A  54     6965  16450   9238   4033   1542  -1416       N  
+ATOM   2920  C4    C A  54     127.872  41.958 161.705  1.00 88.13           C  
+ANISOU 2920  C4    C A  54     7103  16854   9528   3784   1639  -1295       C  
+ATOM   2921  N4    C A  54     127.002  41.016 161.329  1.00 86.81           N  
+ANISOU 2921  N4    C A  54     6673  16912   9397   3616   1660  -1172       N  
+ATOM   2922  C5    C A  54     128.839  41.693 162.719  1.00 84.33           C  
+ANISOU 2922  C5    C A  54     6750  16269   9021   3694   1709  -1293       C  
+ATOM   2923  C6    C A  54     129.677  42.690 163.041  1.00 86.19           C  
+ANISOU 2923  C6    C A  54     7250  16273   9223   3867   1672  -1417       C  
+ATOM   2924  P     U A  55     128.360  46.622 166.737  1.00104.70           P  
+ANISOU 2924  P     U A  55     9899  18901  10983   4917   1629  -1780       P  
+ATOM   2925  OP1   U A  55     128.532  47.528 167.898  1.00101.35           O  
+ANISOU 2925  OP1   U A  55     9635  18461  10413   5147   1615  -1879       O  
+ATOM   2926  OP2   U A  55     127.804  45.255 166.924  1.00107.74           O  
+ANISOU 2926  OP2   U A  55     9997  19549  11393   4666   1745  -1625       O  
+ATOM   2927  O5'   U A  55     127.438  47.371 165.677  1.00100.77           O  
+ANISOU 2927  O5'   U A  55     9351  18450  10485   5108   1527  -1835       O  
+ATOM   2928  C5'   U A  55     127.855  48.594 165.092  1.00 96.07           C  
+ANISOU 2928  C5'   U A  55     9013  17591   9900   5314   1391  -1965       C  
+ATOM   2929  C4'   U A  55     126.889  49.066 164.033  1.00 97.15           C  
+ANISOU 2929  C4'   U A  55     9058  17808  10046   5452   1307  -1992       C  
+ATOM   2930  O4'   U A  55     126.903  48.185 162.882  1.00 95.41           O  
+ANISOU 2930  O4'   U A  55     8712  17560   9977   5222   1315  -1902       O  
+ATOM   2931  C3'   U A  55     125.429  49.108 164.429  1.00104.66           C  
+ANISOU 2931  C3'   U A  55     9757  19136  10873   5595   1346  -1969       C  
+ATOM   2932  O3'   U A  55     125.120  50.219 165.244  1.00110.63           O  
+ANISOU 2932  O3'   U A  55    10627  19940  11468   5897   1301  -2080       O  
+ATOM   2933  C2'   U A  55     124.724  49.116 163.076  1.00108.96           C  
+ANISOU 2933  C2'   U A  55    10187  19715  11497   5601   1277  -1955       C  
+ATOM   2934  O2'   U A  55     124.746  50.411 162.495  1.00111.30           O  
+ANISOU 2934  O2'   U A  55    10696  19824  11769   5858   1132  -2087       O  
+ATOM   2935  C1'   U A  55     125.634  48.205 162.254  1.00 94.49           C  
+ANISOU 2935  C1'   U A  55     8382  17676   9843   5303   1291  -1878       C  
+ATOM   2936  N1    U A  55     125.110  46.827 162.181  1.00 94.38           N  
+ANISOU 2936  N1    U A  55     8072  17902   9886   5041   1394  -1725       N  
+ATOM   2937  C2    U A  55     124.053  46.599 161.326  1.00 97.05           C  
+ANISOU 2937  C2    U A  55     8195  18423  10255   5040   1365  -1678       C  
+ATOM   2938  O2    U A  55     123.544  47.472 160.642  1.00 98.94           O  
+ANISOU 2938  O2    U A  55     8479  18638  10477   5249   1265  -1759       O  
+ATOM   2939  N3    U A  55     123.611  45.301 161.298  1.00 98.67           N  
+ANISOU 2939  N3    U A  55     8137  18838  10514   4779   1450  -1528       N  
+ATOM   2940  C4    U A  55     124.116  44.242 162.029  1.00 94.43           C  
+ANISOU 2940  C4    U A  55     7541  18340   9999   4527   1556  -1426       C  
+ATOM   2941  O4    U A  55     123.617  43.124 161.898  1.00 94.76           O  
+ANISOU 2941  O4    U A  55     7347  18568  10088   4300   1610  -1289       O  
+ATOM   2942  C5    U A  55     125.205  44.563 162.896  1.00 93.14           C  
+ANISOU 2942  C5    U A  55     7610  17983   9798   4555   1584  -1488       C  
+ATOM   2943  C6    U A  55     125.651  45.819 162.940  1.00 93.17           C  
+ANISOU 2943  C6    U A  55     7865  17783   9752   4804   1504  -1632       C  
+ATOM   2944  P     C A  56     124.033  50.072 166.415  1.00105.96           P  
+ANISOU 2944  P     C A  56     9809  19745  10704   6010   1398  -2046       P  
+ATOM   2945  OP1   C A  56     124.130  51.300 167.243  1.00106.58           O  
+ANISOU 2945  OP1   C A  56    10097  19767  10630   6317   1330  -2181       O  
+ATOM   2946  OP2   C A  56     124.213  48.729 167.040  1.00104.82           O  
+ANISOU 2946  OP2   C A  56     9488  19744  10596   5721   1544  -1906       O  
+ATOM   2947  O5'   C A  56     122.655  50.147 165.626  1.00113.84           O  
+ANISOU 2947  O5'   C A  56    10572  20995  11686   6108   1370  -2025       O  
+ATOM   2948  C5'   C A  56     122.432  51.221 164.728  1.00115.22           C  
+ANISOU 2948  C5'   C A  56    10885  21031  11864   6329   1226  -2136       C  
+ATOM   2949  C4'   C A  56     121.332  50.924 163.743  1.00114.58           C  
+ANISOU 2949  C4'   C A  56    10561  21147  11827   6313   1212  -2082       C  
+ATOM   2950  O4'   C A  56     121.662  49.769 162.937  1.00111.66           O  
+ANISOU 2950  O4'   C A  56    10076  20718  11630   5989   1255  -1963       O  
+ATOM   2951  C3'   C A  56     119.980  50.592 164.341  1.00114.70           C  
+ANISOU 2951  C3'   C A  56    10263  21597  11722   6379   1300  -2017       C  
+ATOM   2952  O3'   C A  56     119.296  51.771 164.736  1.00122.38           O  
+ANISOU 2952  O3'   C A  56    11292  22677  12528   6734   1233  -2136       O  
+ATOM   2953  C2'   C A  56     119.291  49.824 163.210  1.00112.36           C  
+ANISOU 2953  C2'   C A  56     9725  21420  11546   6207   1302  -1916       C  
+ATOM   2954  O2'   C A  56     118.716  50.727 162.278  1.00111.96           O  
+ANISOU 2954  O2'   C A  56     9720  21329  11489   6427   1175  -2008       O  
+ATOM   2955  C1'   C A  56     120.475  49.120 162.531  1.00111.48           C  
+ANISOU 2955  C1'   C A  56     9735  21004  11618   5920   1297  -1865       C  
+ATOM   2956  N1    C A  56     120.580  47.670 162.842  1.00107.38           N  
+ANISOU 2956  N1    C A  56     9012  20618  11169   5587   1423  -1705       N  
+ATOM   2957  C2    C A  56     119.770  46.758 162.140  1.00106.34           C  
+ANISOU 2957  C2    C A  56     8601  20686  11116   5407   1447  -1582       C  
+ATOM   2958  O2    C A  56     118.960  47.174 161.290  1.00107.40           O  
+ANISOU 2958  O2    C A  56     8652  20894  11260   5533   1370  -1610       O  
+ATOM   2959  N3    C A  56     119.893  45.436 162.416  1.00105.81           N  
+ANISOU 2959  N3    C A  56     8368  20723  11114   5094   1546  -1432       N  
+ATOM   2960  C4    C A  56     120.773  45.008 163.332  1.00103.63           C  
+ANISOU 2960  C4    C A  56     8190  20361  10825   4965   1624  -1405       C  
+ATOM   2961  N4    C A  56     120.856  43.699 163.573  1.00103.40           N  
+ANISOU 2961  N4    C A  56     7999  20432  10856   4656   1711  -1255       N  
+ATOM   2962  C5    C A  56     121.614  45.908 164.053  1.00103.10           C  
+ANISOU 2962  C5    C A  56     8398  20094  10680   5146   1608  -1530       C  
+ATOM   2963  C6    C A  56     121.487  47.214 163.771  1.00104.10           C  
+ANISOU 2963  C6    C A  56     8691  20117  10747   5449   1504  -1675       C  
+ATOM   2964  P     C A  57     118.158  51.746 165.873  1.00117.14           P  
+ANISOU 2964  P     C A  57    10393  22440  11673   6887   1329  -2109       P  
+ATOM   2965  OP1   C A  57     117.882  53.161 166.226  1.00119.62           O  
+ANISOU 2965  OP1   C A  57    10887  22736  11828   7271   1225  -2268       O  
+ATOM   2966  OP2   C A  57     118.519  50.764 166.928  1.00116.54           O  
+ANISOU 2966  OP2   C A  57    10219  22480  11582   6674   1474  -2000       O  
+ATOM   2967  O5'   C A  57     116.887  51.211 165.088  1.00118.83           O  
+ANISOU 2967  O5'   C A  57    10280  22947  11924   6831   1350  -2017       O  
+ATOM   2968  C5'   C A  57     115.725  50.779 165.769  1.00122.11           C  
+ANISOU 2968  C5'   C A  57    10386  23789  12222   6861   1454  -1934       C  
+ATOM   2969  C4'   C A  57     114.635  50.426 164.792  1.00123.42           C  
+ANISOU 2969  C4'   C A  57    10287  24159  12448   6815   1438  -1865       C  
+ATOM   2970  O4'   C A  57     114.431  51.528 163.866  1.00123.88           O  
+ANISOU 2970  O4'   C A  57    10496  24064  12509   7061   1288  -1999       O  
+ATOM   2971  C3'   C A  57     114.895  49.185 163.937  1.00121.02           C  
+ANISOU 2971  C3'   C A  57     9852  23786  12344   6441   1469  -1722       C  
+ATOM   2972  O3'   C A  57     113.678  48.457 163.798  1.00126.77           O  
+ANISOU 2972  O3'   C A  57    10224  24878  13066   6346   1530  -1595       O  
+ATOM   2973  C2'   C A  57     115.303  49.768 162.583  1.00118.67           C  
+ANISOU 2973  C2'   C A  57     9746  23173  12170   6491   1323  -1812       C  
+ATOM   2974  O2'   C A  57     115.020  48.929 161.482  1.00117.49           O  
+ANISOU 2974  O2'   C A  57     9425  23038  12178   6259   1309  -1707       O  
+ATOM   2975  C1'   C A  57     114.477  51.049 162.535  1.00121.83           C  
+ANISOU 2975  C1'   C A  57    10186  23673  12429   6873   1233  -1947       C  
+ATOM   2976  N1    C A  57     115.006  52.105 161.642  1.00120.50           N  
+ANISOU 2976  N1    C A  57    10314  23164  12308   7045   1073  -2090       N  
+ATOM   2977  C2    C A  57     115.918  53.100 162.063  1.00119.67           C  
+ANISOU 2977  C2    C A  57    10552  22777  12141   7223    999  -2226       C  
+ATOM   2978  O2    C A  57     116.358  53.137 163.225  1.00119.90           O  
+ANISOU 2978  O2    C A  57    10657  22825  12076   7249   1066  -2237       O  
+ATOM   2979  N3    C A  57     116.332  54.032 161.167  1.00118.65           N  
+ANISOU 2979  N3    C A  57    10681  22342  12058   7363    843  -2342       N  
+ATOM   2980  C4    C A  57     115.891  54.028 159.907  1.00118.39           C  
+ANISOU 2980  C4    C A  57    10583  22276  12125   7344    764  -2335       C  
+ATOM   2981  N4    C A  57     116.338  54.978 159.079  1.00117.46           N  
+ANISOU 2981  N4    C A  57    10738  21848  12044   7484    608  -2449       N  
+ATOM   2982  C5    C A  57     114.966  53.045 159.451  1.00119.19           C  
+ANISOU 2982  C5    C A  57    10338  22658  12291   7175    836  -2205       C  
+ATOM   2983  C6    C A  57     114.560  52.126 160.341  1.00120.77           C  
+ANISOU 2983  C6    C A  57    10284  23156  12446   7030    985  -2086       C  
+ATOM   2984  P     C A  58     113.133  47.563 165.020  1.00129.54           P  
+ANISOU 2984  P     C A  58    10312  25591  13315   6215   1687  -1454       P  
+ATOM   2985  OP1   C A  58     111.658  47.760 165.075  1.00130.92           O  
+ANISOU 2985  OP1   C A  58    10208  26158  13377   6382   1704  -1426       O  
+ATOM   2986  OP2   C A  58     113.972  47.789 166.232  1.00126.80           O  
+ANISOU 2986  OP2   C A  58    10156  25150  12870   6270   1744  -1503       O  
+ATOM   2987  O5'   C A  58     113.437  46.074 164.545  1.00132.46           O  
+ANISOU 2987  O5'   C A  58    10537  25929  13864   5784   1738  -1276       O  
+ATOM   2988  C5'   C A  58     114.215  45.819 163.380  1.00122.16           C  
+ANISOU 2988  C5'   C A  58     9371  24298  12747   5614   1656  -1282       C  
+ATOM   2989  C4'   C A  58     114.836  44.453 163.439  1.00118.31           C  
+ANISOU 2989  C4'   C A  58     8821  23750  12382   5224   1725  -1131       C  
+ATOM   2990  O4'   C A  58     116.242  44.583 163.787  1.00116.23           O  
+ANISOU 2990  O4'   C A  58     8852  23159  12152   5179   1728  -1197       O  
+ATOM   2991  C3'   C A  58     114.214  43.510 164.474  1.00121.26           C  
+ANISOU 2991  C3'   C A  58     8933  24464  12675   5062   1854   -977       C  
+ATOM   2992  O3'   C A  58     114.056  42.203 163.923  1.00121.99           O  
+ANISOU 2992  O3'   C A  58     8836  24610  12906   4709   1869   -807       O  
+ATOM   2993  C2'   C A  58     115.246  43.494 165.608  1.00121.65           C  
+ANISOU 2993  C2'   C A  58     9178  24381  12664   5040   1926  -1006       C  
+ATOM   2994  O2'   C A  58     115.281  42.296 166.352  1.00121.70           O  
+ANISOU 2994  O2'   C A  58     9033  24536  12671   4758   2032   -846       O  
+ATOM   2995  C1'   C A  58     116.550  43.709 164.850  1.00117.03           C  
+ANISOU 2995  C1'   C A  58     8887  23359  12218   4980   1844  -1092       C  
+ATOM   2996  N1    C A  58     117.645  44.282 165.658  1.00115.70           N  
+ANISOU 2996  N1    C A  58     9003  22966  11992   5086   1858  -1198       N  
+ATOM   2997  C2    C A  58     118.500  43.368 166.285  1.00115.99           C  
+ANISOU 2997  C2    C A  58     9084  22916  12073   4827   1937  -1113       C  
+ATOM   2998  O2    C A  58     118.259  42.161 166.122  1.00117.36           O  
+ANISOU 2998  O2    C A  58     9060  23207  12323   4533   1985   -956       O  
+ATOM   2999  N3    C A  58     119.545  43.807 167.043  1.00112.46           N  
+ANISOU 2999  N3    C A  58     8890  22259  11581   4900   1951  -1200       N  
+ATOM   3000  C4    C A  58     119.759  45.117 167.190  1.00112.06           C  
+ANISOU 3000  C4    C A  58     9053  22078  11446   5214   1883  -1365       C  
+ATOM   3001  N4    C A  58     120.795  45.499 167.946  1.00108.07           N  
+ANISOU 3001  N4    C A  58     8794  21365  10904   5267   1891  -1441       N  
+ATOM   3002  C5    C A  58     118.904  46.077 166.557  1.00114.40           C  
+ANISOU 3002  C5    C A  58     9321  22452  11694   5483   1795  -1454       C  
+ATOM   3003  C6    C A  58     117.874  45.627 165.809  1.00115.27           C  
+ANISOU 3003  C6    C A  58     9174  22775  11848   5413   1789  -1370       C  
+ATOM   3004  P     U A  59     112.595  41.533 163.874  1.00142.02           P  
+ANISOU 3004  P     U A  59    10992  27555  15414   4614   1904   -654       P  
+ATOM   3005  OP1   U A  59     111.730  42.353 162.990  1.00141.95           O  
+ANISOU 3005  OP1   U A  59    10914  27620  15400   4848   1814   -735       O  
+ATOM   3006  OP2   U A  59     112.172  41.253 165.270  1.00146.78           O  
+ANISOU 3006  OP2   U A  59    11457  28454  15861   4620   2028   -580       O  
+ATOM   3007  O5'   U A  59     112.830  40.136 163.151  1.00122.13           O  
+ANISOU 3007  O5'   U A  59     8369  24958  13077   4202   1886   -490       O  
+ATOM   3008  C5'   U A  59     112.737  38.913 163.876  1.00122.98           C  
+ANISOU 3008  C5'   U A  59     8315  25230  13182   3905   1974   -313       C  
+ATOM   3009  C4'   U A  59     112.034  37.846 163.075  1.00123.43           C  
+ANISOU 3009  C4'   U A  59     8126  25413  13358   3622   1932   -146       C  
+ATOM   3010  O4'   U A  59     110.607  38.108 163.110  1.00128.53           O  
+ANISOU 3010  O4'   U A  59     8499  26421  13916   3761   1941   -105       O  
+ATOM   3011  C3'   U A  59     112.441  37.789 161.607  1.00120.43           C  
+ANISOU 3011  C3'   U A  59     7843  24757  13157   3539   1806   -181       C  
+ATOM   3012  O3'   U A  59     112.647  36.448 161.163  1.00117.52           O  
+ANISOU 3012  O3'   U A  59     7392  24332  12927   3156   1779    -21       O  
+ATOM   3013  C2'   U A  59     111.279  38.453 160.863  1.00125.53           C  
+ANISOU 3013  C2'   U A  59     8326  25580  13788   3746   1737   -221       C  
+ATOM   3014  O2'   U A  59     111.008  37.905 159.590  1.00125.00           O  
+ANISOU 3014  O2'   U A  59     8166  25449  13880   3570   1632   -153       O  
+ATOM   3015  C1'   U A  59     110.091  38.271 161.803  1.00127.69           C  
+ANISOU 3015  C1'   U A  59     8318  26279  13918   3782   1828   -120       C  
+ATOM   3016  N1    U A  59     109.234  39.465 161.821  1.00130.93           N  
+ANISOU 3016  N1    U A  59     8672  26868  14207   4153   1816   -239       N  
+ATOM   3017  C2    U A  59     108.417  39.697 160.732  1.00133.20           C  
+ANISOU 3017  C2    U A  59     8828  27220  14563   4217   1720   -245       C  
+ATOM   3018  O2    U A  59     108.368  38.949 159.771  1.00133.34           O  
+ANISOU 3018  O2    U A  59     8771  27157  14737   3979   1644   -155       O  
+ATOM   3019  N3    U A  59     107.656  40.838 160.804  1.00133.37           N  
+ANISOU 3019  N3    U A  59     8812  27402  14461   4576   1707   -364       N  
+ATOM   3020  C4    U A  59     107.638  41.755 161.831  1.00135.80           C  
+ANISOU 3020  C4    U A  59     9206  27807  14584   4872   1775   -475       C  
+ATOM   3021  O4    U A  59     106.898  42.733 161.750  1.00138.94           O  
+ANISOU 3021  O4    U A  59     9563  28346  14883   5184   1745   -577       O  
+ATOM   3022  C5    U A  59     108.517  41.456 162.918  1.00135.02           C  
+ANISOU 3022  C5    U A  59     9244  27629  14426   4784   1870   -461       C  
+ATOM   3023  C6    U A  59     109.269  40.351 162.874  1.00131.82           C  
+ANISOU 3023  C6    U A  59     8875  27069  14143   4436   1888   -347       C  
+ATOM   3024  P     G A  60     114.118  36.018 160.666  1.00142.15           P  
+ANISOU 3024  P     G A  60    10776  27050  16184   2970   1736    -50       P  
+ATOM   3025  OP1   G A  60     114.017  34.772 159.864  1.00139.95           O  
+ANISOU 3025  OP1   G A  60    10378  26743  16055   2621   1666    105       O  
+ATOM   3026  OP2   G A  60     115.012  36.055 161.855  1.00138.27           O  
+ANISOU 3026  OP2   G A  60    10453  26475  15609   2978   1835    -83       O  
+ATOM   3027  O5'   G A  60     114.569  37.214 159.703  1.00126.03           O  
+ANISOU 3027  O5'   G A  60     8948  24752  14186   3241   1644   -241       O  
+ATOM   3028  C5'   G A  60     113.910  37.462 158.466  1.00122.96           C  
+ANISOU 3028  C5'   G A  60     8468  24373  13879   3301   1534   -258       C  
+ATOM   3029  C4'   G A  60     113.723  38.942 158.207  1.00123.25           C  
+ANISOU 3029  C4'   G A  60     8624  24363  13842   3691   1492   -441       C  
+ATOM   3030  O4'   G A  60     113.644  39.675 159.461  1.00124.95           O  
+ANISOU 3030  O4'   G A  60     8887  24705  13884   3920   1586   -515       O  
+ATOM   3031  C3'   G A  60     114.840  39.636 157.449  1.00120.95           C  
+ANISOU 3031  C3'   G A  60     8640  23691  13625   3802   1413   -589       C  
+ATOM   3032  O3'   G A  60     114.764  39.423 156.051  1.00122.24           O  
+ANISOU 3032  O3'   G A  60     8784  23732  13931   3720   1293   -576       O  
+ATOM   3033  C2'   G A  60     114.670  41.092 157.868  1.00119.65           C  
+ANISOU 3033  C2'   G A  60     8604  23534  13322   4194   1414   -758       C  
+ATOM   3034  O2'   G A  60     113.590  41.695 157.171  1.00120.13           O  
+ANISOU 3034  O2'   G A  60     8534  23742  13368   4385   1337   -797       O  
+ATOM   3035  C1'   G A  60     114.274  40.931 159.332  1.00122.05           C  
+ANISOU 3035  C1'   G A  60     8790  24105  13476   4212   1543   -705       C  
+ATOM   3036  N9    G A  60     115.462  40.923 160.200  1.00119.14           N  
+ANISOU 3036  N9    G A  60     8645  23546  13076   4174   1610   -745       N  
+ATOM   3037  C8    G A  60     115.940  39.830 160.879  1.00116.41           C  
+ANISOU 3037  C8    G A  60     8260  23216  12752   3890   1693   -621       C  
+ATOM   3038  N7    G A  60     117.016  40.083 161.564  1.00115.77           N  
+ANISOU 3038  N7    G A  60     8411  22937  12639   3921   1736   -692       N  
+ATOM   3039  C5    G A  60     117.266  41.427 161.318  1.00115.13           C  
+ANISOU 3039  C5    G A  60     8537  22694  12512   4239   1673   -870       C  
+ATOM   3040  C6    G A  60     118.310  42.258 161.797  1.00110.21           C  
+ANISOU 3040  C6    G A  60     8211  21820  11843   4402   1672  -1007       C  
+ATOM   3041  O6    G A  60     119.243  41.955 162.554  1.00106.60           O  
+ANISOU 3041  O6    G A  60     7888  21237  11378   4298   1733  -1000       O  
+ATOM   3042  N1    G A  60     118.189  43.553 161.300  1.00109.77           N  
+ANISOU 3042  N1    G A  60     8303  21656  11750   4712   1580  -1162       N  
+ATOM   3043  C2    G A  60     117.202  44.001 160.456  1.00113.03           C  
+ANISOU 3043  C2    G A  60     8594  22187  12166   4856   1502  -1187       C  
+ATOM   3044  N2    G A  60     117.284  45.294 160.103  1.00113.39           N  
+ANISOU 3044  N2    G A  60     8836  22082  12167   5156   1410  -1347       N  
+ATOM   3045  N3    G A  60     116.221  43.235 159.998  1.00117.26           N  
+ANISOU 3045  N3    G A  60     8845  22963  12747   4710   1507  -1063       N  
+ATOM   3046  C4    G A  60     116.315  41.968 160.471  1.00118.43           C  
+ANISOU 3046  C4    G A  60     8846  23219  12934   4401   1593   -906       C  
+ATOM   3047  P     A A  61     115.798  40.155 155.068  1.00113.82           P  
+ANISOU 3047  P     A A  61     8015  22286  12946   3842   1195   -721       P  
+ATOM   3048  OP1   A A  61     115.691  39.508 153.732  1.00113.57           O  
+ANISOU 3048  OP1   A A  61     7909  22175  13069   3662   1084   -654       O  
+ATOM   3049  OP2   A A  61     117.114  40.204 155.757  1.00111.26           O  
+ANISOU 3049  OP2   A A  61     7938  21733  12605   3808   1260   -773       O  
+ATOM   3050  O5'   A A  61     115.221  41.638 154.964  1.00121.14           O  
+ANISOU 3050  O5'   A A  61     9010  23247  13770   4239   1146   -879       O  
+ATOM   3051  C5'   A A  61     115.630  42.510 153.930  1.00117.26           C  
+ANISOU 3051  C5'   A A  61     8726  22497  13332   4417   1029  -1009       C  
+ATOM   3052  C4'   A A  61     116.222  43.788 154.468  1.00113.82           C  
+ANISOU 3052  C4'   A A  61     8564  21894  12789   4710   1031  -1176       C  
+ATOM   3053  O4'   A A  61     116.233  43.797 155.919  1.00114.56           O  
+ANISOU 3053  O4'   A A  61     8636  22139  12752   4742   1154  -1166       O  
+ATOM   3054  C3'   A A  61     117.670  44.035 154.110  1.00108.19           C  
+ANISOU 3054  C3'   A A  61     8166  20794  12147   4683    994  -1255       C  
+ATOM   3055  O3'   A A  61     117.846  44.453 152.778  1.00106.33           O  
+ANISOU 3055  O3'   A A  61     8046  20351  12005   4752    863  -1317       O  
+ATOM   3056  C2'   A A  61     118.092  45.063 155.146  1.00108.57           C  
+ANISOU 3056  C2'   A A  61     8419  20774  12060   4922   1033  -1378       C  
+ATOM   3057  O2'   A A  61     117.609  46.352 154.803  1.00106.94           O  
+ANISOU 3057  O2'   A A  61     8315  20538  11781   5247    939  -1512       O  
+ATOM   3058  C1'   A A  61     117.334  44.565 156.377  1.00112.72           C  
+ANISOU 3058  C1'   A A  61     8711  21641  12475   4875   1157  -1289       C  
+ATOM   3059  N9    A A  61     118.193  43.722 157.229  1.00114.26           N  
+ANISOU 3059  N9    A A  61     8942  21787  12684   4642   1263  -1212       N  
+ATOM   3060  C8    A A  61     118.097  42.370 157.461  1.00114.64           C  
+ANISOU 3060  C8    A A  61     8793  21975  12790   4326   1337  -1050       C  
+ATOM   3061  N7    A A  61     119.019  41.897 158.269  1.00111.93           N  
+ANISOU 3061  N7    A A  61     8554  21532  12441   4180   1417  -1021       N  
+ATOM   3062  C5    A A  61     119.779  43.016 158.590  1.00107.90           C  
+ANISOU 3062  C5    A A  61     8324  20802  11869   4415   1396  -1174       C  
+ATOM   3063  C6    A A  61     120.906  43.186 159.412  1.00101.36           C  
+ANISOU 3063  C6    A A  61     7717  19783  11010   4410   1447  -1225       C  
+ATOM   3064  N6    A A  61     121.476  42.181 160.080  1.00100.86           N  
+ANISOU 3064  N6    A A  61     7625  19726  10972   4158   1537  -1125       N  
+ATOM   3065  N1    A A  61     121.427  44.430 159.524  1.00101.09           N  
+ANISOU 3065  N1    A A  61     7944  19547  10918   4672   1391  -1379       N  
+ATOM   3066  C2    A A  61     120.843  45.430 158.852  1.00102.88           C  
+ANISOU 3066  C2    A A  61     8209  19763  11116   4923   1291  -1477       C  
+ATOM   3067  N3    A A  61     119.784  45.398 158.046  1.00108.14           N  
+ANISOU 3067  N3    A A  61     8685  20598  11806   4962   1238  -1447       N  
+ATOM   3068  C4    A A  61     119.288  44.147 157.955  1.00111.51           C  
+ANISOU 3068  C4    A A  61     8848  21227  12294   4697   1298  -1291       C  
+ATOM   3069  P     G A  62     119.074  43.859 151.952  1.00119.78           P  
+ANISOU 3069  P     G A  62     9910  21747  13855   4537    823  -1294       P  
+ATOM   3070  OP1   G A  62     119.084  44.520 150.621  1.00117.81           O  
+ANISOU 3070  OP1   G A  62     9784  21310  13670   4676    678  -1375       O  
+ATOM   3071  OP2   G A  62     119.008  42.378 152.037  1.00118.87           O  
+ANISOU 3071  OP2   G A  62     9579  21768  13817   4196    884  -1128       O  
+ATOM   3072  O5'   G A  62     120.340  44.361 152.777  1.00108.65           O  
+ANISOU 3072  O5'   G A  62     8786  20100  12395   4594    879  -1380       O  
+ATOM   3073  C5'   G A  62     120.901  45.630 152.497  1.00105.31           C  
+ANISOU 3073  C5'   G A  62     8654  19418  11941   4844    796  -1530       C  
+ATOM   3074  C4'   G A  62     121.678  46.204 153.656  1.00100.24           C  
+ANISOU 3074  C4'   G A  62     8217  18666  11206   4939    860  -1604       C  
+ATOM   3075  O4'   G A  62     121.352  45.555 154.910  1.00100.76           O  
+ANISOU 3075  O4'   G A  62     8106  18982  11196   4835    992  -1522       O  
+ATOM   3076  C3'   G A  62     123.184  46.079 153.592  1.00 96.60           C  
+ANISOU 3076  C3'   G A  62     8006  17880  10817   4818    867  -1625       C  
+ATOM   3077  O3'   G A  62     123.784  46.944 152.645  1.00 97.72           O  
+ANISOU 3077  O3'   G A  62     8403  17722  11005   4953    745  -1725       O  
+ATOM   3078  C2'   G A  62     123.585  46.376 155.029  1.00 97.29           C  
+ANISOU 3078  C2'   G A  62     8185  17986  10794   4877    956  -1659       C  
+ATOM   3079  O2'   G A  62     123.530  47.773 155.258  1.00 98.85           O  
+ANISOU 3079  O2'   G A  62     8582  18084  10892   5183    882  -1797       O  
+ATOM   3080  C1'   G A  62     122.438  45.721 155.806  1.00 99.75           C  
+ANISOU 3080  C1'   G A  62     8185  18684  11033   4821   1051  -1563       C  
+ATOM   3081  N9    G A  62     122.820  44.435 156.432  1.00 97.43           N  
+ANISOU 3081  N9    G A  62     7768  18475  10778   4523   1168  -1435       N  
+ATOM   3082  C8    G A  62     122.274  43.187 156.251  1.00 97.07           C  
+ANISOU 3082  C8    G A  62     7457  18633  10794   4269   1214  -1287       C  
+ATOM   3083  N7    G A  62     122.841  42.261 156.986  1.00 94.67           N  
+ANISOU 3083  N7    G A  62     7124  18342  10503   4039   1310  -1200       N  
+ATOM   3084  C5    G A  62     123.814  42.932 157.713  1.00 92.57           C  
+ANISOU 3084  C5    G A  62     7111  17878  10183   4151   1335  -1297       C  
+ATOM   3085  C6    G A  62     124.743  42.454 158.679  1.00 94.61           C  
+ANISOU 3085  C6    G A  62     7463  18056  10428   4009   1425  -1269       C  
+ATOM   3086  O6    G A  62     124.906  41.302 159.110  1.00 91.94           O  
+ANISOU 3086  O6    G A  62     7006  17806  10122   3749   1503  -1149       O  
+ATOM   3087  N1    G A  62     125.550  43.483 159.161  1.00 94.74           N  
+ANISOU 3087  N1    G A  62     7751  17858  10388   4200   1406  -1397       N  
+ATOM   3088  C2    G A  62     125.465  44.801 158.768  1.00 95.55           C  
+ANISOU 3088  C2    G A  62     8022  17835  10450   4486   1308  -1532       C  
+ATOM   3089  N2    G A  62     126.331  45.644 159.353  1.00 93.66           N  
+ANISOU 3089  N2    G A  62     8046  17382  10159   4624   1291  -1636       N  
+ATOM   3090  N3    G A  62     124.601  45.258 157.874  1.00 93.95           N  
+ANISOU 3090  N3    G A  62     7740  17701  10253   4622   1223  -1560       N  
+ATOM   3091  C4    G A  62     123.809  44.276 157.386  1.00 93.68           C  
+ANISOU 3091  C4    G A  62     7435  17882  10277   4445   1245  -1440       C  
+ATOM   3092  P     A A  63     125.219  46.560 152.034  1.00 98.94           P  
+ANISOU 3092  P     A A  63     8760  17552  11280   4777    731  -1716       P  
+ATOM   3093  OP1   A A  63     125.501  47.418 150.857  1.00104.77           O  
+ANISOU 3093  OP1   A A  63     9708  18037  12065   4924    589  -1801       O  
+ATOM   3094  OP2   A A  63     125.291  45.081 151.904  1.00 92.05           O  
+ANISOU 3094  OP2   A A  63     7679  16798  10497   4468    808  -1579       O  
+ATOM   3095  O5'   A A  63     126.238  46.980 153.173  1.00 87.53           O  
+ANISOU 3095  O5'   A A  63     7533  15950   9773   4807    792  -1771       O  
+ATOM   3096  C5'   A A  63     126.517  48.345 153.436  1.00 90.73           C  
+ANISOU 3096  C5'   A A  63     8196  16179  10100   5063    716  -1900       C  
+ATOM   3097  C4'   A A  63     127.654  48.475 154.416  1.00 94.35           C  
+ANISOU 3097  C4'   A A  63     8851  16468  10531   5021    774  -1928       C  
+ATOM   3098  O4'   A A  63     127.269  47.896 155.682  1.00 98.71           O  
+ANISOU 3098  O4'   A A  63     9225  17275  11005   4954    900  -1872       O  
+ATOM   3099  C3'   A A  63     128.916  47.725 154.038  1.00 90.98           C  
+ANISOU 3099  C3'   A A  63     8523  15821  10222   4781    808  -1877       C  
+ATOM   3100  O3'   A A  63     129.725  48.439 153.131  1.00 90.56           O  
+ANISOU 3100  O3'   A A  63     8735  15444  10229   4849    697  -1945       O  
+ATOM   3101  C2'   A A  63     129.579  47.460 155.380  1.00 88.22           C  
+ANISOU 3101  C2'   A A  63     8221  15475   9822   4701    914  -1865       C  
+ATOM   3102  O2'   A A  63     130.284  48.600 155.836  1.00 92.40           O  
+ANISOU 3102  O2'   A A  63     9039  15773  10296   4873    852  -1973       O  
+ATOM   3103  C1'   A A  63     128.368  47.241 156.273  1.00 90.20           C  
+ANISOU 3103  C1'   A A  63     8224  16080   9967   4756    985  -1829       C  
+ATOM   3104  N9    A A  63     128.049  45.815 156.370  1.00 84.73           N  
+ANISOU 3104  N9    A A  63     7263  15606   9325   4492   1089  -1693       N  
+ATOM   3105  C8    A A  63     127.019  45.117 155.786  1.00 85.72           C  
+ANISOU 3105  C8    A A  63     7120  15966   9485   4406   1092  -1607       C  
+ATOM   3106  N7    A A  63     127.036  43.843 156.082  1.00 85.04           N  
+ANISOU 3106  N7    A A  63     6853  16017   9441   4143   1185  -1484       N  
+ATOM   3107  C5    A A  63     128.156  43.725 156.905  1.00 83.41           C  
+ANISOU 3107  C5    A A  63     6812  15655   9226   4062   1249  -1496       C  
+ATOM   3108  C6    A A  63     128.731  42.636 157.561  1.00 85.41           C  
+ANISOU 3108  C6    A A  63     7010  15937   9507   3810   1350  -1403       C  
+ATOM   3109  N6    A A  63     128.216  41.411 157.471  1.00 88.83           N  
+ANISOU 3109  N6    A A  63     7200  16569   9983   3576   1399  -1269       N  
+ATOM   3110  N1    A A  63     129.846  42.856 158.301  1.00 80.70           N  
+ANISOU 3110  N1    A A  63     6622  15150   8892   3802   1387  -1449       N  
+ATOM   3111  C2    A A  63     130.343  44.100 158.380  1.00 80.68           C  
+ANISOU 3111  C2    A A  63     6868  14939   8847   4028   1322  -1577       C  
+ATOM   3112  N3    A A  63     129.889  45.210 157.811  1.00 81.88           N  
+ANISOU 3112  N3    A A  63     7106  15035   8969   4272   1219  -1671       N  
+ATOM   3113  C4    A A  63     128.793  44.932 157.085  1.00 83.97           C  
+ANISOU 3113  C4    A A  63     7156  15496   9252   4275   1191  -1624       C  
+ATOM   3114  P     C A  64     130.598  47.622 152.071  1.00 88.97           P  
+ANISOU 3114  P     C A  64     8569  15067  10170   4630    695  -1884       P  
+ATOM   3115  OP1   C A  64     131.163  48.646 151.149  1.00 89.04           O  
+ANISOU 3115  OP1   C A  64     8856  14766  10209   4768    560  -1966       O  
+ATOM   3116  OP2   C A  64     129.759  46.511 151.541  1.00 77.65           O  
+ANISOU 3116  OP2   C A  64     6834  13882   8788   4479    732  -1784       O  
+ATOM   3117  O5'   C A  64     131.791  47.029 152.952  1.00 83.08           O  
+ANISOU 3117  O5'   C A  64     7906  14219   9442   4445    802  -1852       O  
+ATOM   3118  C5'   C A  64     132.819  47.891 153.419  1.00 82.20           C  
+ANISOU 3118  C5'   C A  64     8087  13841   9305   4530    769  -1930       C  
+ATOM   3119  C4'   C A  64     133.746  47.207 154.384  1.00 75.80           C  
+ANISOU 3119  C4'   C A  64     7299  13000   8501   4351    882  -1890       C  
+ATOM   3120  O4'   C A  64     132.982  46.534 155.409  1.00 83.94           O  
+ANISOU 3120  O4'   C A  64     8090  14337   9465   4291    990  -1832       O  
+ATOM   3121  C3'   C A  64     134.606  46.117 153.797  1.00 80.40           C  
+ANISOU 3121  C3'   C A  64     7860  13492   9197   4097    935  -1815       C  
+ATOM   3122  O3'   C A  64     135.731  46.636 153.124  1.00 84.35           O  
+ANISOU 3122  O3'   C A  64     8627  13665   9758   4109    865  -1861       O  
+ATOM   3123  C2'   C A  64     134.954  45.277 155.018  1.00 78.43           C  
+ANISOU 3123  C2'   C A  64     7521  13359   8921   3931   1066  -1758       C  
+ATOM   3124  O2'   C A  64     135.976  45.912 155.773  1.00 80.44           O  
+ANISOU 3124  O2'   C A  64     8018  13401   9146   3980   1063  -1821       O  
+ATOM   3125  C1'   C A  64     133.662  45.366 155.819  1.00 78.63           C  
+ANISOU 3125  C1'   C A  64     7346  13686   8843   4035   1099  -1748       C  
+ATOM   3126  N1    C A  64     132.759  44.211 155.624  1.00 77.41           N  
+ANISOU 3126  N1    C A  64     6884  13814   8713   3874   1160  -1638       N  
+ATOM   3127  C2    C A  64     132.977  43.028 156.344  1.00 79.15           C  
+ANISOU 3127  C2    C A  64     6967  14161   8944   3638   1273  -1540       C  
+ATOM   3128  O2    C A  64     133.953  42.938 157.109  1.00 78.26           O  
+ANISOU 3128  O2    C A  64     6991  13921   8822   3570   1327  -1551       O  
+ATOM   3129  N3    C A  64     132.122  41.992 156.176  1.00 79.87           N  
+ANISOU 3129  N3    C A  64     6785  14504   9057   3481   1314  -1431       N  
+ATOM   3130  C4    C A  64     131.078  42.110 155.358  1.00 79.80           C  
+ANISOU 3130  C4    C A  64     6630  14630   9059   3557   1250  -1420       C  
+ATOM   3131  N4    C A  64     130.251  41.065 155.241  1.00 81.21           N  
+ANISOU 3131  N4    C A  64     6540  15055   9262   3385   1282  -1304       N  
+ATOM   3132  C5    C A  64     130.834  43.308 154.626  1.00 75.39           C  
+ANISOU 3132  C5    C A  64     6202  13953   8489   3806   1140  -1524       C  
+ATOM   3133  C6    C A  64     131.686  44.324 154.791  1.00 74.70           C  
+ANISOU 3133  C6    C A  64     6394  13610   8378   3956   1097  -1629       C  
+ATOM   3134  P     A A  65     136.049  46.150 151.633  1.00 82.45           P  
+ANISOU 3134  P     A A  65     8390  13310   9627   4007    820  -1824       P  
+ATOM   3135  OP1   A A  65     137.152  47.012 151.128  1.00 79.97           O  
+ANISOU 3135  OP1   A A  65     8393  12646   9345   4072    734  -1884       O  
+ATOM   3136  OP2   A A  65     134.762  46.057 150.887  1.00 80.72           O  
+ANISOU 3136  OP2   A A  65     7972  13289   9407   4078    770  -1805       O  
+ATOM   3137  O5'   A A  65     136.600  44.671 151.840  1.00 87.28           O  
+ANISOU 3137  O5'   A A  65     8859  14006  10299   3721    941  -1727       O  
+ATOM   3138  C5'   A A  65     137.694  44.413 152.715  1.00 75.52           C  
+ANISOU 3138  C5'   A A  65     7490  12393   8810   3590   1013  -1715       C  
+ATOM   3139  C4'   A A  65     138.590  43.338 152.161  1.00 75.72           C  
+ANISOU 3139  C4'   A A  65     7567  12261   8942   3260   1030  -1603       C  
+ATOM   3140  O4'   A A  65     137.825  42.107 152.042  1.00 79.63           O  
+ANISOU 3140  O4'   A A  65     7789  13007   9460   3092   1084  -1508       O  
+ATOM   3141  C3'   A A  65     139.143  43.635 150.775  1.00 77.57           C  
+ANISOU 3141  C3'   A A  65     8000  12214   9260   3204    920  -1585       C  
+ATOM   3142  O3'   A A  65     140.454  43.091 150.641  1.00 79.29           O  
+ANISOU 3142  O3'   A A  65     8376  12203   9549   2966    941  -1522       O  
+ATOM   3143  C2'   A A  65     138.178  42.894 149.854  1.00 77.17           C  
+ANISOU 3143  C2'   A A  65     7746  12328   9247   3128    893  -1518       C  
+ATOM   3144  O2'   A A  65     138.743  42.524 148.614  1.00 73.93           O  
+ANISOU 3144  O2'   A A  65     7459  11707   8923   2962    828  -1456       O  
+ATOM   3145  C1'   A A  65     137.809  41.674 150.697  1.00 72.77           C  
+ANISOU 3145  C1'   A A  65     6941  12032   8678   2960   1006  -1446       C  
+ATOM   3146  N9    A A  65     136.473  41.132 150.409  1.00 67.86           N  
+ANISOU 3146  N9    A A  65     6035  11701   8047   2966   1002  -1403       N  
+ATOM   3147  C8    A A  65     135.487  41.708 149.647  1.00 69.81           C  
+ANISOU 3147  C8    A A  65     6209  12034   8283   3145    917  -1439       C  
+ATOM   3148  N7    A A  65     134.384  40.995 149.560  1.00 74.55           N  
+ANISOU 3148  N7    A A  65     6527  12917   8881   3095    929  -1379       N  
+ATOM   3149  C5    A A  65     134.662  39.858 150.310  1.00 66.99           C  
+ANISOU 3149  C5    A A  65     5457  12063   7934   2859   1027  -1292       C  
+ATOM   3150  C6    A A  65     133.905  38.703 150.615  1.00 67.75           C  
+ANISOU 3150  C6    A A  65     5270  12436   8034   2684   1076  -1188       C  
+ATOM   3151  N6    A A  65     132.662  38.474 150.181  1.00 69.92           N  
+ANISOU 3151  N6    A A  65     5301  12956   8308   2716   1035  -1150       N  
+ATOM   3152  N1    A A  65     134.485  37.760 151.396  1.00 68.25           N  
+ANISOU 3152  N1    A A  65     5310  12516   8104   2463   1162  -1117       N  
+ATOM   3153  C2    A A  65     135.734  37.976 151.830  1.00 65.80           C  
+ANISOU 3153  C2    A A  65     5235  11966   7798   2429   1198  -1154       C  
+ATOM   3154  N3    A A  65     136.545  39.011 151.616  1.00 68.45           N  
+ANISOU 3154  N3    A A  65     5836  12038   8135   2572   1160  -1245       N  
+ATOM   3155  C4    A A  65     135.943  39.935 150.842  1.00 71.62           C  
+ANISOU 3155  C4    A A  65     6262  12423   8526   2785   1073  -1310       C  
+ATOM   3156  P     G A  66     141.573  43.936 149.861  1.00 83.97           P  
+ANISOU 3156  P     G A  66     9281  12435  10188   2971    850  -1539       P  
+ATOM   3157  OP1   G A  66     140.879  45.116 149.281  1.00 78.40           O  
+ANISOU 3157  OP1   G A  66     8642  11701   9445   3226    743  -1615       O  
+ATOM   3158  OP2   G A  66     142.358  43.034 148.980  1.00 87.41           O  
+ANISOU 3158  OP2   G A  66     9772  12726  10712   2712    850  -1440       O  
+ATOM   3159  O5'   G A  66     142.559  44.413 151.020  1.00 74.92           O  
+ANISOU 3159  O5'   G A  66     8290  11164   9012   2991    889  -1583       O  
+ATOM   3160  C5'   G A  66     143.523  43.522 151.574  1.00 72.41           C  
+ANISOU 3160  C5'   G A  66     7985  10796   8734   2761    970  -1520       C  
+ATOM   3161  C4'   G A  66     143.993  43.962 152.940  1.00 68.01           C  
+ANISOU 3161  C4'   G A  66     7496  10225   8117   2836   1015  -1580       C  
+ATOM   3162  O4'   G A  66     145.048  44.951 152.800  1.00 71.05           O  
+ANISOU 3162  O4'   G A  66     8160  10312   8524   2876    936  -1613       O  
+ATOM   3163  C3'   G A  66     142.923  44.592 153.831  1.00 76.55           C  
+ANISOU 3163  C3'   G A  66     8466  11530   9089   3097   1031  -1674       C  
+ATOM   3164  O3'   G A  66     143.133  44.200 155.185  1.00 78.45           O  
+ANISOU 3164  O3'   G A  66     8644  11887   9277   3066   1128  -1683       O  
+ATOM   3165  C2'   G A  66     143.192  46.089 153.693  1.00 80.52           C  
+ANISOU 3165  C2'   G A  66     9211  11821   9562   3320    917  -1768       C  
+ATOM   3166  O2'   G A  66     142.774  46.854 154.807  1.00 85.01           O  
+ANISOU 3166  O2'   G A  66     9787  12489  10023   3560    922  -1873       O  
+ATOM   3167  C1'   G A  66     144.711  46.122 153.518  1.00 75.74           C  
+ANISOU 3167  C1'   G A  66     8837  10907   9033   3136    890  -1722       C  
+ATOM   3168  N9    G A  66     145.187  47.273 152.745  1.00 76.74           N  
+ANISOU 3168  N9    G A  66     9211  10764   9184   3228    759  -1751       N  
+ATOM   3169  C8    G A  66     144.726  47.639 151.508  1.00 78.75           C  
+ANISOU 3169  C8    G A  66     9493  10966   9463   3286    675  -1741       C  
+ATOM   3170  N7    G A  66     145.311  48.698 151.024  1.00 80.15           N  
+ANISOU 3170  N7    G A  66     9916  10884   9654   3353    560  -1763       N  
+ATOM   3171  C5    G A  66     146.223  49.048 152.003  1.00 75.27           C  
+ANISOU 3171  C5    G A  66     9439  10135   9023   3335    564  -1788       C  
+ATOM   3172  C6    G A  66     147.136  50.127 152.030  1.00 77.40           C  
+ANISOU 3172  C6    G A  66     9987  10120   9303   3372    454  -1809       C  
+ATOM   3173  O6    G A  66     147.336  50.998 151.176  1.00 84.51           O  
+ANISOU 3173  O6    G A  66    11068  10820  10222   3426    332  -1806       O  
+ATOM   3174  N1    G A  66     147.860  50.124 153.208  1.00 76.50           N  
+ANISOU 3174  N1    G A  66     9935   9960   9172   3333    489  -1831       N  
+ATOM   3175  C2    G A  66     147.734  49.207 154.220  1.00 85.15           C  
+ANISOU 3175  C2    G A  66    10855  11258  10241   3269    618  -1832       C  
+ATOM   3176  N2    G A  66     148.546  49.392 155.270  1.00 87.99           N  
+ANISOU 3176  N2    G A  66    11325  11522  10585   3242    624  -1855       N  
+ATOM   3177  N3    G A  66     146.881  48.194 154.211  1.00 82.14           N  
+ANISOU 3177  N3    G A  66    10214  11147   9848   3228    724  -1806       N  
+ATOM   3178  C4    G A  66     146.162  48.180 153.074  1.00 75.12           C  
+ANISOU 3178  C4    G A  66     9257  10306   8980   3263    687  -1785       C  
+ATOM   3179  P     C A  67     141.915  43.590 156.034  1.00103.51           P  
+ANISOU 3179  P     C A  67    11521  15444  12365   3126   1230  -1683       P  
+ATOM   3180  OP1   C A  67     140.809  43.261 155.098  1.00101.50           O  
+ANISOU 3180  OP1   C A  67    11075  15360  12129   3140   1208  -1646       O  
+ATOM   3181  OP2   C A  67     141.669  44.487 157.191  1.00 93.69           O  
+ANISOU 3181  OP2   C A  67    10319  14274  11005   3372   1243  -1788       O  
+ATOM   3182  O5'   C A  67     142.494  42.210 156.568  1.00 84.80           O  
+ANISOU 3182  O5'   C A  67     9060  13125  10035   2834   1332  -1582       O  
+ATOM   3183  C5'   C A  67     143.455  42.170 157.611  1.00 76.91           C  
+ANISOU 3183  C5'   C A  67     8179  12027   9016   2774   1377  -1595       C  
+ATOM   3184  C4'   C A  67     143.236  40.955 158.473  1.00 74.30           C  
+ANISOU 3184  C4'   C A  67     7649  11922   8659   2609   1494  -1523       C  
+ATOM   3185  O4'   C A  67     141.860  40.935 158.944  1.00 80.68           O  
+ANISOU 3185  O4'   C A  67     8213  13072   9370   2758   1549  -1540       O  
+ATOM   3186  C3'   C A  67     143.389  39.620 157.772  1.00 78.95           C  
+ANISOU 3186  C3'   C A  67     8139  12516   9343   2321   1511  -1401       C  
+ATOM   3187  O3'   C A  67     144.743  39.232 157.601  1.00 75.70           O  
+ANISOU 3187  O3'   C A  67     7905  11843   9012   2127   1496  -1361       O  
+ATOM   3188  C2'   C A  67     142.577  38.684 158.664  1.00 85.74           C  
+ANISOU 3188  C2'   C A  67     8743  13697  10138   2249   1613  -1345       C  
+ATOM   3189  O2'   C A  67     143.323  38.314 159.817  1.00 94.17           O  
+ANISOU 3189  O2'   C A  67     9864  14744  11174   2158   1682  -1336       O  
+ATOM   3190  C1'   C A  67     141.432  39.597 159.105  1.00 83.16           C  
+ANISOU 3190  C1'   C A  67     8301  13598   9698   2542   1627  -1430       C  
+ATOM   3191  N1    C A  67     140.186  39.377 158.332  1.00 84.87           N  
+ANISOU 3191  N1    C A  67     8307  14020   9922   2571   1605  -1391       N  
+ATOM   3192  C2    C A  67     139.462  38.181 158.528  1.00 83.75           C  
+ANISOU 3192  C2    C A  67     7921  14119   9782   2381   1660  -1275       C  
+ATOM   3193  O2    C A  67     139.862  37.308 159.321  1.00 80.02           O  
+ANISOU 3193  O2    C A  67     7411  13692   9301   2198   1732  -1209       O  
+ATOM   3194  N3    C A  67     138.319  37.984 157.836  1.00 81.67           N  
+ANISOU 3194  N3    C A  67     7469  14034   9530   2394   1626  -1232       N  
+ATOM   3195  C4    C A  67     137.883  38.908 156.979  1.00 80.45           C  
+ANISOU 3195  C4    C A  67     7357  13829   9383   2592   1544  -1302       C  
+ATOM   3196  N4    C A  67     136.742  38.642 156.333  1.00 72.25           N  
+ANISOU 3196  N4    C A  67     6118  12979   8355   2594   1510  -1254       N  
+ATOM   3197  C5    C A  67     138.592  40.133 156.756  1.00 81.56           C  
+ANISOU 3197  C5    C A  67     7752  13719   9519   2789   1485  -1419       C  
+ATOM   3198  C6    C A  67     139.725  40.322 157.452  1.00 80.02           C  
+ANISOU 3198  C6    C A  67     7743  13347   9315   2766   1516  -1457       C  
+ATOM   3199  P     C A  68     145.195  38.430 156.285  1.00 93.63           P  
+ANISOU 3199  P     C A  68    10207  13968  11399   1910   1449  -1273       P  
+ATOM   3200  OP1   C A  68     146.672  38.572 156.148  1.00 87.38           O  
+ANISOU 3200  OP1   C A  68     9646  12881  10671   1810   1421  -1269       O  
+ATOM   3201  OP2   C A  68     144.317  38.855 155.166  1.00 91.59           O  
+ANISOU 3201  OP2   C A  68     9896  13751  11153   2021   1380  -1285       O  
+ATOM   3202  O5'   C A  68     144.849  36.908 156.615  1.00 80.27           O  
+ANISOU 3202  O5'   C A  68     8315  12468   9716   1686   1516  -1173       O  
+ATOM   3203  C5'   C A  68     144.940  36.424 157.945  1.00 82.19           C  
+ANISOU 3203  C5'   C A  68     8488  12840   9901   1630   1603  -1159       C  
+ATOM   3204  C4'   C A  68     144.159  35.150 158.119  1.00 79.46           C  
+ANISOU 3204  C4'   C A  68     7909  12734   9547   1461   1649  -1063       C  
+ATOM   3205  O4'   C A  68     142.751  35.412 158.378  1.00 81.04           O  
+ANISOU 3205  O4'   C A  68     7891  13234   9668   1608   1679  -1075       O  
+ATOM   3206  C3'   C A  68     144.135  34.242 156.912  1.00 75.96           C  
+ANISOU 3206  C3'   C A  68     7438  12227   9195   1275   1589   -980       C  
+ATOM   3207  O3'   C A  68     145.362  33.557 156.726  1.00 79.31           O  
+ANISOU 3207  O3'   C A  68     8012  12431   9690   1083   1574   -939       O  
+ATOM   3208  C2'   C A  68     142.935  33.343 157.210  1.00 81.78           C  
+ANISOU 3208  C2'   C A  68     7907  13271   9896   1186   1624   -901       C  
+ATOM   3209  O2'   C A  68     143.283  32.331 158.141  1.00 91.77           O  
+ANISOU 3209  O2'   C A  68     9126  14596  11145    997   1684   -833       O  
+ATOM   3210  C1'   C A  68     141.975  34.328 157.886  1.00 78.33           C  
+ANISOU 3210  C1'   C A  68     7350  13057   9356   1439   1671   -972       C  
+ATOM   3211  N1    C A  68     140.931  34.822 156.945  1.00 72.29           N  
+ANISOU 3211  N1    C A  68     6479  12391   8595   1576   1613   -991       N  
+ATOM   3212  C2    C A  68     139.821  33.994 156.648  1.00 74.86           C  
+ANISOU 3212  C2    C A  68     6559  12960   8924   1472   1607   -902       C  
+ATOM   3213  O2    C A  68     139.708  32.874 157.164  1.00 85.82           O  
+ANISOU 3213  O2    C A  68     7824  14473  10310   1265   1648   -806       O  
+ATOM   3214  N3    C A  68     138.860  34.415 155.795  1.00 74.01           N  
+ANISOU 3214  N3    C A  68     6348  12949   8823   1594   1547   -917       N  
+ATOM   3215  C4    C A  68     138.962  35.616 155.227  1.00 74.47           C  
+ANISOU 3215  C4    C A  68     6547  12867   8882   1815   1494  -1018       C  
+ATOM   3216  N4    C A  68     137.984  35.981 154.394  1.00 72.20           N  
+ANISOU 3216  N4    C A  68     6152  12682   8599   1931   1431  -1030       N  
+ATOM   3217  C5    C A  68     140.065  36.487 155.494  1.00 70.78           C  
+ANISOU 3217  C5    C A  68     6337  12148   8410   1919   1494  -1105       C  
+ATOM   3218  C6    C A  68     141.017  36.053 156.346  1.00 71.04           C  
+ANISOU 3218  C6    C A  68     6461  12091   8440   1793   1554  -1088       C  
+ATOM   3219  P     G A  69     145.672  32.834 155.325  1.00 96.48           P  
+ANISOU 3219  P     G A  69    10242  14456  11960    928   1495   -880       P  
+ATOM   3220  OP1   G A  69     146.796  31.883 155.533  1.00 94.61           O  
+ANISOU 3220  OP1   G A  69    10105  14072  11769    723   1504   -829       O  
+ATOM   3221  OP2   G A  69     145.776  33.882 154.274  1.00 86.34           O  
+ANISOU 3221  OP2   G A  69     9082  13019  10703   1081   1430   -938       O  
+ATOM   3222  O5'   G A  69     144.371  31.947 155.111  1.00 76.41           O  
+ANISOU 3222  O5'   G A  69     7460  12164   9407    839   1484   -804       O  
+ATOM   3223  C5'   G A  69     144.112  31.245 153.918  1.00 67.30           C  
+ANISOU 3223  C5'   G A  69     6286  10971   8316    723   1403   -746       C  
+ATOM   3224  C4'   G A  69     142.815  30.489 154.043  1.00 73.29           C  
+ANISOU 3224  C4'   G A  69     6794  12001   9050    643   1399   -672       C  
+ATOM   3225  O4'   G A  69     141.787  31.348 154.614  1.00 81.20           O  
+ANISOU 3225  O4'   G A  69     7641  13236   9977    840   1447   -717       O  
+ATOM   3226  C3'   G A  69     142.227  30.036 152.727  1.00 74.09           C  
+ANISOU 3226  C3'   G A  69     6851  12094   9204    580   1297   -628       C  
+ATOM   3227  O3'   G A  69     142.854  28.870 152.231  1.00 80.01           O  
+ANISOU 3227  O3'   G A  69     7686  12703  10013    361   1241   -561       O  
+ATOM   3228  C2'   G A  69     140.741  29.916 153.037  1.00 76.88           C  
+ANISOU 3228  C2'   G A  69     6932  12765   9513    606   1306   -586       C  
+ATOM   3229  O2'   G A  69     140.464  28.726 153.749  1.00 85.33           O  
+ANISOU 3229  O2'   G A  69     7863  13986  10571    395   1330   -485       O  
+ATOM   3230  C1'   G A  69     140.545  31.107 153.977  1.00 81.50           C  
+ANISOU 3230  C1'   G A  69     7487  13461  10018    840   1396   -672       C  
+ATOM   3231  N9    G A  69     140.190  32.325 153.221  1.00 77.12           N  
+ANISOU 3231  N9    G A  69     6980  12863   9460   1076   1352   -759       N  
+ATOM   3232  C8    G A  69     140.906  33.502 153.202  1.00 71.67           C  
+ANISOU 3232  C8    G A  69     6486  11986   8759   1259   1357   -860       C  
+ATOM   3233  N7    G A  69     140.383  34.422 152.434  1.00 66.41           N  
+ANISOU 3233  N7    G A  69     5835  11308   8090   1446   1300   -917       N  
+ATOM   3234  C5    G A  69     139.261  33.810 151.898  1.00 64.45           C  
+ANISOU 3234  C5    G A  69     5381  11251   7854   1384   1255   -853       C  
+ATOM   3235  C6    G A  69     138.301  34.324 150.988  1.00 67.36           C  
+ANISOU 3235  C6    G A  69     5670  11696   8227   1520   1179   -875       C  
+ATOM   3236  O6    G A  69     138.262  35.455 150.465  1.00 72.22           O  
+ANISOU 3236  O6    G A  69     6392  12215   8832   1730   1136   -959       O  
+ATOM   3237  N1    G A  69     137.313  33.368 150.714  1.00 63.96           N  
+ANISOU 3237  N1    G A  69     5015  11472   7814   1382   1146   -783       N  
+ATOM   3238  C2    G A  69     137.266  32.090 151.242  1.00 61.07           C  
+ANISOU 3238  C2    G A  69     4529  11215   7458   1139   1175   -679       C  
+ATOM   3239  N2    G A  69     136.237  31.329 150.848  1.00 62.30           N  
+ANISOU 3239  N2    G A  69     4477  11561   7634   1025   1119   -592       N  
+ATOM   3240  N3    G A  69     138.160  31.600 152.089  1.00 70.55           N  
+ANISOU 3240  N3    G A  69     5812  12340   8652   1013   1245   -659       N  
+ATOM   3241  C4    G A  69     139.123  32.512 152.370  1.00 70.37           C  
+ANISOU 3241  C4    G A  69     5998  12125   8614   1151   1284   -752       C  
+ATOM   3242  P     G A  70     143.659  28.970 150.847  1.00 90.28           P  
+ANISOU 3242  P     G A  70     9197  13729  11377    365   1159   -587       P  
+ATOM   3243  OP1   G A  70     144.718  27.919 150.814  1.00 90.53           O  
+ANISOU 3243  OP1   G A  70     9358  13594  11447    174   1142   -543       O  
+ATOM   3244  OP2   G A  70     144.122  30.382 150.681  1.00 80.65           O  
+ANISOU 3244  OP2   G A  70     8110  12388  10145    579   1184   -681       O  
+ATOM   3245  O5'   G A  70     142.517  28.632 149.785  1.00 68.85           O  
+ANISOU 3245  O5'   G A  70     6361  11116   8683    344   1058   -545       O  
+ATOM   3246  C5'   G A  70     141.739  27.451 149.926  1.00 66.29           C  
+ANISOU 3246  C5'   G A  70     5870  10953   8365    160   1016   -450       C  
+ATOM   3247  C4'   G A  70     140.375  27.582 149.290  1.00 74.62           C  
+ANISOU 3247  C4'   G A  70     6746  12186   9419    211    947   -426       C  
+ATOM   3248  O4'   G A  70     139.610  28.634 149.943  1.00 80.24           O  
+ANISOU 3248  O4'   G A  70     7312  13100  10074    408   1022   -475       O  
+ATOM   3249  C3'   G A  70     140.352  27.974 147.822  1.00 74.62           C  
+ANISOU 3249  C3'   G A  70     6860  12036   9456    296    848   -462       C  
+ATOM   3250  O3'   G A  70     140.628  26.899 146.949  1.00 78.30           O  
+ANISOU 3250  O3'   G A  70     7413  12370   9968    123    743   -407       O  
+ATOM   3251  C2'   G A  70     138.955  28.549 147.670  1.00 73.48           C  
+ANISOU 3251  C2'   G A  70     6508  12123   9289    424    824   -466       C  
+ATOM   3252  O2'   G A  70     137.995  27.503 147.671  1.00 74.14           O  
+ANISOU 3252  O2'   G A  70     6393  12391   9386    251    761   -365       O  
+ATOM   3253  C1'   G A  70     138.826  29.318 148.985  1.00 75.63           C  
+ANISOU 3253  C1'   G A  70     6685  12553   9498    556    953   -509       C  
+ATOM   3254  N9    G A  70     139.364  30.688 148.862  1.00 66.09           N  
+ANISOU 3254  N9    G A  70     5634  11207   8270    789    989   -620       N  
+ATOM   3255  C8    G A  70     140.481  31.186 149.501  1.00 58.63           C  
+ANISOU 3255  C8    G A  70     4857  10110   7310    839   1065   -675       C  
+ATOM   3256  N7    G A  70     140.752  32.434 149.210  1.00 60.04           N  
+ANISOU 3256  N7    G A  70     5161  10176   7475   1045   1065   -763       N  
+ATOM   3257  C5    G A  70     139.742  32.779 148.309  1.00 70.08           C  
+ANISOU 3257  C5    G A  70     6345  11531   8750   1145    986   -771       C  
+ATOM   3258  C6    G A  70     139.503  34.011 147.639  1.00 67.79           C  
+ANISOU 3258  C6    G A  70     6132  11176   8448   1370    941   -849       C  
+ATOM   3259  O6    G A  70     140.154  35.067 147.725  1.00 66.79           O  
+ANISOU 3259  O6    G A  70     6176  10898   8305   1520    959   -924       O  
+ATOM   3260  N1    G A  70     138.383  33.929 146.804  1.00 62.92           N  
+ANISOU 3260  N1    G A  70     5382  10683   7842   1405    856   -828       N  
+ATOM   3261  C2    G A  70     137.586  32.822 146.634  1.00 59.51           C  
+ANISOU 3261  C2    G A  70     4761  10418   7432   1240    815   -739       C  
+ATOM   3262  N2    G A  70     136.561  32.983 145.783  1.00 60.50           N  
+ANISOU 3262  N2    G A  70     4780  10640   7567   1311    723   -734       N  
+ATOM   3263  N3    G A  70     137.789  31.662 147.254  1.00 62.58           N  
+ANISOU 3263  N3    G A  70     5078  10866   7834   1020    850   -660       N  
+ATOM   3264  C4    G A  70     138.877  31.713 148.074  1.00 69.41           C  
+ANISOU 3264  C4    G A  70     6074  11612   8685    990    938   -683       C  
+ATOM   3265  P     G A  71     141.640  27.119 145.721  1.00 78.40           P  
+ANISOU 3265  P     G A  71     7686  12092  10009    172    688   -455       P  
+ATOM   3266  OP1   G A  71     142.062  25.771 145.246  1.00 82.65           O  
+ANISOU 3266  OP1   G A  71     8308  12516  10579    -31    602   -394       O  
+ATOM   3267  OP2   G A  71     142.669  28.116 146.128  1.00 73.25           O  
+ANISOU 3267  OP2   G A  71     7181  11309   9341    306    786   -530       O  
+ATOM   3268  O5'   G A  71     140.737  27.815 144.603  1.00 69.68           O  
+ANISOU 3268  O5'   G A  71     6544  11024   8909    314    604   -482       O  
+ATOM   3269  C5'   G A  71     139.499  27.245 144.206  1.00 65.86           C  
+ANISOU 3269  C5'   G A  71     5883  10704   8437    243    508   -423       C  
+ATOM   3270  C4'   G A  71     138.708  28.187 143.333  1.00 71.63           C  
+ANISOU 3270  C4'   G A  71     6578  11475   9163    426    450   -467       C  
+ATOM   3271  O4'   G A  71     138.261  29.330 144.106  1.00 78.11           O  
+ANISOU 3271  O4'   G A  71     7288  12446   9945    615    543   -523       O  
+ATOM   3272  C3'   G A  71     139.449  28.819 142.167  1.00 70.71           C  
+ANISOU 3272  C3'   G A  71     6700  11114   9053    540    409   -528       C  
+ATOM   3273  O3'   G A  71     139.610  27.957 141.059  1.00 75.97           O  
+ANISOU 3273  O3'   G A  71     7473  11649   9744    426    292   -491       O  
+ATOM   3274  C2'   G A  71     138.590  30.033 141.866  1.00 67.73           C  
+ANISOU 3274  C2'   G A  71     6245  10834   8655    759    396   -583       C  
+ATOM   3275  O2'   G A  71     137.410  29.646 141.179  1.00 68.73           O  
+ANISOU 3275  O2'   G A  71     6228  11090   8798    730    280   -542       O  
+ATOM   3276  C1'   G A  71     138.212  30.474 143.275  1.00 71.89           C  
+ANISOU 3276  C1'   G A  71     6601  11564   9148    822    510   -597       C  
+ATOM   3277  N9    G A  71     139.172  31.465 143.774  1.00 58.91           N  
+ANISOU 3277  N9    G A  71     5114   9791   7480    955    606   -672       N  
+ATOM   3278  C8    G A  71     140.174  31.294 144.687  1.00 56.61           C  
+ANISOU 3278  C8    G A  71     4902   9425   7182    888    702   -675       C  
+ATOM   3279  N7    G A  71     140.862  32.391 144.882  1.00 56.55           N  
+ANISOU 3279  N7    G A  71     5036   9294   7155   1040    755   -747       N  
+ATOM   3280  C5    G A  71     140.271  33.323 144.041  1.00 56.99           C  
+ANISOU 3280  C5    G A  71     5111   9341   7201   1217    690   -793       C  
+ATOM   3281  C6    G A  71     140.563  34.687 143.812  1.00 57.30           C  
+ANISOU 3281  C6    G A  71     5290   9263   7219   1422    691   -871       C  
+ATOM   3282  O6    G A  71     141.442  35.391 144.321  1.00 56.78           O  
+ANISOU 3282  O6    G A  71     5362   9072   7138   1488    750   -915       O  
+ATOM   3283  N1    G A  71     139.706  35.239 142.872  1.00 57.57           N  
+ANISOU 3283  N1    G A  71     5298   9329   7249   1553    600   -893       N  
+ATOM   3284  C2    G A  71     138.701  34.578 142.226  1.00 63.15           C  
+ANISOU 3284  C2    G A  71     5858  10164   7972   1496    518   -848       C  
+ATOM   3285  N2    G A  71     137.992  35.299 141.355  1.00 63.67           N  
+ANISOU 3285  N2    G A  71     5926  10236   8030   1650    431   -882       N  
+ATOM   3286  N3    G A  71     138.410  33.307 142.426  1.00 65.88           N  
+ANISOU 3286  N3    G A  71     6070  10620   8341   1298    510   -772       N  
+ATOM   3287  C4    G A  71     139.233  32.758 143.344  1.00 60.35           C  
+ANISOU 3287  C4    G A  71     5399   9888   7643   1170    600   -749       C  
+ATOM   3288  P     C A  72     140.831  28.180 140.040  1.00 61.57           P  
+ANISOU 3288  P     C A  72     5932   9543   7918    473    276   -531       P  
+ATOM   3289  OP1   C A  72     140.752  27.075 139.055  1.00 64.99           O  
+ANISOU 3289  OP1   C A  72     6431   9897   8367    342    145   -485       O  
+ATOM   3290  OP2   C A  72     142.066  28.429 140.822  1.00 58.73           O  
+ANISOU 3290  OP2   C A  72     5687   9078   7550    475    398   -558       O  
+ATOM   3291  O5'   C A  72     140.483  29.543 139.289  1.00 62.73           O  
+ANISOU 3291  O5'   C A  72     6125   9662   8046    697    257   -594       O  
+ATOM   3292  C5'   C A  72     139.324  29.662 138.479  1.00 65.06           C  
+ANISOU 3292  C5'   C A  72     6326  10049   8346    753    145   -587       C  
+ATOM   3293  C4'   C A  72     139.255  31.007 137.799  1.00 65.23           C  
+ANISOU 3293  C4'   C A  72     6440   9999   8344    971    134   -652       C  
+ATOM   3294  O4'   C A  72     139.096  32.063 138.783  1.00 63.48           O  
+ANISOU 3294  O4'   C A  72     6140   9876   8103   1115    231   -702       O  
+ATOM   3295  C3'   C A  72     140.494  31.418 137.034  1.00 64.30           C  
+ANISOU 3295  C3'   C A  72     6591   9629   8211   1017    149   -680       C  
+ATOM   3296  O3'   C A  72     140.599  30.792 135.776  1.00 71.88           O  
+ANISOU 3296  O3'   C A  72     7668  10472   9170    960     43   -654       O  
+ATOM   3297  C2'   C A  72     140.359  32.932 136.979  1.00 61.63           C  
+ANISOU 3297  C2'   C A  72     6295   9272   7849   1234    174   -743       C  
+ATOM   3298  O2'   C A  72     139.389  33.312 136.015  1.00 64.11           O  
+ANISOU 3298  O2'   C A  72     6578   9625   8156   1338     61   -755       O  
+ATOM   3299  C1'   C A  72     139.793  33.219 138.364  1.00 61.47           C  
+ANISOU 3299  C1'   C A  72     6078   9451   7827   1272    254   -760       C  
+ATOM   3300  N1    C A  72     140.856  33.506 139.353  1.00 59.61           N  
+ANISOU 3300  N1    C A  72     5922   9142   7585   1261    376   -780       N  
+ATOM   3301  C2    C A  72     141.295  34.821 139.511  1.00 58.72           C  
+ANISOU 3301  C2    C A  72     5925   8937   7449   1429    418   -840       C  
+ATOM   3302  O2    C A  72     140.809  35.716 138.816  1.00 57.89           O  
+ANISOU 3302  O2    C A  72     5861   8807   7327   1586    353   -877       O  
+ATOM   3303  N3    C A  72     142.246  35.082 140.426  1.00 57.25           N  
+ANISOU 3303  N3    C A  72     5811   8682   7259   1414    516   -856       N  
+ATOM   3304  C4    C A  72     142.751  34.096 141.168  1.00 56.29           C  
+ANISOU 3304  C4    C A  72     5647   8587   7155   1247    579   -818       C  
+ATOM   3305  N4    C A  72     143.692  34.399 142.060  1.00 53.17           N  
+ANISOU 3305  N4    C A  72     5327   8121   6756   1239    670   -836       N  
+ATOM   3306  C5    C A  72     142.327  32.746 141.031  1.00 59.33           C  
+ANISOU 3306  C5    C A  72     5920   9063   7561   1076    540   -756       C  
+ATOM   3307  C6    C A  72     141.383  32.506 140.120  1.00 58.82           C  
+ANISOU 3307  C6    C A  72     5787   9061   7501   1087    437   -739       C  
+ATOM   3308  P     U A  73     142.047  30.625 135.111  1.00 61.76           P  
+ANISOU 3308  P     U A  73     6644   8953   7869    928     70   -654       P  
+ATOM   3309  OP1   U A  73     141.777  30.422 133.663  1.00 65.44           O  
+ANISOU 3309  OP1   U A  73     7214   9334   8315    953    -55   -646       O  
+ATOM   3310  OP2   U A  73     142.861  29.641 135.869  1.00 60.35           O  
+ANISOU 3310  OP2   U A  73     6476   8750   7705    768    134   -624       O  
+ATOM   3311  O5'   U A  73     142.734  32.011 135.471  1.00 71.72           O  
+ANISOU 3311  O5'   U A  73     8000  10138   9114   1075    171   -700       O  
+ATOM   3312  C5'   U A  73     143.661  32.640 134.617  1.00 67.67           C  
+ANISOU 3312  C5'   U A  73     7701   9438   8572   1147    180   -711       C  
+ATOM   3313  C4'   U A  73     143.505  34.131 134.696  1.00 63.55           C  
+ANISOU 3313  C4'   U A  73     7211   8898   8035   1324    200   -755       C  
+ATOM   3314  O4'   U A  73     143.030  34.515 136.014  1.00 61.25           O  
+ANISOU 3314  O4'   U A  73     6761   8750   7760   1362    263   -784       O  
+ATOM   3315  C3'   U A  73     144.781  34.925 134.525  1.00 61.66           C  
+ANISOU 3315  C3'   U A  73     7172   8478   7777   1367    266   -757       C  
+ATOM   3316  O3'   U A  73     145.162  35.041 133.171  1.00 63.53           O  
+ANISOU 3316  O3'   U A  73     7577   8581   7980   1395    210   -736       O  
+ATOM   3317  C2'   U A  73     144.438  36.245 135.199  1.00 56.23           C  
+ANISOU 3317  C2'   U A  73     6453   7823   7086   1517    290   -806       C  
+ATOM   3318  O2'   U A  73     143.625  37.049 134.360  1.00 57.72           O  
+ANISOU 3318  O2'   U A  73     6668   8009   7253   1663    196   -830       O  
+ATOM   3319  C1'   U A  73     143.589  35.759 136.379  1.00 57.97           C  
+ANISOU 3319  C1'   U A  73     6446   8248   7330   1483    319   -822       C  
+ATOM   3320  N1    U A  73     144.410  35.566 137.590  1.00 54.02           N  
+ANISOU 3320  N1    U A  73     5934   7747   6846   1404    429   -820       N  
+ATOM   3321  C2    U A  73     144.940  36.688 138.175  1.00 54.27           C  
+ANISOU 3321  C2    U A  73     6047   7706   6867   1504    482   -857       C  
+ATOM   3322  O2    U A  73     144.747  37.808 137.757  1.00 57.71           O  
+ANISOU 3322  O2    U A  73     6564   8080   7282   1652    439   -889       O  
+ATOM   3323  N3    U A  73     145.707  36.457 139.286  1.00 55.14           N  
+ANISOU 3323  N3    U A  73     6148   7811   6991   1425    576   -855       N  
+ATOM   3324  C4    U A  73     146.003  35.246 139.867  1.00 51.82           C  
+ANISOU 3324  C4    U A  73     5649   7449   6592   1260    626   -820       C  
+ATOM   3325  O4    U A  73     146.712  35.227 140.870  1.00 53.68           O  
+ANISOU 3325  O4    U A  73     5893   7667   6835   1212    706   -824       O  
+ATOM   3326  C5    U A  73     145.417  34.124 139.205  1.00 52.59           C  
+ANISOU 3326  C5    U A  73     5670   7614   6697   1162    563   -782       C  
+ATOM   3327  C6    U A  73     144.665  34.320 138.113  1.00 55.21           C  
+ANISOU 3327  C6    U A  73     6009   7951   7017   1234    468   -784       C  
+ATOM   3328  P     G A  74     146.709  35.082 132.783  1.00 61.40           P  
+ANISOU 3328  P     G A  74     7503   8138   7689   1345    279   -702       P  
+ATOM   3329  OP1   G A  74     146.780  34.954 131.308  1.00 63.52           O  
+ANISOU 3329  OP1   G A  74     7906   8318   7911   1372    204   -677       O  
+ATOM   3330  OP2   G A  74     147.476  34.122 133.609  1.00 58.27           O  
+ANISOU 3330  OP2   G A  74     7069   7755   7318   1204    360   -683       O  
+ATOM   3331  O5'   G A  74     147.119  36.557 133.198  1.00 62.32           O  
+ANISOU 3331  O5'   G A  74     7695   8181   7802   1456    324   -722       O  
+ATOM   3332  C5'   G A  74     146.415  37.657 132.656  1.00 63.88           C  
+ANISOU 3332  C5'   G A  74     7932   8360   7978   1607    250   -747       C  
+ATOM   3333  C4'   G A  74     146.914  38.960 133.209  1.00 66.65           C  
+ANISOU 3333  C4'   G A  74     8367   8627   8328   1693    287   -765       C  
+ATOM   3334  O4'   G A  74     146.576  39.065 134.612  1.00 70.12           O  
+ANISOU 3334  O4'   G A  74     8667   9176   8799   1706    337   -809       O  
+ATOM   3335  C3'   G A  74     148.416  39.164 133.189  1.00 66.81           C  
+ANISOU 3335  C3'   G A  74     8540   8501   8344   1618    364   -716       C  
+ATOM   3336  O3'   G A  74     148.903  39.518 131.907  1.00 68.59           O  
+ANISOU 3336  O3'   G A  74     8933   8602   8526   1637    328   -669       O  
+ATOM   3337  C2'   G A  74     148.606  40.239 134.246  1.00 64.77           C  
+ANISOU 3337  C2'   G A  74     8293   8214   8104   1685    394   -750       C  
+ATOM   3338  O2'   G A  74     148.224  41.509 133.740  1.00 61.68           O  
+ANISOU 3338  O2'   G A  74     8004   7745   7685   1830    314   -767       O  
+ATOM   3339  C1'   G A  74     147.564  39.819 135.283  1.00 65.55           C  
+ANISOU 3339  C1'   G A  74     8186   8492   8226   1708    400   -808       C  
+ATOM   3340  N9    G A  74     148.152  38.997 136.352  1.00 58.68           N  
+ANISOU 3340  N9    G A  74     7234   7673   7388   1580    495   -800       N  
+ATOM   3341  C8    G A  74     148.149  37.628 136.481  1.00 53.84           C  
+ANISOU 3341  C8    G A  74     6521   7145   6792   1446    526   -777       C  
+ATOM   3342  N7    G A  74     148.764  37.221 137.563  1.00 54.14           N  
+ANISOU 3342  N7    G A  74     6514   7204   6854   1357    609   -775       N  
+ATOM   3343  C5    G A  74     149.203  38.396 138.172  1.00 58.54           C  
+ANISOU 3343  C5    G A  74     7147   7686   7412   1437    633   -800       C  
+ATOM   3344  C6    G A  74     149.928  38.614 139.377  1.00 57.51           C  
+ANISOU 3344  C6    G A  74     7019   7532   7299   1402    707   -812       C  
+ATOM   3345  O6    G A  74     150.361  37.775 140.177  1.00 62.39           O  
+ANISOU 3345  O6    G A  74     7569   8197   7939   1288    773   -801       O  
+ATOM   3346  N1    G A  74     150.152  39.970 139.618  1.00 54.28           N  
+ANISOU 3346  N1    G A  74     6717   7026   6881   1515    686   -838       N  
+ATOM   3347  C2    G A  74     149.733  40.989 138.805  1.00 59.52           C  
+ANISOU 3347  C2    G A  74     7475   7620   7519   1645    604   -850       C  
+ATOM   3348  N2    G A  74     150.053  42.223 139.208  1.00 60.83           N  
+ANISOU 3348  N2    G A  74     7754   7681   7679   1737    580   -874       N  
+ATOM   3349  N3    G A  74     149.054  40.807 137.680  1.00 65.03           N  
+ANISOU 3349  N3    G A  74     8168   8342   8198   1682    540   -839       N  
+ATOM   3350  C4    G A  74     148.829  39.499 137.432  1.00 60.14           C  
+ANISOU 3350  C4    G A  74     7442   7819   7588   1574    560   -815       C  
+ATOM   3351  P     C A  75     150.428  39.220 131.506  1.00 62.92           P  
+ANISOU 3351  P     C A  75     8346   7771   7790   1527    406   -596       P  
+ATOM   3352  OP1   C A  75     150.556  39.444 130.043  1.00 68.09           O  
+ANISOU 3352  OP1   C A  75     9142   8345   8384   1566    353   -551       O  
+ATOM   3353  OP2   C A  75     150.856  37.931 132.092  1.00 58.45           O  
+ANISOU 3353  OP2   C A  75     7685   7272   7250   1398    476   -592       O  
+ATOM   3354  O5'   C A  75     151.227  40.349 132.286  1.00 65.46           O  
+ANISOU 3354  O5'   C A  75     8741   8000   8132   1540    452   -586       O  
+ATOM   3355  C5'   C A  75     151.061  41.713 131.952  1.00 65.53           C  
+ANISOU 3355  C5'   C A  75     8865   7913   8121   1650    387   -585       C  
+ATOM   3356  C4'   C A  75     152.153  42.557 132.557  1.00 69.90           C  
+ANISOU 3356  C4'   C A  75     9515   8352   8692   1614    432   -551       C  
+ATOM   3357  O4'   C A  75     151.934  42.708 133.978  1.00 69.84           O  
+ANISOU 3357  O4'   C A  75     9409   8398   8729   1630    459   -613       O  
+ATOM   3358  C3'   C A  75     153.558  41.993 132.465  1.00 66.88           C  
+ANISOU 3358  C3'   C A  75     9176   7922   8311   1471    527   -474       C  
+ATOM   3359  O3'   C A  75     154.143  42.232 131.203  1.00 66.76           O  
+ANISOU 3359  O3'   C A  75     9299   7824   8244   1457    517   -394       O  
+ATOM   3360  C2'   C A  75     154.276  42.707 133.593  1.00 63.38           C  
+ANISOU 3360  C2'   C A  75     8757   7414   7909   1440    562   -473       C  
+ATOM   3361  O2'   C A  75     154.615  44.022 133.189  1.00 67.10           O  
+ANISOU 3361  O2'   C A  75     9386   7745   8361   1487    504   -430       O  
+ATOM   3362  C1'   C A  75     153.171  42.804 134.645  1.00 63.70           C  
+ANISOU 3362  C1'   C A  75     8677   7549   7978   1529    532   -572       C  
+ATOM   3363  N1    C A  75     153.240  41.742 135.677  1.00 57.11           N  
+ANISOU 3363  N1    C A  75     7694   6826   7181   1445    611   -604       N  
+ATOM   3364  C2    C A  75     154.255  41.767 136.635  1.00 56.11           C  
+ANISOU 3364  C2    C A  75     7575   6656   7088   1359    679   -587       C  
+ATOM   3365  O2    C A  75     155.111  42.649 136.599  1.00 57.70           O  
+ANISOU 3365  O2    C A  75     7903   6729   7293   1344    673   -541       O  
+ATOM   3366  N3    C A  75     154.300  40.825 137.590  1.00 56.15           N  
+ANISOU 3366  N3    C A  75     7453   6759   7123   1286    745   -615       N  
+ATOM   3367  C4    C A  75     153.378  39.867 137.624  1.00 56.80           C  
+ANISOU 3367  C4    C A  75     7400   6978   7202   1287    743   -652       C  
+ATOM   3368  N4    C A  75     153.465  38.952 138.585  1.00 52.08           N  
+ANISOU 3368  N4    C A  75     6687   6469   6631   1204    804   -671       N  
+ATOM   3369  C5    C A  75     152.327  39.816 136.667  1.00 61.56           C  
+ANISOU 3369  C5    C A  75     7984   7631   7775   1366    671   -667       C  
+ATOM   3370  C6    C A  75     152.294  40.768 135.725  1.00 59.72           C  
+ANISOU 3370  C6    C A  75     7881   7299   7512   1449    608   -646       C  
+ATOM   3371  P     C A  76     155.221  41.212 130.611  1.00 63.97           P  
+ANISOU 3371  P     C A  76     8960   7482   7863   1340    604   -323       P  
+ATOM   3372  OP1   C A  76     155.599  41.761 129.284  1.00 68.37           O  
+ANISOU 3372  OP1   C A  76     9666   7958   8352   1363    577   -245       O  
+ATOM   3373  OP2   C A  76     154.693  39.837 130.791  1.00 59.66           O  
+ANISOU 3373  OP2   C A  76     8284   7056   7328   1311    620   -375       O  
+ATOM   3374  O5'   C A  76     156.475  41.364 131.577  1.00 69.01           O  
+ANISOU 3374  O5'   C A  76     9596   8078   8547   1236    691   -284       O  
+ATOM   3375  C5'   C A  76     157.181  42.592 131.679  1.00 65.72           C  
+ANISOU 3375  C5'   C A  76     9292   7543   8136   1226    680   -226       C  
+ATOM   3376  C4'   C A  76     158.361  42.450 132.604  1.00 62.21           C  
+ANISOU 3376  C4'   C A  76     8819   7081   7738   1111    764   -191       C  
+ATOM   3377  O4'   C A  76     157.907  42.374 133.979  1.00 60.66           O  
+ANISOU 3377  O4'   C A  76     8523   6923   7600   1125    763   -277       O  
+ATOM   3378  C3'   C A  76     159.190  41.188 132.422  1.00 59.33           C  
+ANISOU 3378  C3'   C A  76     8393   6786   7363   1015    861   -156       C  
+ATOM   3379  O3'   C A  76     160.099  41.282 131.337  1.00 61.85           O  
+ANISOU 3379  O3'   C A  76     8802   7071   7626    975    896    -53       O  
+ATOM   3380  C2'   C A  76     159.868  41.041 133.775  1.00 56.69           C  
+ANISOU 3380  C2'   C A  76     7990   6455   7096    934    918   -170       C  
+ATOM   3381  O2'   C A  76     160.976  41.920 133.865  1.00 60.03           O  
+ANISOU 3381  O2'   C A  76     8496   6780   7532    869    934    -84       O  
+ATOM   3382  C1'   C A  76     158.773  41.544 134.724  1.00 58.81           C  
+ANISOU 3382  C1'   C A  76     8213   6731   7402   1015    854   -266       C  
+ATOM   3383  N1    C A  76     157.980  40.449 135.337  1.00 56.56           N  
+ANISOU 3383  N1    C A  76     7786   6569   7135   1022    871   -349       N  
+ATOM   3384  C2    C A  76     158.477  39.811 136.470  1.00 55.95           C  
+ANISOU 3384  C2    C A  76     7623   6533   7103    942    935   -370       C  
+ATOM   3385  O2    C A  76     159.578  40.160 136.918  1.00 54.53           O  
+ANISOU 3385  O2    C A  76     7484   6286   6949    870    975   -322       O  
+ATOM   3386  N3    C A  76     157.747  38.818 137.039  1.00 55.00           N  
+ANISOU 3386  N3    C A  76     7377   6524   6996    936    946   -435       N  
+ATOM   3387  C4    C A  76     156.567  38.465 136.534  1.00 55.11           C  
+ANISOU 3387  C4    C A  76     7341   6612   6985   1003    894   -476       C  
+ATOM   3388  N4    C A  76     155.898  37.494 137.138  1.00 54.60           N  
+ANISOU 3388  N4    C A  76     7149   6660   6937    978    901   -526       N  
+ATOM   3389  C5    C A  76     156.029  39.090 135.381  1.00 55.41           C  
+ANISOU 3389  C5    C A  76     7460   6612   6981   1091    825   -462       C  
+ATOM   3390  C6    C A  76     156.767  40.066 134.835  1.00 55.89           C  
+ANISOU 3390  C6    C A  76     7653   6558   7024   1099    818   -400       C  
+ATOM   3391  P     G A  77     160.540  39.971 130.520  1.00 64.77           P  
+ANISOU 3391  P     G A  77     9144   7526   7941    945    964    -28       P  
+ATOM   3392  OP1   G A  77     161.151  40.420 129.245  1.00 77.74           O  
+ANISOU 3392  OP1   G A  77    10900   9131   9504    949    976     75       O  
+ATOM   3393  OP2   G A  77     159.426  38.992 130.514  1.00 61.23           O  
+ANISOU 3393  OP2   G A  77     8617   7158   7489    998    925   -122       O  
+ATOM   3394  O5'   G A  77     161.721  39.360 131.381  1.00 61.65           O  
+ANISOU 3394  O5'   G A  77     8676   7159   7588    837   1061     -4       O  
+ATOM   3395  C5'   G A  77     162.838  40.153 131.753  1.00 65.35           C  
+ANISOU 3395  C5'   G A  77     9180   7564   8085    760   1100     78       C  
+ATOM   3396  C4'   G A  77     163.595  39.486 132.863  1.00 66.10           C  
+ANISOU 3396  C4'   G A  77     9180   7695   8239    675   1169     62       C  
+ATOM   3397  O4'   G A  77     162.661  39.191 133.945  1.00 67.81           O  
+ANISOU 3397  O4'   G A  77     9318   7936   8511    702   1132    -48       O  
+ATOM   3398  C3'   G A  77     164.227  38.154 132.472  1.00 61.28           C  
+ANISOU 3398  C3'   G A  77     8517   7174   7590    647   1246     73       C  
+ATOM   3399  O3'   G A  77     165.419  37.957 133.226  1.00 59.69           O  
+ANISOU 3399  O3'   G A  77     8266   6980   7432    554   1318    113       O  
+ATOM   3400  C2'   G A  77     163.179  37.148 132.927  1.00 63.16           C  
+ANISOU 3400  C2'   G A  77     8679   7473   7845    685   1214    -40       C  
+ATOM   3401  O2'   G A  77     163.666  35.849 133.166  1.00 65.38           O  
+ANISOU 3401  O2'   G A  77     8895   7821   8124    645   1267    -62       O  
+ATOM   3402  C1'   G A  77     162.670  37.803 134.208  1.00 63.25           C  
+ANISOU 3402  C1'   G A  77     8649   7447   7934    676   1177    -95       C  
+ATOM   3403  N9    G A  77     161.337  37.329 134.604  1.00 55.75           N  
+ANISOU 3403  N9    G A  77     7633   6551   7000    730   1122   -194       N  
+ATOM   3404  C8    G A  77     160.208  37.272 133.827  1.00 57.73           C  
+ANISOU 3404  C8    G A  77     7898   6826   7211    813   1055   -229       C  
+ATOM   3405  N7    G A  77     159.183  36.741 134.439  1.00 54.60           N  
+ANISOU 3405  N7    G A  77     7410   6495   6840    833   1020   -309       N  
+ATOM   3406  C5    G A  77     159.671  36.383 135.680  1.00 51.81           C  
+ANISOU 3406  C5    G A  77     6984   6161   6541    759   1071   -328       C  
+ATOM   3407  C6    G A  77     159.015  35.745 136.767  1.00 53.09           C  
+ANISOU 3407  C6    G A  77     7034   6397   6743    737   1067   -397       C  
+ATOM   3408  O6    G A  77     157.831  35.380 136.823  1.00 55.71           O  
+ANISOU 3408  O6    G A  77     7297   6800   7072    775   1017   -450       O  
+ATOM   3409  N1    G A  77     159.875  35.577 137.859  1.00 49.73           N  
+ANISOU 3409  N1    G A  77     6574   5961   6361    659   1126   -392       N  
+ATOM   3410  C2    G A  77     161.197  35.968 137.868  1.00 50.14           C  
+ANISOU 3410  C2    G A  77     6686   5943   6423    607   1178   -329       C  
+ATOM   3411  N2    G A  77     161.894  35.742 138.982  1.00 48.50           N  
+ANISOU 3411  N2    G A  77     6435   5732   6261    535   1223   -334       N  
+ATOM   3412  N3    G A  77     161.812  36.551 136.855  1.00 54.70           N  
+ANISOU 3412  N3    G A  77     7356   6462   6966    621   1183   -258       N  
+ATOM   3413  C4    G A  77     160.995  36.735 135.799  1.00 52.16           C  
+ANISOU 3413  C4    G A  77     7077   6145   6595    699   1130   -262       C  
+ATOM   3414  P     A A  78     166.850  38.381 132.631  1.00 77.65           P  
+ANISOU 3414  P     A A  78    10578   9251   9677    489   1387    248       P  
+ATOM   3415  OP1   A A  78     166.732  39.705 131.968  1.00 72.46           O  
+ANISOU 3415  OP1   A A  78    10024   8513   8994    500   1338    323       O  
+ATOM   3416  OP2   A A  78     167.384  37.237 131.853  1.00 76.07           O  
+ANISOU 3416  OP2   A A  78    10352   9146   9404    509   1457    264       O  
+ATOM   3417  O5'   A A  78     167.741  38.546 133.942  1.00 68.06           O  
+ANISOU 3417  O5'   A A  78     9300   8011   8550    388   1419    262       O  
+ATOM   3418  C5'   A A  78     167.895  37.457 134.835  1.00 69.46           C  
+ANISOU 3418  C5'   A A  78     9384   8243   8766    364   1454    191       C  
+ATOM   3419  C4'   A A  78     168.602  37.845 136.109  1.00 67.20           C  
+ANISOU 3419  C4'   A A  78     9056   7912   8564    275   1463    203       C  
+ATOM   3420  O4'   A A  78     167.689  38.579 136.961  1.00 66.98           O  
+ANISOU 3420  O4'   A A  78     9050   7813   8588    298   1386    134       O  
+ATOM   3421  C3'   A A  78     169.064  36.668 136.962  1.00 72.80           C  
+ANISOU 3421  C3'   A A  78     9672   8683   9306    236   1512    152       C  
+ATOM   3422  O3'   A A  78     170.327  36.167 136.548  1.00 81.04           O  
+ANISOU 3422  O3'   A A  78    10682   9784  10324    195   1590    229       O  
+ATOM   3423  C2'   A A  78     169.064  37.239 138.379  1.00 75.54           C  
+ANISOU 3423  C2'   A A  78     9999   8963   9739    184   1478    118       C  
+ATOM   3424  O2'   A A  78     170.275  37.932 138.645  1.00 81.29           O  
+ANISOU 3424  O2'   A A  78    10734   9647  10504     95   1498    213       O  
+ATOM   3425  C1'   A A  78     167.920  38.255 138.316  1.00 68.09           C  
+ANISOU 3425  C1'   A A  78     9126   7952   8795    248   1395     82       C  
+ATOM   3426  N9    A A  78     166.660  37.758 138.902  1.00 64.23           N  
+ANISOU 3426  N9    A A  78     8595   7495   8313    310   1359    -35       N  
+ATOM   3427  C8    A A  78     165.482  37.551 138.238  1.00 59.54           C  
+ANISOU 3427  C8    A A  78     8011   6936   7675    396   1321    -85       C  
+ATOM   3428  N7    A A  78     164.502  37.133 138.999  1.00 60.27           N  
+ANISOU 3428  N7    A A  78     8044   7068   7786    428   1294   -179       N  
+ATOM   3429  C5    A A  78     165.077  37.053 140.258  1.00 58.28           C  
+ANISOU 3429  C5    A A  78     7749   6804   7590    362   1318   -194       C  
+ATOM   3430  C6    A A  78     164.565  36.677 141.513  1.00 52.14           C  
+ANISOU 3430  C6    A A  78     6903   6061   6846    355   1312   -272       C  
+ATOM   3431  N6    A A  78     163.307  36.292 141.702  1.00 51.35           N  
+ANISOU 3431  N6    A A  78     6751   6027   6731    412   1282   -346       N  
+ATOM   3432  N1    A A  78     165.395  36.716 142.584  1.00 60.84           N  
+ANISOU 3432  N1    A A  78     7987   7133   7996    285   1337   -267       N  
+ATOM   3433  C2    A A  78     166.661  37.112 142.397  1.00 63.85           C  
+ANISOU 3433  C2    A A  78     8408   7456   8395    221   1362   -185       C  
+ATOM   3434  N3    A A  78     167.251  37.492 141.263  1.00 64.45           N  
+ANISOU 3434  N3    A A  78     8538   7506   8444    215   1374    -99       N  
+ATOM   3435  C4    A A  78     166.403  37.442 140.219  1.00 60.96           C  
+ANISOU 3435  C4    A A  78     8121   7092   7948    290   1353   -109       C  
+ATOM   3436  P     A A  79     170.592  34.586 136.385  1.00 85.15           P  
+ANISOU 3436  P     A A  79    11145  10402  10805    225   1640    182       P  
+ATOM   3437  OP1   A A  79     171.877  34.406 135.661  1.00 85.04           O  
+ANISOU 3437  OP1   A A  79    11115  10453  10744    210   1719    280       O  
+ATOM   3438  OP2   A A  79     169.364  33.914 135.903  1.00 86.33           O  
+ANISOU 3438  OP2   A A  79    11320  10573  10909    308   1595     96       O  
+ATOM   3439  O5'   A A  79     170.795  34.090 137.881  1.00 74.45           O  
+ANISOU 3439  O5'   A A  79     9719   9036   9531    163   1638    119       O  
+ATOM   3440  C5'   A A  79     171.598  34.827 138.788  1.00 75.05           C  
+ANISOU 3440  C5'   A A  79     9772   9063   9679     77   1644    166       C  
+ATOM   3441  C4'   A A  79     171.351  34.372 140.202  1.00 70.77           C  
+ANISOU 3441  C4'   A A  79     9183   8503   9203     43   1621     81       C  
+ATOM   3442  O4'   A A  79     170.192  35.048 140.757  1.00 65.86           O  
+ANISOU 3442  O4'   A A  79     8593   7824   8608     68   1554     18       O  
+ATOM   3443  C3'   A A  79     171.029  32.895 140.342  1.00 72.67           C  
+ANISOU 3443  C3'   A A  79     9381   8810   9419     73   1631      2       C  
+ATOM   3444  O3'   A A  79     172.203  32.101 140.336  1.00 83.67           O  
+ANISOU 3444  O3'   A A  79    10731  10255  10806     47   1687     33       O  
+ATOM   3445  C2'   A A  79     170.244  32.841 141.647  1.00 71.56           C  
+ANISOU 3445  C2'   A A  79     9217   8640   9334     50   1586    -83       C  
+ATOM   3446  O2'   A A  79     171.134  32.860 142.748  1.00 74.80           O  
+ANISOU 3446  O2'   A A  79     9590   9028   9805    -24   1602    -73       O  
+ATOM   3447  C1'   A A  79     169.477  34.170 141.603  1.00 70.90           C  
+ANISOU 3447  C1'   A A  79     9184   8493   9261     77   1538    -79       C  
+ATOM   3448  N9    A A  79     168.104  34.007 141.071  1.00 69.34           N  
+ANISOU 3448  N9    A A  79     9003   8321   9023    155   1496   -138       N  
+ATOM   3449  C8    A A  79     167.692  34.083 139.763  1.00 59.87           C  
+ANISOU 3449  C8    A A  79     7848   7137   7762    218   1487   -114       C  
+ATOM   3450  N7    A A  79     166.410  33.897 139.586  1.00 52.82           N  
+ANISOU 3450  N7    A A  79     6955   6267   6849    276   1439   -178       N  
+ATOM   3451  C5    A A  79     165.938  33.674 140.867  1.00 57.41           C  
+ANISOU 3451  C5    A A  79     7478   6857   7476    249   1422   -244       C  
+ATOM   3452  C6    A A  79     164.642  33.405 141.363  1.00 60.91           C  
+ANISOU 3452  C6    A A  79     7877   7343   7923    280   1378   -320       C  
+ATOM   3453  N6    A A  79     163.542  33.311 140.606  1.00 61.08           N  
+ANISOU 3453  N6    A A  79     7903   7399   7906    344   1334   -346       N  
+ATOM   3454  N1    A A  79     164.511  33.244 142.694  1.00 58.93           N  
+ANISOU 3454  N1    A A  79     7571   7107   7714    240   1381   -364       N  
+ATOM   3455  C2    A A  79     165.613  33.341 143.461  1.00 59.47           C  
+ANISOU 3455  C2    A A  79     7639   7136   7821    175   1417   -339       C  
+ATOM   3456  N3    A A  79     166.882  33.588 143.121  1.00 58.50           N  
+ANISOU 3456  N3    A A  79     7552   6969   7708    137   1453   -270       N  
+ATOM   3457  C4    A A  79     166.972  33.743 141.789  1.00 62.79           C  
+ANISOU 3457  C4    A A  79     8140   7511   8206    177   1457   -222       C  
+ATOM   3458  P     A A  80     172.115  30.510 140.143  1.00 88.76           P  
+ANISOU 3458  P     A A  80    11356  10963  11403     91   1693    -31       P  
+ATOM   3459  OP1   A A  80     173.507  29.992 140.215  1.00 94.49           O  
+ANISOU 3459  OP1   A A  80    12038  11735  12129     70   1750     14       O  
+ATOM   3460  OP2   A A  80     171.276  30.197 138.956  1.00 84.49           O  
+ANISOU 3460  OP2   A A  80    10868  10448  10785    175   1671    -51       O  
+ATOM   3461  O5'   A A  80     171.320  30.023 141.431  1.00 67.56           O  
+ANISOU 3461  O5'   A A  80     8645   8252   8771     55   1643   -122       O  
+ATOM   3462  C5'   A A  80     170.404  28.947 141.350  1.00 63.76           C  
+ANISOU 3462  C5'   A A  80     8171   7799   8258     87   1601   -197       C  
+ATOM   3463  C4'   A A  80     169.661  28.757 142.646  1.00 66.51           C  
+ANISOU 3463  C4'   A A  80     8483   8130   8657     37   1561   -261       C  
+ATOM   3464  O4'   A A  80     168.730  29.849 142.876  1.00 70.27           O  
+ANISOU 3464  O4'   A A  80     8964   8578   9155     47   1534   -272       O  
+ATOM   3465  C3'   A A  80     168.787  27.526 142.692  1.00 72.19           C  
+ANISOU 3465  C3'   A A  80     9198   8881   9349     43   1511   -326       C  
+ATOM   3466  O3'   A A  80     169.527  26.355 142.950  1.00 74.89           O  
+ANISOU 3466  O3'   A A  80     9536   9236   9683     22   1514   -340       O  
+ATOM   3467  C2'   A A  80     167.774  27.868 143.774  1.00 71.91           C  
+ANISOU 3467  C2'   A A  80     9123   8843   9356      6   1479   -370       C  
+ATOM   3468  O2'   A A  80     168.330  27.692 145.068  1.00 83.15           O  
+ANISOU 3468  O2'   A A  80    10511  10253  10827    -62   1494   -382       O  
+ATOM   3469  C1'   A A  80     167.567  29.358 143.519  1.00 75.47           C  
+ANISOU 3469  C1'   A A  80     9593   9263   9821     40   1489   -340       C  
+ATOM   3470  N9    A A  80     166.394  29.578 142.652  1.00 77.88           N  
+ANISOU 3470  N9    A A  80     9916   9588  10087    103   1449   -356       N  
+ATOM   3471  C8    A A  80     165.093  29.304 143.011  1.00 80.61           C  
+ANISOU 3471  C8    A A  80    10223   9974  10430    108   1402   -409       C  
+ATOM   3472  N7    A A  80     164.205  29.550 142.076  1.00 73.52           N  
+ANISOU 3472  N7    A A  80     9344   9092   9497    170   1365   -414       N  
+ATOM   3473  C5    A A  80     164.985  29.997 141.026  1.00 67.97           C  
+ANISOU 3473  C5    A A  80     8707   8352   8765    209   1392   -361       C  
+ATOM   3474  C6    A A  80     164.616  30.418 139.746  1.00 71.24           C  
+ANISOU 3474  C6    A A  80     9175   8760   9131    279   1372   -338       C  
+ATOM   3475  N6    A A  80     163.336  30.443 139.343  1.00 66.91           N  
+ANISOU 3475  N6    A A  80     8621   8239   8563    325   1312   -372       N  
+ATOM   3476  N1    A A  80     165.618  30.814 138.921  1.00 77.45           N  
+ANISOU 3476  N1    A A  80    10018   9520   9889    298   1415   -273       N  
+ATOM   3477  C2    A A  80     166.890  30.781 139.368  1.00 76.32           C  
+ANISOU 3477  C2    A A  80     9864   9364   9770    248   1473   -235       C  
+ATOM   3478  N3    A A  80     167.354  30.408 140.557  1.00 73.27           N  
+ANISOU 3478  N3    A A  80     9427   8976   9435    182   1490   -255       N  
+ATOM   3479  C4    A A  80     166.337  30.013 141.348  1.00 67.96           C  
+ANISOU 3479  C4    A A  80     8713   8325   8786    166   1447   -321       C  
+ATOM   3480  P     U A  81     169.447  25.152 141.907  1.00 80.75           P  
+ANISOU 3480  P     U A  81    10327  10002  10351     80   1480   -360       P  
+ATOM   3481  OP1   U A  81     170.119  23.997 142.573  1.00 95.56           O  
+ANISOU 3481  OP1   U A  81    12198  11876  12233     48   1467   -387       O  
+ATOM   3482  OP2   U A  81     169.912  25.649 140.574  1.00 70.48           O  
+ANISOU 3482  OP2   U A  81     9067   8717   8994    159   1519   -310       O  
+ATOM   3483  O5'   U A  81     167.899  24.768 141.915  1.00 73.80           O  
+ANISOU 3483  O5'   U A  81     9449   9129   9460     71   1401   -410       O  
+ATOM   3484  C5'   U A  81     167.278  24.442 143.147  1.00 70.93           C  
+ANISOU 3484  C5'   U A  81     9037   8770   9142     -7   1369   -445       C  
+ATOM   3485  C4'   U A  81     165.776  24.447 143.057  1.00 78.15           C  
+ANISOU 3485  C4'   U A  81     9931   9714  10051    -11   1309   -472       C  
+ATOM   3486  O4'   U A  81     165.264  25.771 142.737  1.00 82.76           O  
+ANISOU 3486  O4'   U A  81    10501  10301  10643     34   1331   -456       O  
+ATOM   3487  C3'   U A  81     165.176  23.564 141.983  1.00 79.10           C  
+ANISOU 3487  C3'   U A  81    10101   9840  10112     25   1236   -487       C  
+ATOM   3488  O3'   U A  81     165.206  22.192 142.317  1.00 78.52           O  
+ANISOU 3488  O3'   U A  81    10048   9760  10028    -25   1175   -512       O  
+ATOM   3489  C2'   U A  81     163.779  24.146 141.844  1.00 73.99           C  
+ANISOU 3489  C2'   U A  81     9414   9229   9471     32   1199   -496       C  
+ATOM   3490  O2'   U A  81     162.976  23.757 142.946  1.00 72.60           O  
+ANISOU 3490  O2'   U A  81     9164   9091   9328    -49   1166   -517       O  
+ATOM   3491  C1'   U A  81     164.079  25.644 141.965  1.00 77.30           C  
+ANISOU 3491  C1'   U A  81     9815   9636   9917     70   1270   -472       C  
+ATOM   3492  N1    U A  81     164.318  26.249 140.631  1.00 77.38           N  
+ANISOU 3492  N1    U A  81     9890   9627   9885    155   1284   -442       N  
+ATOM   3493  C2    U A  81     163.235  26.441 139.779  1.00 76.17           C  
+ANISOU 3493  C2    U A  81     9750   9490   9699    206   1229   -451       C  
+ATOM   3494  O2    U A  81     162.076  26.145 140.072  1.00 81.07           O  
+ANISOU 3494  O2    U A  81    10323  10150  10330    182   1170   -481       O  
+ATOM   3495  N3    U A  81     163.568  27.002 138.565  1.00 62.19           N  
+ANISOU 3495  N3    U A  81     8049   7698   7882    283   1246   -418       N  
+ATOM   3496  C4    U A  81     164.827  27.365 138.124  1.00 64.66           C  
+ANISOU 3496  C4    U A  81     8407   7987   8175    309   1315   -371       C  
+ATOM   3497  O4    U A  81     164.973  27.842 137.004  1.00 65.41           O  
+ANISOU 3497  O4    U A  81     8560   8073   8219    375   1326   -337       O  
+ATOM   3498  C5    U A  81     165.883  27.130 139.045  1.00 68.15           C  
+ANISOU 3498  C5    U A  81     8817   8421   8656    251   1369   -361       C  
+ATOM   3499  C6    U A  81     165.594  26.597 140.235  1.00 75.11           C  
+ANISOU 3499  C6    U A  81     9643   9311   9585    181   1349   -399       C  
+ATOM   3500  P     A A  82     165.664  21.138 141.200  1.00102.22           P  
+ANISOU 3500  P     A A  82    13148  12733  12958     37   1124   -524       P  
+ATOM   3501  OP1   A A  82     165.956  19.847 141.889  1.00 92.95           O  
+ANISOU 3501  OP1   A A  82    11996  11534  11786    -24   1067   -549       O  
+ATOM   3502  OP2   A A  82     166.718  21.810 140.388  1.00 98.00           O  
+ANISOU 3502  OP2   A A  82    12646  12195  12392    127   1205   -493       O  
+ATOM   3503  O5'   A A  82     164.352  20.969 140.302  1.00 84.68           O  
+ANISOU 3503  O5'   A A  82    10951  10524  10700     60   1036   -536       O  
+ATOM   3504  C5'   A A  82     163.104  20.663 140.916  1.00 75.17           C  
+ANISOU 3504  C5'   A A  82     9687   9348   9526    -25    965   -547       C  
+ATOM   3505  C4'   A A  82     161.931  20.993 140.026  1.00 72.65           C  
+ANISOU 3505  C4'   A A  82     9366   9054   9184     12    908   -547       C  
+ATOM   3506  O4'   A A  82     161.843  22.424 139.820  1.00 82.53           O  
+ANISOU 3506  O4'   A A  82    10580  10327  10451     71    985   -530       O  
+ATOM   3507  C3'   A A  82     161.979  20.424 138.619  1.00 77.51           C  
+ANISOU 3507  C3'   A A  82    10093   9631   9725     92    840   -558       C  
+ATOM   3508  O3'   A A  82     161.596  19.059 138.559  1.00 82.32           O  
+ANISOU 3508  O3'   A A  82    10754  10212  10311     42    717   -579       O  
+ATOM   3509  C2'   A A  82     161.047  21.355 137.855  1.00 69.99           C  
+ANISOU 3509  C2'   A A  82     9120   8708   8764    146    830   -548       C  
+ATOM   3510  O2'   A A  82     159.693  21.021 138.109  1.00 73.78           O  
+ANISOU 3510  O2'   A A  82     9539   9227   9267     78    738   -555       O  
+ATOM   3511  C1'   A A  82     161.347  22.691 138.523  1.00 75.42           C  
+ANISOU 3511  C1'   A A  82     9733   9422   9502    152    944   -528       C  
+ATOM   3512  N9    A A  82     162.363  23.443 137.775  1.00 65.03           N  
+ANISOU 3512  N9    A A  82     8477   8077   8153    241   1025   -503       N  
+ATOM   3513  C8    A A  82     163.694  23.633 138.076  1.00 60.48           C  
+ANISOU 3513  C8    A A  82     7913   7483   7584    247   1113   -482       C  
+ATOM   3514  N7    A A  82     164.322  24.368 137.176  1.00 68.57           N  
+ANISOU 3514  N7    A A  82     8985   8499   8569    326   1169   -447       N  
+ATOM   3515  C5    A A  82     163.334  24.673 136.237  1.00 63.74           C  
+ANISOU 3515  C5    A A  82     8405   7892   7921    379   1113   -451       C  
+ATOM   3516  C6    A A  82     163.332  25.419 135.048  1.00 66.75           C  
+ANISOU 3516  C6    A A  82     8846   8267   8248    466   1127   -421       C  
+ATOM   3517  N6    A A  82     164.404  26.035 134.541  1.00 70.36           N  
+ANISOU 3517  N6    A A  82     9340   8719   8673    512   1211   -371       N  
+ATOM   3518  N1    A A  82     162.169  25.506 134.366  1.00 70.54           N  
+ANISOU 3518  N1    A A  82     9346   8751   8704    501   1047   -439       N  
+ATOM   3519  C2    A A  82     161.083  24.894 134.844  1.00 69.09           C  
+ANISOU 3519  C2    A A  82     9113   8586   8553    446    960   -477       C  
+ATOM   3520  N3    A A  82     160.954  24.166 135.947  1.00 72.15           N  
+ANISOU 3520  N3    A A  82     9435   8988   8989    355    941   -500       N  
+ATOM   3521  C4    A A  82     162.127  24.099 136.596  1.00 67.10           C  
+ANISOU 3521  C4    A A  82     8791   8334   8369    329   1021   -487       C  
+ATOM   3522  P     U A  83     162.292  18.079 137.494  1.00 93.00           P  
+ANISOU 3522  P     U A  83    12256  11500  11579    127    654   -603       P  
+ATOM   3523  OP1   U A  83     161.803  16.698 137.770  1.00 91.47           O  
+ANISOU 3523  OP1   U A  83    12109  11266  11379     44    511   -623       O  
+ATOM   3524  OP2   U A  83     163.762  18.355 137.497  1.00 79.27           O  
+ANISOU 3524  OP2   U A  83    10544   9753   9822    198    766   -599       O  
+ATOM   3525  O5'   U A  83     161.744  18.587 136.079  1.00 83.76           O  
+ANISOU 3525  O5'   U A  83    11140  10333  10351    228    625   -602       O  
+ATOM   3526  C5'   U A  83     160.353  18.703 135.807  1.00 77.69           C  
+ANISOU 3526  C5'   U A  83    10335   9587   9597    191    536   -600       C  
+ATOM   3527  C4'   U A  83     160.099  19.488 134.537  1.00 76.80           C  
+ANISOU 3527  C4'   U A  83    10270   9479   9433    304    545   -594       C  
+ATOM   3528  O4'   U A  83     160.587  20.846 134.678  1.00 77.88           O  
+ANISOU 3528  O4'   U A  83    10349   9647   9593    348    684   -566       O  
+ATOM   3529  C3'   U A  83     160.781  18.968 133.277  1.00 76.55           C  
+ANISOU 3529  C3'   U A  83    10391   9398   9298    424    514   -612       C  
+ATOM   3530  O3'   U A  83     160.041  17.908 132.688  1.00 82.56           O  
+ANISOU 3530  O3'   U A  83    11237  10114  10016    416    350   -641       O  
+ATOM   3531  C2'   U A  83     160.890  20.217 132.394  1.00 75.60           C  
+ANISOU 3531  C2'   U A  83    10279   9301   9143    526    597   -586       C  
+ATOM   3532  O2'   U A  83     159.697  20.432 131.653  1.00 76.98           O  
+ANISOU 3532  O2'   U A  83    10467   9479   9304    545    503   -590       O  
+ATOM   3533  C1'   U A  83     161.033  21.340 133.432  1.00 72.91           C  
+ANISOU 3533  C1'   U A  83     9809   9004   8890    469    716   -554       C  
+ATOM   3534  N1    U A  83     162.424  21.826 133.581  1.00 69.25           N  
+ANISOU 3534  N1    U A  83     9351   8544   8417    509    849   -528       N  
+ATOM   3535  C2    U A  83     162.910  22.731 132.662  1.00 64.79           C  
+ANISOU 3535  C2    U A  83     8828   7987   7801    602    921   -492       C  
+ATOM   3536  O2    U A  83     162.230  23.124 131.732  1.00 65.54           O  
+ANISOU 3536  O2    U A  83     8966   8079   7855    659    877   -488       O  
+ATOM   3537  N3    U A  83     164.208  23.154 132.869  1.00 64.25           N  
+ANISOU 3537  N3    U A  83     8749   7933   7732    619   1040   -456       N  
+ATOM   3538  C4    U A  83     165.051  22.757 133.902  1.00 65.61           C  
+ANISOU 3538  C4    U A  83     8871   8107   7949    560   1090   -458       C  
+ATOM   3539  O4    U A  83     166.205  23.189 133.999  1.00 65.32           O  
+ANISOU 3539  O4    U A  83     8819   8088   7910    578   1192   -419       O  
+ATOM   3540  C5    U A  83     164.467  21.818 134.809  1.00 73.54           C  
+ANISOU 3540  C5    U A  83     9844   9094   9002    473   1008   -503       C  
+ATOM   3541  C6    U A  83     163.209  21.404 134.625  1.00 74.56           C  
+ANISOU 3541  C6    U A  83     9982   9215   9132    447    895   -531       C  
+ATOM   3542  P     C A  84     160.715  16.874 131.655  1.00 93.98           P  
+ANISOU 3542  P     C A  84    12864  11493  11350    526    274   -679       P  
+ATOM   3543  OP1   C A  84     159.609  16.030 131.128  1.00 89.90           O  
+ANISOU 3543  OP1   C A  84    12417  10928  10810    494     84   -702       O  
+ATOM   3544  OP2   C A  84     161.892  16.239 132.315  1.00 83.32           O  
+ANISOU 3544  OP2   C A  84    11537  10125   9998    525    323   -694       O  
+ATOM   3545  O5'   C A  84     161.183  17.792 130.437  1.00 82.49           O  
+ANISOU 3545  O5'   C A  84    11467  10061   9815    678    362   -665       O  
+ATOM   3546  C5'   C A  84     161.239  17.285 129.105  1.00 82.13           C  
+ANISOU 3546  C5'   C A  84    11578   9977   9652    804    281   -694       C  
+ATOM   3547  C4'   C A  84     160.755  18.313 128.111  1.00 83.13           C  
+ANISOU 3547  C4'   C A  84    11715  10130   9741    879    307   -669       C  
+ATOM   3548  O4'   C A  84     161.165  19.626 128.575  1.00 82.17           O  
+ANISOU 3548  O4'   C A  84    11478  10067   9675    863    470   -618       O  
+ATOM   3549  C3'   C A  84     161.289  18.164 126.689  1.00 85.53           C  
+ANISOU 3549  C3'   C A  84    12175  10421   9902   1046    301   -683       C  
+ATOM   3550  O3'   C A  84     160.287  18.541 125.738  1.00 85.37           O  
+ANISOU 3550  O3'   C A  84    12203  10387   9846   1086    215   -682       O  
+ATOM   3551  C2'   C A  84     162.454  19.156 126.644  1.00 84.51           C  
+ANISOU 3551  C2'   C A  84    12001  10356   9753   1108    495   -633       C  
+ATOM   3552  O2'   C A  84     162.693  19.694 125.358  1.00 90.06           O  
+ANISOU 3552  O2'   C A  84    12793  11082  10345   1241    534   -611       O  
+ATOM   3553  C1'   C A  84     162.016  20.246 127.629  1.00 79.21           C  
+ANISOU 3553  C1'   C A  84    11168   9717   9211    989    570   -590       C  
+ATOM   3554  N1    C A  84     163.137  20.835 128.391  1.00 74.12           N  
+ANISOU 3554  N1    C A  84    10438   9115   8610    964    728   -550       N  
+ATOM   3555  C2    C A  84     163.789  22.013 127.984  1.00 69.10           C  
+ANISOU 3555  C2    C A  84     9783   8523   7951   1014    860   -488       C  
+ATOM   3556  O2    C A  84     163.420  22.578 126.947  1.00 73.33           O  
+ANISOU 3556  O2    C A  84    10379   9061   8423   1088    848   -468       O  
+ATOM   3557  N3    C A  84     164.825  22.499 128.729  1.00 60.63           N  
+ANISOU 3557  N3    C A  84     8629   7484   6925    977    989   -447       N  
+ATOM   3558  C4    C A  84     165.214  21.873 129.856  1.00 62.49           C  
+ANISOU 3558  C4    C A  84     8805   7713   7227    900    995   -471       C  
+ATOM   3559  N4    C A  84     166.226  22.381 130.576  1.00 69.00           N  
+ANISOU 3559  N4    C A  84     9551   8569   8098    862   1115   -429       N  
+ATOM   3560  C5    C A  84     164.564  20.685 130.303  1.00 65.33           C  
+ANISOU 3560  C5    C A  84     9186   8030   7608    850    868   -534       C  
+ATOM   3561  C6    C A  84     163.556  20.218 129.546  1.00 73.15           C  
+ANISOU 3561  C6    C A  84    10255   8986   8552    880    739   -567       C  
+TER    3562        C A  84                                                      
+HETATM 3563  PB  GDP R 101     205.160  42.556 133.063  1.00 91.07           P  
+ANISOU 3563  PB  GDP R 101     8660  14164  11781  -2210   2620   3848       P  
+HETATM 3564  O1B GDP R 101     204.739  42.587 131.552  1.00 92.89           O  
+ANISOU 3564  O1B GDP R 101     8938  14517  11840  -2113   2741   3899       O  
+HETATM 3565  O2B GDP R 101     206.459  43.396 133.170  1.00 90.53           O  
+ANISOU 3565  O2B GDP R 101     8435  14185  11776  -2411   2557   4045       O  
+HETATM 3566  O3B GDP R 101     203.950  43.273 133.770  1.00 85.56           O  
+ANISOU 3566  O3B GDP R 101     8194  13135  11179  -2317   2486   3787       O  
+HETATM 3567  O3A GDP R 101     205.545  41.062 133.544  1.00 89.81           O  
+ANISOU 3567  O3A GDP R 101     8373  14144  11605  -2000   2699   3688       O  
+HETATM 3568  PA  GDP R 101     204.829  40.376 134.838  1.00 88.93           P  
+ANISOU 3568  PA  GDP R 101     8355  13839  11594  -1935   2632   3488       P  
+HETATM 3569  O1A GDP R 101     204.904  38.885 134.405  1.00 90.28           O  
+ANISOU 3569  O1A GDP R 101     8448  14208  11647  -1660   2772   3353       O  
+HETATM 3570  O2A GDP R 101     203.477  41.146 135.020  1.00 77.38           O  
+ANISOU 3570  O2A GDP R 101     7131  12098  10174  -2022   2546   3456       O  
+HETATM 3571  O5' GDP R 101     205.692  40.820 136.123  1.00 79.79           O  
+ANISOU 3571  O5' GDP R 101     7109  12602  10603  -2114   2498   3539       O  
+HETATM 3572  C5' GDP R 101     206.704  39.977 136.604  1.00 81.40           C  
+ANISOU 3572  C5' GDP R 101     7129  12969  10830  -2037   2529   3507       C  
+HETATM 3573  C4' GDP R 101     207.162  40.885 137.737  1.00 86.86           C  
+ANISOU 3573  C4' GDP R 101     7817  13497  11687  -2269   2362   3582       C  
+HETATM 3574  O4' GDP R 101     207.008  42.278 137.279  1.00 91.41           O  
+ANISOU 3574  O4' GDP R 101     8483  13971  12278  -2466   2287   3740       O  
+HETATM 3575  C3' GDP R 101     206.282  40.894 138.960  1.00 80.18           C  
+ANISOU 3575  C3' GDP R 101     7134  12377  10956  -2304   2246   3445       C  
+HETATM 3576  O3' GDP R 101     206.720  39.980 140.032  1.00 77.14           O  
+ANISOU 3576  O3' GDP R 101     6660  12009  10642  -2233   2225   3332       O  
+HETATM 3577  C2' GDP R 101     206.665  42.213 139.564  1.00 83.68           C  
+ANISOU 3577  C2' GDP R 101     7611  12662  11521  -2558   2081   3576       C  
+HETATM 3578  O2' GDP R 101     207.753  41.895 140.458  1.00 84.80           O  
+ANISOU 3578  O2' GDP R 101     7595  12875  11751  -2598   2029   3586       O  
+HETATM 3579  C1' GDP R 101     207.231  43.076 138.457  1.00 83.90           C  
+ANISOU 3579  C1' GDP R 101     7575  12819  11484  -2663   2109   3775       C  
+HETATM 3580  N9  GDP R 101     206.114  43.977 138.244  1.00 81.29           N  
+ANISOU 3580  N9  GDP R 101     7467  12263  11157  -2746   2041   3782       N  
+HETATM 3581  C8  GDP R 101     205.319  43.890 137.144  1.00 80.87           C  
+ANISOU 3581  C8  GDP R 101     7499  12247  10979  -2645   2146   3771       C  
+HETATM 3582  N7  GDP R 101     204.303  44.818 137.255  1.00 79.93           N  
+ANISOU 3582  N7  GDP R 101     7597  11873  10898  -2746   2041   3773       N  
+HETATM 3583  C5  GDP R 101     204.500  45.399 138.477  1.00 79.72           C  
+ANISOU 3583  C5  GDP R 101     7617  11656  11017  -2895   1873   3771       C  
+HETATM 3584  C6  GDP R 101     203.799  46.431 139.173  1.00 79.01           C  
+ANISOU 3584  C6  GDP R 101     7731  11266  11024  -3036   1699   3767       C  
+HETATM 3585  O6  GDP R 101     202.809  46.843 138.504  1.00 78.42           O  
+ANISOU 3585  O6  GDP R 101     7813  11095  10887  -3017   1713   3767       O  
+HETATM 3586  N1  GDP R 101     204.207  46.820 140.408  1.00 79.05           N  
+ANISOU 3586  N1  GDP R 101     7749  11124  11162  -3156   1542   3756       N  
+HETATM 3587  C2  GDP R 101     205.310  46.232 140.941  1.00 79.81           C  
+ANISOU 3587  C2  GDP R 101     7653  11369  11302  -3152   1557   3762       C  
+HETATM 3588  N2  GDP R 101     205.760  46.605 142.162  1.00 79.96           N  
+ANISOU 3588  N2  GDP R 101     7682  11248  11449  -3270   1398   3755       N  
+HETATM 3589  N3  GDP R 101     206.017  45.232 140.337  1.00 80.48           N  
+ANISOU 3589  N3  GDP R 101     7533  11742  11304  -3021   1720   3768       N  
+HETATM 3590  C4  GDP R 101     205.634  44.812 139.124  1.00 80.47           C  
+ANISOU 3590  C4  GDP R 101     7520  11890  11167  -2890   1876   3770       C  
+HETATM 3591  P1  C2E R 102     188.109  24.705 140.503  1.00 58.91           P  
+ANISOU 3591  P1  C2E R 102     6592   8285   7508    310   2340    477       P  
+HETATM 3592  O2P C2E R 102     189.294  24.725 141.452  1.00 56.91           O  
+ANISOU 3592  O2P C2E R 102     6206   8075   7342    240   2342    523       O  
+HETATM 3593  O1P C2E R 102     187.956  23.551 139.537  1.00 71.84           O  
+ANISOU 3593  O1P C2E R 102     8292  10000   9003    510   2359    397       O  
+HETATM 3594  O5' C2E R 102     186.757  24.810 141.378  1.00 60.66           O  
+ANISOU 3594  O5' C2E R 102     6943   8301   7805    221   2235    377       O  
+HETATM 3595  C5' C2E R 102     185.556  24.318 140.800  1.00 57.42           C  
+ANISOU 3595  C5' C2E R 102     6665   7831   7322    302   2199    286       C  
+HETATM 3596  C4' C2E R 102     184.313  24.869 141.474  1.00 61.63           C  
+ANISOU 3596  C4' C2E R 102     7284   8203   7930    194   2124    240       C  
+HETATM 3597  O4' C2E R 102     184.094  24.080 142.641  1.00 53.64           O  
+ANISOU 3597  O4' C2E R 102     6301   7106   6973    169   2048    141       O  
+HETATM 3598  C3' C2E R 102     184.369  26.328 141.908  1.00 58.79           C  
+ANISOU 3598  C3' C2E R 102     6884   7791   7663     44   2129    336       C  
+HETATM 3599  O3' C2E R 102     183.702  27.163 140.958  1.00 61.73           O  
+ANISOU 3599  O3' C2E R 102     7307   8157   7993     44   2151    387       O  
+HETATM 3600  C2' C2E R 102     183.578  26.300 143.202  1.00 49.81           C  
+ANISOU 3600  C2' C2E R 102     5802   6509   6612    -39   2041    250       C  
+HETATM 3601  O2' C2E R 102     182.192  26.457 142.910  1.00 46.74           O  
+ANISOU 3601  O2' C2E R 102     5515   6043   6198    -26   2002    193       O  
+HETATM 3602  C1' C2E R 102     183.717  24.897 143.739  1.00 57.45           C  
+ANISOU 3602  C1' C2E R 102     6784   7479   7565     26   2004    148       C  
+HETATM 3603  N9  C2E R 102     184.810  24.781 144.737  1.00 57.84           N  
+ANISOU 3603  N9  C2E R 102     6747   7541   7687    -30   1998    169       N  
+HETATM 3604  C8  C2E R 102     186.011  24.203 144.524  1.00 50.66           C  
+ANISOU 3604  C8  C2E R 102     5752   6745   6750     36   2040    198       C  
+HETATM 3605  N7  C2E R 102     186.773  24.255 145.655  1.00 52.54           N  
+ANISOU 3605  N7  C2E R 102     5925   6961   7078    -44   2012    210       N  
+HETATM 3606  C5  C2E R 102     186.048  24.880 146.619  1.00 46.09           C  
+ANISOU 3606  C5  C2E R 102     5159   6010   6342   -162   1951    186       C  
+HETATM 3607  C6  C2E R 102     186.234  25.263 148.056  1.00 44.92           C  
+ANISOU 3607  C6  C2E R 102     4999   5767   6301   -283   1891    178       C  
+HETATM 3608  O6  C2E R 102     187.301  25.013 148.673  1.00 56.60           O  
+ANISOU 3608  O6  C2E R 102     6401   7280   7826   -305   1883    199       O  
+HETATM 3609  N1  C2E R 102     185.219  25.895 148.664  1.00 40.55           N  
+ANISOU 3609  N1  C2E R 102     4523   5096   5789   -360   1842    145       N  
+HETATM 3610  C2  C2E R 102     184.066  26.174 148.033  1.00 43.85           C  
+ANISOU 3610  C2  C2E R 102     5016   5483   6161   -333   1846    121       C  
+HETATM 3611  N2  C2E R 102     183.087  26.804 148.699  1.00 48.70           N  
+ANISOU 3611  N2  C2E R 102     5696   5992   6815   -398   1797     85       N  
+HETATM 3612  N3  C2E R 102     183.828  25.853 146.742  1.00 53.05           N  
+ANISOU 3612  N3  C2E R 102     6196   6722   7238   -235   1893    128       N  
+HETATM 3613  C4  C2E R 102     184.761  25.220 145.999  1.00 50.70           C  
+ANISOU 3613  C4  C2E R 102     5838   6543   6883   -147   1946    159       C  
+HETATM 3614  P11 C2E R 102     183.950  28.769 140.884  1.00 63.77           P  
+ANISOU 3614  P11 C2E R 102     7529   8391   8308    -83   2170    522       P  
+HETATM 3615  O21 C2E R 102     183.291  29.390 139.679  1.00 71.52           O  
+ANISOU 3615  O21 C2E R 102     8576   9383   9216    -47   2195    568       O  
+HETATM 3616  O11 C2E R 102     183.590  29.307 142.250  1.00 80.49           O  
+ANISOU 3616  O11 C2E R 102     9669  10370  10544   -204   2091    487       O  
+HETATM 3617  O5A C2E R 102     185.546  28.827 140.671  1.00 70.39           O  
+ANISOU 3617  O5A C2E R 102     8226   9376   9144    -98   2248    642       O  
+HETATM 3618  C5A C2E R 102     186.110  28.877 139.362  1.00 60.56           C  
+ANISOU 3618  C5A C2E R 102     6933   8282   7795    -23   2340    735       C  
+HETATM 3619  C4A C2E R 102     187.583  28.457 139.309  1.00 53.82           C  
+ANISOU 3619  C4A C2E R 102     5930   7593   6925      5   2412    807       C  
+HETATM 3620  O4A C2E R 102     188.436  29.585 139.583  1.00 64.71           O  
+ANISOU 3620  O4A C2E R 102     7206   8997   8383   -147   2429    959       O  
+HETATM 3621  C3A C2E R 102     188.012  27.365 140.270  1.00 55.43           C  
+ANISOU 3621  C3A C2E R 102     6099   7794   7167     48   2377    707       C  
+HETATM 3622  O3A C2E R 102     188.057  26.079 139.650  1.00 60.97           O  
+ANISOU 3622  O3A C2E R 102     6824   8585   7756    231   2404    621       O  
+HETATM 3623  C2A C2E R 102     189.421  27.769 140.642  1.00 57.94           C  
+ANISOU 3623  C2A C2E R 102     6255   8217   7545    -34   2418    829       C  
+HETATM 3624  O2A C2E R 102     190.264  27.231 139.625  1.00 68.12           O  
+ANISOU 3624  O2A C2E R 102     7452   9710   8719     98   2518    881       O  
+HETATM 3625  C1A C2E R 102     189.458  29.279 140.541  1.00 53.94           C  
+ANISOU 3625  C1A C2E R 102     5728   7669   7098   -196   2418    971       C  
+HETATM 3626  N91 C2E R 102     189.091  29.892 141.852  1.00 51.95           N  
+ANISOU 3626  N91 C2E R 102     5523   7235   6981   -343   2315    940       N  
+HETATM 3627  C81 C2E R 102     188.031  30.695 142.066  1.00 48.19           C  
+ANISOU 3627  C81 C2E R 102     5166   6602   6544   -414   2250    916       C  
+HETATM 3628  N71 C2E R 102     187.953  31.085 143.364  1.00 49.46           N  
+ANISOU 3628  N71 C2E R 102     5347   6626   6819   -526   2162    884       N  
+HETATM 3629  C51 C2E R 102     188.981  30.518 144.013  1.00 45.73           C  
+ANISOU 3629  C51 C2E R 102     4769   6219   6389   -536   2167    889       C  
+HETATM 3630  C61 C2E R 102     189.488  30.519 145.406  1.00 47.09           C  
+ANISOU 3630  C61 C2E R 102     4906   6315   6671   -629   2095    866       C  
+HETATM 3631  O61 C2E R 102     188.897  31.166 146.304  1.00 49.71           O  
+ANISOU 3631  O61 C2E R 102     5321   6486   7079   -721   2008    830       O  
+HETATM 3632  N11 C2E R 102     190.586  29.805 145.668  1.00 47.10           N  
+ANISOU 3632  N11 C2E R 102     4787   6428   6682   -600   2122    881       N  
+HETATM 3633  C21 C2E R 102     191.231  29.099 144.712  1.00 52.65           C  
+ANISOU 3633  C21 C2E R 102     5398   7313   7293   -482   2216    913       C  
+HETATM 3634  N21 C2E R 102     192.337  28.392 145.054  1.00 46.76           N  
+ANISOU 3634  N21 C2E R 102     4528   6679   6559   -444   2235    921       N  
+HETATM 3635  N31 C2E R 102     190.820  29.057 143.419  1.00 54.45           N  
+ANISOU 3635  N31 C2E R 102     5656   7621   7410   -387   2289    934       N  
+HETATM 3636  C41 C2E R 102     189.725  29.739 143.016  1.00 47.58           C  
+ANISOU 3636  C41 C2E R 102     4907   6648   6523   -414   2268    926       C  
+HETATM 3637 MG    MG R 103     161.430   7.241 164.317  1.00 73.22          MG  
+ANISOU 3637 MG    MG R 103     9235   9368   9217  -2510    368     50      MG  
+HETATM 3638 MG    MG R 104     191.330  21.547 137.168  1.00 81.12          MG  
+ANISOU 3638 MG    MG R 104     9190  11808   9824   1038   2616    478      MG  
+HETATM 3639 MG    MG R 105     186.918  33.602 146.448  1.00 52.40          MG  
+ANISOU 3639 MG    MG R 105     5910   6526   7475   -864   1878    847      MG  
+HETATM 3640  K     K R 106     168.188  33.353 160.869  1.00 57.72           K  
+ANISOU 3640  K     K R 106     7359   6817   7755   -190   1390   -764       K  
+HETATM 3641  K     K R 107     178.433  10.388 153.835  1.00 62.96           K  
+ANISOU 3641  K     K R 107     8475   7247   8201   -322    740   -760       K  
+HETATM 3642  PB  GDP A 101     173.883  29.758 129.672  1.00117.35           P  
+ANISOU 3642  PB  GDP A 101    15329  15047  14213    730   1963    324       P  
+HETATM 3643  O1B GDP A 101     174.304  28.804 128.500  1.00 82.52           O  
+ANISOU 3643  O1B GDP A 101    10967  10738   9650    875   2001    314       O  
+HETATM 3644  O2B GDP A 101     174.778  29.340 130.912  1.00 70.77           O  
+ANISOU 3644  O2B GDP A 101     9324   9163   8402    658   1996    313       O  
+HETATM 3645  O3B GDP A 101     174.226  31.196 129.217  1.00101.01           O  
+ANISOU 3645  O3B GDP A 101    13259  12979  12141    670   2009    459       O  
+HETATM 3646  O3A GDP A 101     172.327  29.425 129.584  1.00 91.93           O  
+ANISOU 3646  O3A GDP A 101    12191  11739  10998    768   1846    214       O  
+HETATM 3647  PA  GDP A 101     172.009  30.633 128.575  1.00 93.46           P  
+ANISOU 3647  PA  GDP A 101    12450  11922  11141    780   1853    302       P  
+HETATM 3648  O1A GDP A 101     172.957  31.314 127.550  1.00 72.45           O  
+ANISOU 3648  O1A GDP A 101     9798   9342   8385    800   1947    438       O  
+HETATM 3649  O2A GDP A 101     171.847  31.749 129.637  1.00 85.05           O  
+ANISOU 3649  O2A GDP A 101    11335  10773  10206    654   1833    332       O  
+HETATM 3650  O5' GDP A 101     170.628  30.543 127.725  1.00 67.31           O  
+ANISOU 3650  O5' GDP A 101     9245   8560   7770    861   1757    238       O  
+HETATM 3651  C5' GDP A 101     170.727  31.167 126.466  1.00 65.40           C  
+ANISOU 3651  C5' GDP A 101     9076   8350   7423    919   1786    320       C  
+HETATM 3652  C4' GDP A 101     169.680  30.444 125.602  1.00 77.91           C  
+ANISOU 3652  C4' GDP A 101    10761   9918   8925   1030   1698    234       C  
+HETATM 3653  O4' GDP A 101     170.006  28.978 125.751  1.00 85.32           O  
+ANISOU 3653  O4' GDP A 101    11690  10901   9827   1090   1695    153       O  
+HETATM 3654  C3' GDP A 101     168.220  30.422 126.014  1.00 78.40           C  
+ANISOU 3654  C3' GDP A 101    10843   9888   9059   1014   1575    140       C  
+HETATM 3655  O3' GDP A 101     167.240  31.397 125.402  1.00 75.93           O  
+ANISOU 3655  O3' GDP A 101    10598   9516   8734   1032   1511    159       O  
+HETATM 3656  C2' GDP A 101     167.770  29.174 125.268  1.00 77.70           C  
+ANISOU 3656  C2' GDP A 101    10830   9818   8875   1122   1512     59       C  
+HETATM 3657  O2' GDP A 101     167.581  29.756 123.967  1.00 80.32           O  
+ANISOU 3657  O2' GDP A 101    11258  10160   9098   1199   1511    113       O  
+HETATM 3658  C1' GDP A 101     168.910  28.183 125.218  1.00 68.67           C  
+ANISOU 3658  C1' GDP A 101     9671   8752   7668   1169   1582     56       C  
+HETATM 3659  N9  GDP A 101     168.774  27.299 126.397  1.00 63.58           N  
+ANISOU 3659  N9  GDP A 101     8963   8078   7118   1112   1538    -29       N  
+HETATM 3660  C8  GDP A 101     169.630  27.349 127.464  1.00 62.99           C  
+ANISOU 3660  C8  GDP A 101     8787   8021   7125   1030   1607     -6       C  
+HETATM 3661  N7  GDP A 101     169.239  26.444 128.464  1.00 62.69           N  
+ANISOU 3661  N7  GDP A 101     8713   7943   7162    984   1541    -96       N  
+HETATM 3662  C5  GDP A 101     168.097  25.853 128.003  1.00 62.21           C  
+ANISOU 3662  C5  GDP A 101     8728   7840   7069   1029   1427   -169       C  
+HETATM 3663  C6  GDP A 101     167.183  24.831 128.496  1.00 61.74           C  
+ANISOU 3663  C6  GDP A 101     8680   7731   7047   1006   1309   -264       C  
+HETATM 3664  O6  GDP A 101     167.392  24.300 129.626  1.00 61.01           O  
+ANISOU 3664  O6  GDP A 101     8522   7627   7033    931   1304   -298       O  
+HETATM 3665  N1  GDP A 101     166.158  24.443 127.751  1.00 62.17           N  
+ANISOU 3665  N1  GDP A 101     8817   7755   7051   1057   1201   -310       N  
+HETATM 3666  C2  GDP A 101     165.934  24.994 126.580  1.00 62.96           C  
+ANISOU 3666  C2  GDP A 101     8993   7864   7067   1138   1200   -277       C  
+HETATM 3667  N2  GDP A 101     164.848  24.582 125.880  1.00 63.42           N  
+ANISOU 3667  N2  GDP A 101     9131   7884   7080   1185   1078   -327       N  
+HETATM 3668  N3  GDP A 101     166.708  25.982 126.063  1.00 63.41           N  
+ANISOU 3668  N3  GDP A 101     9048   7965   7081   1166   1310   -189       N  
+HETATM 3669  C4  GDP A 101     167.811  26.420 126.687  1.00 63.13           C  
+ANISOU 3669  C4  GDP A 101     8931   7969   7087   1114   1425   -129       C  
+HETATM 3670  P1  C2E A 102     160.051  46.215 143.674  1.00 62.36           P  
+ANISOU 3670  P1  C2E A 102     8806   6788   8099   1095    681   -555       P  
+HETATM 3671  O2P C2E A 102     160.772  47.504 144.003  1.00 61.94           O  
+ANISOU 3671  O2P C2E A 102     8923   6547   8064   1085    584   -522       O  
+HETATM 3672  O1P C2E A 102     159.507  46.081 142.275  1.00 68.32           O  
+ANISOU 3672  O1P C2E A 102     9561   7576   8821   1130    673   -521       O  
+HETATM 3673  O5' C2E A 102     158.854  45.934 144.710  1.00 75.35           O  
+ANISOU 3673  O5' C2E A 102    10343   8569   9720   1225    690   -684       O  
+HETATM 3674  C5' C2E A 102     158.691  46.713 145.888  1.00 60.20           C  
+ANISOU 3674  C5' C2E A 102     8479   6600   7792   1315    634   -759       C  
+HETATM 3675  C4' C2E A 102     157.759  46.003 146.856  1.00 54.80           C  
+ANISOU 3675  C4' C2E A 102     7641   6098   7083   1391    693   -856       C  
+HETATM 3676  O4' C2E A 102     156.490  46.638 146.790  1.00 54.56           O  
+ANISOU 3676  O4' C2E A 102     7610   6119   7001   1583    630   -939       O  
+HETATM 3677  C3' C2E A 102     157.512  44.527 146.571  1.00 54.93           C  
+ANISOU 3677  C3' C2E A 102     7483   6282   7107   1300    800   -837       C  
+HETATM 3678  O3' C2E A 102     158.259  43.733 147.481  1.00 53.11           O  
+ANISOU 3678  O3' C2E A 102     7190   6084   6906   1179    875   -825       O  
+HETATM 3679  C2' C2E A 102     156.044  44.348 146.887  1.00 55.37           C  
+ANISOU 3679  C2' C2E A 102     7416   6505   7115   1444    802   -926       C  
+HETATM 3680  O2' C2E A 102     155.889  43.995 148.263  1.00 56.52           O  
+ANISOU 3680  O2' C2E A 102     7478   6747   7249   1455    850   -985       O  
+HETATM 3681  C1' C2E A 102     155.424  45.704 146.713  1.00 55.05           C  
+ANISOU 3681  C1' C2E A 102     7491   6387   7039   1623    693   -978       C  
+HETATM 3682  N9  C2E A 102     154.814  45.791 145.365  1.00 59.72           N  
+ANISOU 3682  N9  C2E A 102     8087   6986   7616   1669    654   -952       N  
+HETATM 3683  C8  C2E A 102     155.315  46.474 144.321  1.00 62.11           C  
+ANISOU 3683  C8  C2E A 102     8537   7134   7928   1650    589   -888       C  
+HETATM 3684  N7  C2E A 102     154.504  46.359 143.242  1.00 63.91           N  
+ANISOU 3684  N7  C2E A 102     8733   7417   8132   1711    563   -883       N  
+HETATM 3685  C5  C2E A 102     153.457  45.589 143.588  1.00 61.42           C  
+ANISOU 3685  C5  C2E A 102     8240   7297   7799   1765    608   -944       C  
+HETATM 3686  C6  C2E A 102     152.239  45.073 142.920  1.00 62.10           C  
+ANISOU 3686  C6  C2E A 102     8200   7534   7860   1835    602   -969       C  
+HETATM 3687  O6  C2E A 102     152.004  45.362 141.722  1.00 65.06           O  
+ANISOU 3687  O6  C2E A 102     8640   7855   8224   1867    544   -937       O  
+HETATM 3688  N1  C2E A 102     151.409  44.298 143.639  1.00 61.24           N  
+ANISOU 3688  N1  C2E A 102     7907   7622   7741   1856    656  -1019       N  
+HETATM 3689  C2  C2E A 102     151.665  43.992 144.925  1.00 67.50           C  
+ANISOU 3689  C2  C2E A 102     8635   8473   8538   1821    719  -1049       C  
+HETATM 3690  N2  C2E A 102     150.797  43.204 145.598  1.00 73.70           N  
+ANISOU 3690  N2  C2E A 102     9231   9466   9307   1834    774  -1087       N  
+HETATM 3691  N3  C2E A 102     152.756  44.429 145.594  1.00 65.19           N  
+ANISOU 3691  N3  C2E A 102     8459   8044   8265   1766    727  -1037       N  
+HETATM 3692  C4  C2E A 102     153.671  45.217 144.990  1.00 61.83           C  
+ANISOU 3692  C4  C2E A 102     8216   7417   7858   1734    671   -985       C  
+HETATM 3693  P11 C2E A 102     158.460  42.131 147.310  1.00 53.96           P  
+ANISOU 3693  P11 C2E A 102     7152   6317   7033   1040    977   -786       P  
+HETATM 3694  O21 C2E A 102     157.118  41.487 147.060  1.00 54.87           O  
+ANISOU 3694  O21 C2E A 102     7131   6603   7113   1109    994   -831       O  
+HETATM 3695  O11 C2E A 102     159.332  41.691 148.471  1.00 53.76           O  
+ANISOU 3695  O11 C2E A 102     7109   6281   7036    940   1026   -785       O  
+HETATM 3696  O5A C2E A 102     159.307  42.033 145.938  1.00 54.70           O  
+ANISOU 3696  O5A C2E A 102     7316   6318   7150    944    978   -686       O  
+HETATM 3697  C5A C2E A 102     160.715  42.265 145.948  1.00 57.26           C  
+ANISOU 3697  C5A C2E A 102     7726   6516   7513    831    985   -612       C  
+HETATM 3698  C4A C2E A 102     161.282  42.592 144.563  1.00 57.57           C  
+ANISOU 3698  C4A C2E A 102     7851   6470   7554    790    967   -520       C  
+HETATM 3699  O4A C2E A 102     161.313  41.402 143.772  1.00 56.15           O  
+ANISOU 3699  O4A C2E A 102     7586   6383   7364    728   1033   -486       O  
+HETATM 3700  C3A C2E A 102     160.492  43.630 143.769  1.00 57.92           C  
+ANISOU 3700  C3A C2E A 102     7984   6459   7563    913    880   -531       C  
+HETATM 3701  O3A C2E A 102     161.014  44.948 143.932  1.00 55.78           O  
+ANISOU 3701  O3A C2E A 102     7863   6027   7303    929    798   -504       O  
+HETATM 3702  C2A C2E A 102     160.655  43.138 142.343  1.00 57.50           C  
+ANISOU 3702  C2A C2E A 102     7930   6426   7493    868    907   -458       C  
+HETATM 3703  O2A C2E A 102     161.854  43.656 141.760  1.00 60.91           O  
+ANISOU 3703  O2A C2E A 102     8466   6739   7939    777    901   -352       O  
+HETATM 3704  C1A C2E A 102     160.815  41.636 142.452  1.00 56.57           C  
+ANISOU 3704  C1A C2E A 102     7680   6432   7383    784   1000   -459       C  
+HETATM 3705  N91 C2E A 102     159.488  40.985 142.320  1.00 56.01           N  
+ANISOU 3705  N91 C2E A 102     7507   6492   7282    862    998   -528       N  
+HETATM 3706  C81 C2E A 102     158.949  40.114 143.196  1.00 61.64           C  
+ANISOU 3706  C81 C2E A 102     8095   7324   8000    853   1036   -588       C  
+HETATM 3707  N71 C2E A 102     157.712  39.700 142.804  1.00 62.88           N  
+ANISOU 3707  N71 C2E A 102     8171   7592   8129    923   1016   -630       N  
+HETATM 3708  C51 C2E A 102     157.435  40.322 141.647  1.00 59.60           C  
+ANISOU 3708  C51 C2E A 102     7835   7122   7687    989    962   -605       C  
+HETATM 3709  C61 C2E A 102     156.307  40.334 140.681  1.00 57.33           C  
+ANISOU 3709  C61 C2E A 102     7527   6890   7364   1081    909   -625       C  
+HETATM 3710  O61 C2E A 102     155.268  39.662 140.857  1.00 55.89           O  
+ANISOU 3710  O61 C2E A 102     7223   6841   7173   1111    906   -672       O  
+HETATM 3711  N11 C2E A 102     156.424  41.118 139.608  1.00 60.05           N  
+ANISOU 3711  N11 C2E A 102     7991   7139   7687   1127    857   -584       N  
+HETATM 3712  C21 C2E A 102     157.516  41.863 139.377  1.00 56.96           C  
+ANISOU 3712  C21 C2E A 102     7728   6611   7304   1083    855   -518       C  
+HETATM 3713  N21 C2E A 102     157.533  42.604 138.259  1.00 55.80           N  
+ANISOU 3713  N21 C2E A 102     7696   6379   7127   1127    800   -471       N  
+HETATM 3714  N31 C2E A 102     158.587  41.899 140.204  1.00 57.63           N  
+ANISOU 3714  N31 C2E A 102     7830   6642   7426    992    900   -492       N  
+HETATM 3715  C41 C2E A 102     158.608  41.163 141.335  1.00 56.23           C  
+ANISOU 3715  C41 C2E A 102     7547   6544   7274    947    953   -536       C  
+HETATM 3716 MG    MG A 103     126.077  61.593 159.180  1.00108.82          MG  
+ANISOU 3716 MG    MG A 103    12694  17569  11085   7812   -343  -3109      MG  
+HETATM 3717 MG    MG A 104     154.141  37.118 142.411  1.00 59.42          MG  
+ANISOU 3717 MG    MG A 104     7339   7600   7637    979    989   -730      MG  
+HETATM 3718  O   HOH R 201     194.140  17.513 153.337  1.00 61.48           O  
+ANISOU 3718  O   HOH R 201     6733   8120   8507    136   1562   -132       O  
+HETATM 3719  O   HOH R 202     161.756   7.501 168.565  1.00 55.55           O  
+ANISOU 3719  O   HOH R 202     6938   7333   6834  -2694    551    148       O  
+HETATM 3720  O   HOH R 203     175.268   8.201 164.984  1.00 54.06           O  
+ANISOU 3720  O   HOH R 203     7522   5907   7112  -1438    412   -590       O  
+HETATM 3721  O   HOH R 204     185.990  35.893 165.478  1.00 45.32           O  
+ANISOU 3721  O   HOH R 204     5958   4128   7135  -1326    647    -81       O  
+HETATM 3722  O   HOH R 205     160.849   8.174 166.038  1.00 47.19           O  
+ANISOU 3722  O   HOH R 205     5772   6298   5858  -2550    546     96       O  
+HETATM 3723  O   HOH R 206     175.244   3.496 149.804  1.00 47.31           O  
+ANISOU 3723  O   HOH R 206     7388   4796   5790   -130   -157   -970       O  
+HETATM 3724  O   HOH R 207     189.944  29.290 159.034  1.00 51.36           O  
+ANISOU 3724  O   HOH R 207     5821   5839   7856  -1155   1264    221       O  
+HETATM 3725  O   HOH R 208     161.355   5.124 164.391  1.00 58.27           O  
+ANISOU 3725  O   HOH R 208     7524   7321   7294  -2745    104    144       O  
+HETATM 3726  O   HOH R 209     179.433  34.347 155.699  1.00 38.82           O  
+ANISOU 3726  O   HOH R 209     4906   3957   5886   -782   1335    -63       O  
+HETATM 3727  O   HOH R 210     178.335  24.007 162.316  1.00 43.91           O  
+ANISOU 3727  O   HOH R 210     5508   4853   6323   -871   1299   -529       O  
+HETATM 3728  O   HOH R 211     166.040  34.737 161.264  1.00 41.40           O  
+ANISOU 3728  O   HOH R 211     5294   4862   5576     35   1384   -866       O  
+HETATM 3729  O   HOH R 212     177.696  29.197 157.848  1.00 38.76           O  
+ANISOU 3729  O   HOH R 212     4815   4177   5736   -707   1419   -353       O  
+HETATM 3730  O   HOH R 213     188.435  34.568 147.192  1.00 63.67           O  
+ANISOU 3730  O   HOH R 213     7234   7937   9021  -1050   1824   1002       O  
+HETATM 3731  O   HOH R 214     163.612   6.584 164.814  1.00 55.37           O  
+ANISOU 3731  O   HOH R 214     7218   6842   6979  -2432    296    -39       O  
+HETATM 3732  O   HOH R 215     162.398   9.190 159.926  1.00 47.07           O  
+ANISOU 3732  O   HOH R 215     5959   5884   6044  -1978    440   -194       O  
+HETATM 3733  O   HOH R 216     177.140  10.854 156.375  1.00 41.64           O  
+ANISOU 3733  O   HOH R 216     5731   4513   5579   -626    730   -713       O  
+HETATM 3734  O   HOH R 217     170.338  34.207 161.684  1.00 42.07           O  
+ANISOU 3734  O   HOH R 217     5507   4614   5864   -272   1309   -730       O  
+HETATM 3735  O   HOH R 218     175.465  31.862 156.690  1.00 43.73           O  
+ANISOU 3735  O   HOH R 218     5537   4763   6317   -584   1410   -360       O  
+HETATM 3736  O   HOH R 219     149.956  27.097 162.158  1.00 70.44           O  
+ANISOU 3736  O   HOH R 219     7073  11119   8571   -117   1777   -592       O  
+HETATM 3737  O   HOH R 220     174.890  10.771 155.831  1.00 42.94           O  
+ANISOU 3737  O   HOH R 220     5913   4703   5702   -735    690   -686       O  
+HETATM 3738  O   HOH R 221     178.521  12.748 154.978  1.00 54.03           O  
+ANISOU 3738  O   HOH R 221     7139   6200   7192   -443    934   -686       O  
+HETATM 3739  O   HOH R 222     183.729  18.028 143.996  1.00 50.75           O  
+ANISOU 3739  O   HOH R 222     6225   6609   6450    502   1738   -312       O  
+HETATM 3740  O   HOH R 223     181.031  10.519 154.712  1.00 67.13           O  
+ANISOU 3740  O   HOH R 223     8919   7800   8787   -216    793   -768       O  
+HETATM 3741  O   HOH R 224     181.066  12.777 151.760  1.00 52.14           O  
+ANISOU 3741  O   HOH R 224     6842   6112   6857    -29   1055   -690       O  
+HETATM 3742  O   HOH R 225     196.123  35.666 148.157  1.00 75.64           O  
+ANISOU 3742  O   HOH R 225     7884   9987  10870  -1627   1823   1750       O  
+HETATM 3743  O   HOH R 226     160.743   7.342 162.620  1.00 49.65           O  
+ANISOU 3743  O   HOH R 226     6218   6381   6267  -2450    316     34       O  
+HETATM 3744  O   HOH R 227     149.975  25.209 160.415  1.00 68.61           O  
+ANISOU 3744  O   HOH R 227     6841  10768   8462   -413   1636   -469       O  
+HETATM 3745  O   HOH A 201     121.611  61.639 155.485  1.00110.30           O  
+ANISOU 3745  O   HOH A 201    12187  18436  11288   8166   -478  -3114       O  
+HETATM 3746  O   HOH A 202     123.642  61.074 158.175  1.00108.84           O  
+ANISOU 3746  O   HOH A 202    12187  18122  11047   7953   -280  -3076       O  
+HETATM 3747  O   HOH A 203     125.272  63.470 159.131  1.00108.74           O  
+ANISOU 3747  O   HOH A 203    12930  17504  10881   8259   -594  -3281       O  
+HETATM 3748  O   HOH A 204     130.760  58.100 159.657  1.00 91.85           O  
+ANISOU 3748  O   HOH A 204    10638  14815   9443   6661     56  -2781       O  
+HETATM 3749  O   HOH A 205     132.692  58.246 161.065  1.00 98.65           O  
+ANISOU 3749  O   HOH A 205    11823  15350  10309   6534     66  -2798       O  
+HETATM 3750  O   HOH A 206     134.823  53.784 159.738  1.00 80.84           O  
+ANISOU 3750  O   HOH A 206     9112  13072   8530   5501    518  -2434       O  
+HETATM 3751  O   HOH A 207     135.853  54.087 152.710  1.00 77.36           O  
+ANISOU 3751  O   HOH A 207     9012  11790   8593   5265    135  -2340       O  
+HETATM 3752  O   HOH A 208     126.923  61.949 157.215  1.00101.78           O  
+ANISOU 3752  O   HOH A 208    12056  16226  10391   7672   -512  -3095       O  
+HETATM 3753  O   HOH A 209     128.689  51.083 153.281  1.00 85.88           O  
+ANISOU 3753  O   HOH A 209     8404  14781   9446   5415    484  -2155       O  
+HETATM 3754  O   HOH A 210     126.298  53.651 155.040  1.00 91.27           O  
+ANISOU 3754  O   HOH A 210     9088  15853   9739   6136    361  -2375       O  
+HETATM 3755  O   HOH A 211     142.173  58.880 148.515  1.00 80.41           O  
+ANISOU 3755  O   HOH A 211    11339   9921   9292   5076   -690  -2301       O  
+HETATM 3756  O   HOH A 212     140.081  57.839 150.850  1.00 79.93           O  
+ANISOU 3756  O   HOH A 212    10705  10604   9060   5273   -435  -2408       O  
+HETATM 3757  O   HOH A 213     132.660  53.824 160.089  1.00 89.80           O  
+ANISOU 3757  O   HOH A 213     9906  14700   9513   5729    559  -2444       O  
+HETATM 3758  O   HOH A 214     145.186  66.539 153.387  1.00 88.26           O  
+ANISOU 3758  O   HOH A 214    14066   9604   9863   5565  -1752  -2592       O  
+HETATM 3759  O   HOH A 215     154.214  35.616 140.564  1.00 57.54           O  
+ANISOU 3759  O   HOH A 215     7116   7364   7382    880    961   -664       O  
+CONECT    1 3576                                                                
+CONECT  194 3638                                                                
+CONECT  195 3638                                                                
+CONECT  217 3638                                                                
+CONECT  746 3641                                                                
+CONECT  849 3639                                                                
+CONECT  851 3639                                                                
+CONECT 1074 3640                                                                
+CONECT 1782 3655                                                                
+CONECT 2332 3716                                                                
+CONECT 2632 3717                                                                
+CONECT 3563 3564 3565 3566 3567                                                 
+CONECT 3564 3563                                                                
+CONECT 3565 3563                                                                
+CONECT 3566 3563                                                                
+CONECT 3567 3563 3568                                                           
+CONECT 3568 3567 3569 3570 3571                                                 
+CONECT 3569 3568                                                                
+CONECT 3570 3568                                                                
+CONECT 3571 3568 3572                                                           
+CONECT 3572 3571 3573                                                           
+CONECT 3573 3572 3574 3575                                                      
+CONECT 3574 3573 3579                                                           
+CONECT 3575 3573 3576 3577                                                      
+CONECT 3576    1 3575                                                           
+CONECT 3577 3575 3578 3579                                                      
+CONECT 3578 3577                                                                
+CONECT 3579 3574 3577 3580                                                      
+CONECT 3580 3579 3581 3590                                                      
+CONECT 3581 3580 3582                                                           
+CONECT 3582 3581 3583                                                           
+CONECT 3583 3582 3584 3590                                                      
+CONECT 3584 3583 3585 3586                                                      
+CONECT 3585 3584                                                                
+CONECT 3586 3584 3587                                                           
+CONECT 3587 3586 3588 3589                                                      
+CONECT 3588 3587                                                                
+CONECT 3589 3587 3590                                                           
+CONECT 3590 3580 3583 3589                                                      
+CONECT 3591 3592 3593 3594 3622                                                 
+CONECT 3592 3591                                                                
+CONECT 3593 3591                                                                
+CONECT 3594 3591 3595                                                           
+CONECT 3595 3594 3596                                                           
+CONECT 3596 3595 3597 3598                                                      
+CONECT 3597 3596 3602                                                           
+CONECT 3598 3596 3599 3600                                                      
+CONECT 3599 3598 3614                                                           
+CONECT 3600 3598 3601 3602                                                      
+CONECT 3601 3600                                                                
+CONECT 3602 3597 3600 3603                                                      
+CONECT 3603 3602 3604 3613                                                      
+CONECT 3604 3603 3605                                                           
+CONECT 3605 3604 3606                                                           
+CONECT 3606 3605 3607 3613                                                      
+CONECT 3607 3606 3608 3609                                                      
+CONECT 3608 3607                                                                
+CONECT 3609 3607 3610                                                           
+CONECT 3610 3609 3611 3612                                                      
+CONECT 3611 3610                                                                
+CONECT 3612 3610 3613                                                           
+CONECT 3613 3603 3606 3612                                                      
+CONECT 3614 3599 3615 3616 3617                                                 
+CONECT 3615 3614                                                                
+CONECT 3616 3614                                                                
+CONECT 3617 3614 3618                                                           
+CONECT 3618 3617 3619                                                           
+CONECT 3619 3618 3620 3621                                                      
+CONECT 3620 3619 3625                                                           
+CONECT 3621 3619 3622 3623                                                      
+CONECT 3622 3591 3621                                                           
+CONECT 3623 3621 3624 3625                                                      
+CONECT 3624 3623                                                                
+CONECT 3625 3620 3623 3626                                                      
+CONECT 3626 3625 3627 3636                                                      
+CONECT 3627 3626 3628                                                           
+CONECT 3628 3627 3629                                                           
+CONECT 3629 3628 3630 3636                                                      
+CONECT 3630 3629 3631 3632                                                      
+CONECT 3631 3630                                                                
+CONECT 3632 3630 3633                                                           
+CONECT 3633 3632 3634 3635                                                      
+CONECT 3634 3633                                                                
+CONECT 3635 3633 3636                                                           
+CONECT 3636 3626 3629 3635                                                      
+CONECT 3637 3722 3725 3731 3743                                                 
+CONECT 3638  194  195  217                                                      
+CONECT 3639  849  851 3730                                                      
+CONECT 3640 1074 3728 3734                                                      
+CONECT 3641  746 3733 3738 3740                                                 
+CONECT 3642 3643 3644 3645 3646                                                 
+CONECT 3643 3642                                                                
+CONECT 3644 3642                                                                
+CONECT 3645 3642                                                                
+CONECT 3646 3642 3647                                                           
+CONECT 3647 3646 3648 3649 3650                                                 
+CONECT 3648 3647                                                                
+CONECT 3649 3647                                                                
+CONECT 3650 3647 3651                                                           
+CONECT 3651 3650 3652                                                           
+CONECT 3652 3651 3653 3654                                                      
+CONECT 3653 3652 3658                                                           
+CONECT 3654 3652 3655 3656                                                      
+CONECT 3655 1782 3654                                                           
+CONECT 3656 3654 3657 3658                                                      
+CONECT 3657 3656                                                                
+CONECT 3658 3653 3656 3659                                                      
+CONECT 3659 3658 3660 3669                                                      
+CONECT 3660 3659 3661                                                           
+CONECT 3661 3660 3662                                                           
+CONECT 3662 3661 3663 3669                                                      
+CONECT 3663 3662 3664 3665                                                      
+CONECT 3664 3663                                                                
+CONECT 3665 3663 3666                                                           
+CONECT 3666 3665 3667 3668                                                      
+CONECT 3667 3666                                                                
+CONECT 3668 3666 3669                                                           
+CONECT 3669 3659 3662 3668                                                      
+CONECT 3670 3671 3672 3673 3701                                                 
+CONECT 3671 3670                                                                
+CONECT 3672 3670                                                                
+CONECT 3673 3670 3674                                                           
+CONECT 3674 3673 3675                                                           
+CONECT 3675 3674 3676 3677                                                      
+CONECT 3676 3675 3681                                                           
+CONECT 3677 3675 3678 3679                                                      
+CONECT 3678 3677 3693                                                           
+CONECT 3679 3677 3680 3681                                                      
+CONECT 3680 3679                                                                
+CONECT 3681 3676 3679 3682                                                      
+CONECT 3682 3681 3683 3692                                                      
+CONECT 3683 3682 3684                                                           
+CONECT 3684 3683 3685                                                           
+CONECT 3685 3684 3686 3692                                                      
+CONECT 3686 3685 3687 3688                                                      
+CONECT 3687 3686                                                                
+CONECT 3688 3686 3689                                                           
+CONECT 3689 3688 3690 3691                                                      
+CONECT 3690 3689                                                                
+CONECT 3691 3689 3692                                                           
+CONECT 3692 3682 3685 3691                                                      
+CONECT 3693 3678 3694 3695 3696                                                 
+CONECT 3694 3693                                                                
+CONECT 3695 3693                                                                
+CONECT 3696 3693 3697                                                           
+CONECT 3697 3696 3698                                                           
+CONECT 3698 3697 3699 3700                                                      
+CONECT 3699 3698 3704                                                           
+CONECT 3700 3698 3701 3702                                                      
+CONECT 3701 3670 3700                                                           
+CONECT 3702 3700 3703 3704                                                      
+CONECT 3703 3702                                                                
+CONECT 3704 3699 3702 3705                                                      
+CONECT 3705 3704 3706 3715                                                      
+CONECT 3706 3705 3707                                                           
+CONECT 3707 3706 3708                                                           
+CONECT 3708 3707 3709 3715                                                      
+CONECT 3709 3708 3710 3711                                                      
+CONECT 3710 3709                                                                
+CONECT 3711 3709 3712                                                           
+CONECT 3712 3711 3713 3714                                                      
+CONECT 3713 3712                                                                
+CONECT 3714 3712 3715                                                           
+CONECT 3715 3705 3708 3714                                                      
+CONECT 3716 2332 3746 3747 3752                                                 
+CONECT 3717 2632 3759                                                           
+CONECT 3722 3637                                                                
+CONECT 3725 3637                                                                
+CONECT 3728 3640                                                                
+CONECT 3730 3639                                                                
+CONECT 3731 3637                                                                
+CONECT 3733 3641                                                                
+CONECT 3734 3640                                                                
+CONECT 3738 3641                                                                
+CONECT 3740 3641                                                                
+CONECT 3743 3637                                                                
+CONECT 3746 3716                                                                
+CONECT 3747 3716                                                                
+CONECT 3752 3716                                                                
+CONECT 3759 3717                                                                
+MASTER      375    0   11    0    0    0   20    6 3757    2  180   14          
+END                                                                             

--- a/plip/test/test_salt_bridges.py
+++ b/plip/test/test_salt_bridges.py
@@ -1,0 +1,23 @@
+import unittest
+
+from plip.basic import config
+from plip.structure.preparation import PDBComplex, PLInteraction
+
+
+def characterize_complex(pdb_file: str, binding_site_id: str) -> PLInteraction:
+    pdb_complex = PDBComplex()
+    pdb_complex.load_pdb(pdb_file)
+    for ligand in pdb_complex.ligands:
+        if ':'.join([ligand.hetid, ligand.chain, str(ligand.position)]) == binding_site_id:
+            pdb_complex.characterize_complex(ligand)
+    return pdb_complex.interaction_sets[binding_site_id]
+
+class SaltBridgeTest(unittest.TestCase):
+
+    def test_4yb0(self):
+        '''test salt bridge detection for nucleic acids as part of the receptor'''
+
+        config.DNARECEPTOR = True
+        interactions = characterize_complex('./pdb/4yb0.pdb', 'C2E:R:102')
+        salt_bridges = interactions.saltbridge_lneg + interactions.saltbridge_pneg
+        self.assertTrue(len(salt_bridges) == 1)


### PR DESCRIPTION
This change fixes the issue of the salt bridge not getting detected when nucleic acids are treated as a part of the receptor.

On the receptor side, now it recognizes nucleic acid residues and looks for the negative charge in the phosphate backbone, which are possible candidates to form salt bridges.

Thank you.