### PR TITLE
fixes NumPy DeprecationWarning

### DIFF
--- a/plip/basic/supplemental.py
+++ b/plip/basic/supplemental.py
@@ -358,7 +358,7 @@ def int32_to_negative(int32):
     if int32 == 4294967295:  # Special case in some structures (note, this is just a workaround)
         return -1
     for i in range(-1000, -1):
-        dct[np.uint32(i)] = i
+        dct[int(np.array(i).astype(np.uint32))] = i
     if int32 in dct:
         return dct[int32]
     else:


### PR DESCRIPTION
my numpy version is:
`numpy                     1.24.4           py38h59b608b_0    conda-forge`


`dct[np.uint32(i)] = i`
the line above will raise a DeprecationWarning when passing a negative number to `np.uint32` :

```
plip/basic/supplemental.py:361: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -1000 to uint32 will fail in the future.
   For the old behavior, usually:
       np.array(value).astype(dtype)`
   will give the desired result (the cast overflows).
      dct[np.uint32(i)] = i
```

so I changed it to 
`dct[int(np.array(i).astype(np.uint32))] = i`


Thank you.