### PR TITLE
Updates ImageMagick to version 7 and makes its use platform independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you cannot use the containerized bundle or want to use PLIP sources, make sur
 - Python >= 3.6.9
 - [OpenBabel](#Installing-OpenBabel) >= 3.0.0 with [Python bindings](https://open-babel.readthedocs.io/en/latest/UseTheLibrary/PythonInstall.html)
 - PyMOL >= 2.3.0 with Python bindings (optional, for visualization only)
-- ImageMagick >= 6.9 (optional)
+- ImageMagick >= 7.0 (optional)
 
 **Python:** If you are on a system where Python 3 is executed using `python3` instead of just `python`, replace the `python` and `pip` commands in the following steps with `python3` and `pip3` accordingly.
 
@@ -164,7 +164,7 @@ Using PLIP in your commercial or non-commercial project is generally possible wh
 If you are using PLIP in your work, please cite
 > Adasme,M. et al. PLIP 2021: expanding the scope of the protein-ligand interaction profiler to DNA and RNA.
 > Nucl. Acids Res. (05 May 2021), gkab294. doi: 10.1093/nar/gkab294
- 
+
 or
 
 > Salentin,S. et al. PLIP: fully automated protein-ligand interaction profiler.

--- a/plip/visualization/pymol.py
+++ b/plip/visualization/pymol.py
@@ -371,7 +371,7 @@ class PyMOLVisualizer:
                                         stderr=subprocess.STDOUT)
                 sleep(0.1)
                 attempts += 1
-            trim = f'magick convert -trim {newfile} -bordercolor White -border 20x20 {newfile}'  # Trim the image
+            trim = f'magick {newfile} -trim -bordercolor White -border 20x20 {newfile}'  # Trim the image
             os.system(trim)
             # Get the width of the new image
             getwidth = f'magick {newfile} -ping -format "%w" info:'


### PR DESCRIPTION
The code for cropping pictures was tailored to unix systems only, now it should run on all platforms.
Code is also adapted to work with the latest ImageMagick (major changes were introduced with ImageMagick 7, ImageMagick 6 is legacy now).

Details: In the past, "convert" needed to be replaced with "magick convert" to work on windows. Now only "magick" is used on both systems (porting guide: https://imagemagick.org/script/porting.php).