### PR TITLE
Fixes several mistakes in interaction detection with peptide ligands

### DIFF
--- a/plip/plipcmd.py
+++ b/plip/plipcmd.py
@@ -271,7 +271,7 @@ def main():
     config.INTRA = arguments.intra
     config.NOFIX = arguments.nofix
     config.NOFIXFILE = arguments.nofixfile
-    config.NOPDBCANMAP = arguments.nopdbcanmap
+    config.NOPDBCANMAP = bool(arguments.nopdbcanmap or config.INTRA or config.PEPTIDES)
     config.KEEPMOD = arguments.keepmod
     config.DNARECEPTOR = arguments.dnareceptor
     config.OUTPUTFILENAME = arguments.outputfilename

--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -625,10 +625,11 @@ class PLInteraction:
 
         self.pistacking = pistacking(self.bindingsite.rings, self.ligand.rings)
 
-        self.all_pi_cation_laro = pication(self.ligand.rings, self.bindingsite.get_pos_charged(), True)
-        self.pication_paro = pication(self.bindingsite.rings, self.ligand.get_pos_charged(), False)
+        self.all_pication_laro = pication(self.ligand.rings, self.bindingsite.get_pos_charged(), True)
+        self.all_pication_paro = pication(self.bindingsite.rings, self.ligand.get_pos_charged(), False)
 
-        self.pication_laro = self.refine_pi_cation_laro(self.all_pi_cation_laro, self.pistacking)
+        self.pication_laro = self.refine_pication(self.all_pication_laro, self.pistacking)
+        self.pication_paro = self.refine_pication(self.all_pication_paro, self.pistacking)
 
         self.all_hydrophobic_contacts = hydrophobic_interactions(self.bindingsite.get_hydrophobic_atoms(),
                                                                  self.ligand.get_hydrophobic_atoms())
@@ -843,7 +844,7 @@ class PLInteraction:
         return [hb[1] for hb in second_set.values()]
 
     @staticmethod
-    def refine_pi_cation_laro(all_picat, stacks):
+    def refine_pication(all_picat, stacks):
         """Just important for constellations with histidine involved. If the histidine ring is positioned in stacking
         position to an aromatic ring in the ligand, there is in most cases stacking and pi-cation interaction reported
         as histidine also carries a positive charge in the ring. For such cases, only report stacking.
@@ -851,9 +852,15 @@ class PLInteraction:
         i_set = []
         for picat in all_picat:
             exclude = False
-            for stack in stacks:
-                if whichrestype(stack.proteinring.atoms[0]) == 'HIS' and picat.ring.obj == stack.ligandring.obj:
-                    exclude = True
+            if picat.restype == 'HIS':
+                for stack in stacks:
+                    if whichresnumber(stack.proteinring.atoms[0]) == picat.resnr and picat.ring.obj == stack.ligandring.obj:
+                        exclude = True
+            # HIS could also be on ligand side for protein-protein interactions
+            if picat.restype_l == 'HIS':
+                for stack in stacks:
+                    if whichresnumber(stack.ligandring.atoms[0]) == picat.resnr_l and picat.ring.obj == stack.proteinring.obj:
+                        exclude = True
             if not exclude:
                 i_set.append(picat)
         return i_set

--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -1032,7 +1032,8 @@ class Ligand(Mol):
         self.type = ligand.type
         self.complex = cclass
         self.molecule = ligand.mol  # Pybel Molecule
-        self.smiles = self.molecule.write(format='can')  # SMILES String
+        # get canonical SMILES String, but not for peptide ligand (tend to be too long -> openBabel crashes)
+        self.smiles = "" if (config.INTRA or config.PEPTIDES) else self.molecule.write(format='can')
         self.inchikey = self.molecule.write(format='inchikey')
         self.can_to_pdb = ligand.can_to_pdb
         if not len(self.smiles) == 0:

--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -243,7 +243,7 @@ class LigandFinder:
         given chain without water
         """
         all_from_chain = [o for o in pybel.ob.OBResidueIter(
-            self.proteincomplex.OBMol) if o.GetChain() == chain]  # All residues from chain
+            self.proteincomplex.OBMol) if o.GetChain() == chain and not self.is_het_residue(o)]  # All residues from chain
         if len(all_from_chain) == 0:
             return None
         else:

--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -1168,74 +1168,110 @@ class Ligand(Mol):
         """
         data = namedtuple('lcharge', 'atoms orig_atoms atoms_orig_idx type center fgroup')
         a_set = []
-        for a in all_atoms:
-            a_orig_idx = self.Mapper.mapid(a.idx, mtype=self.mtype, bsid=self.bsid)
-            a_orig = self.Mapper.id_to_atom(a_orig_idx)
-            if self.is_functional_group(a, 'quartamine'):
-                a_set.append(data(atoms=[a, ], orig_atoms=[a_orig, ], atoms_orig_idx=[a_orig_idx, ], type='positive',
-                                  center=list(a.coords), fgroup='quartamine'))
-            elif self.is_functional_group(a, 'tertamine'):
-                a_set.append(data(atoms=[a, ], orig_atoms=[a_orig, ], atoms_orig_idx=[a_orig_idx, ], type='positive',
-                                  center=list(a.coords),
-                                  fgroup='tertamine'))
-            if self.is_functional_group(a, 'sulfonium'):
-                a_set.append(data(atoms=[a, ], orig_atoms=[a_orig, ], atoms_orig_idx=[a_orig_idx, ], type='positive',
-                                  center=list(a.coords),
-                                  fgroup='sulfonium'))
-            if self.is_functional_group(a, 'phosphate'):
-                a_contributing = [a, ]
-                a_contributing_orig_idx = [a_orig_idx, ]
-                [a_contributing.append(pybel.Atom(neighbor)) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom)]
-                [a_contributing_orig_idx.append(self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid))
-                 for neighbor in a_contributing]
-                orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
-                a_set.append(
-                    data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
-                         type='negative',
-                         center=a.coords, fgroup='phosphate'))
-            if self.is_functional_group(a, 'sulfonicacid'):
-                a_contributing = [a, ]
-                a_contributing_orig_idx = [a_orig_idx, ]
-                [a_contributing.append(pybel.Atom(neighbor)) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom) if
-                 neighbor.GetAtomicNum() == 8]
-                [a_contributing_orig_idx.append(self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid))
-                 for neighbor in a_contributing]
-                orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
-                a_set.append(
-                    data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
-                         type='negative',
-                         center=a.coords, fgroup='sulfonicacid'))
-            elif self.is_functional_group(a, 'sulfate'):
-                a_contributing = [a, ]
-                a_contributing_orig_idx = [a_orig_idx, ]
-                [a_contributing_orig_idx.append(self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid))
-                 for neighbor in a_contributing]
-                [a_contributing.append(pybel.Atom(neighbor)) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom)]
-                orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
-                a_set.append(
-                    data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
-                         type='negative',
-                         center=a.coords, fgroup='sulfate'))
-            if self.is_functional_group(a, 'carboxylate'):
-                a_contributing = [pybel.Atom(neighbor) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom)
-                                  if neighbor.GetAtomicNum() == 8]
-                a_contributing_orig_idx = [self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid)
-                                           for neighbor in a_contributing]
-                orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
-                a_set.append(
-                    data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
-                         type='negative',
-                         center=centroid([a.coords for a in a_contributing]), fgroup='carboxylate'))
-            elif self.is_functional_group(a, 'guanidine'):
-                a_contributing = [pybel.Atom(neighbor) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom)
-                                  if neighbor.GetAtomicNum() == 7]
-                a_contributing_orig_idx = [self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid)
-                                           for neighbor in a_contributing]
-                orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
-                a_set.append(
-                    data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
-                         type='positive',
-                         center=a.coords, fgroup='guanidine'))
+        if not (config.INTRA or config.PEPTIDES):
+            for a in all_atoms:
+                a_orig_idx = self.Mapper.mapid(a.idx, mtype=self.mtype, bsid=self.bsid)
+                a_orig = self.Mapper.id_to_atom(a_orig_idx)
+                if self.is_functional_group(a, 'quartamine'):
+                    a_set.append(data(atoms=[a, ], orig_atoms=[a_orig, ], atoms_orig_idx=[a_orig_idx, ], type='positive',
+                                      center=list(a.coords), fgroup='quartamine'))
+                elif self.is_functional_group(a, 'tertamine'):
+                    a_set.append(data(atoms=[a, ], orig_atoms=[a_orig, ], atoms_orig_idx=[a_orig_idx, ], type='positive',
+                                      center=list(a.coords),
+                                      fgroup='tertamine'))
+                if self.is_functional_group(a, 'sulfonium'):
+                    a_set.append(data(atoms=[a, ], orig_atoms=[a_orig, ], atoms_orig_idx=[a_orig_idx, ], type='positive',
+                                      center=list(a.coords),
+                                      fgroup='sulfonium'))
+                if self.is_functional_group(a, 'phosphate'):
+                    a_contributing = [a, ]
+                    a_contributing_orig_idx = [a_orig_idx, ]
+                    [a_contributing.append(pybel.Atom(neighbor)) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom)]
+                    [a_contributing_orig_idx.append(self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid))
+                     for neighbor in a_contributing]
+                    orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
+                    a_set.append(
+                        data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
+                             type='negative',
+                             center=a.coords, fgroup='phosphate'))
+                if self.is_functional_group(a, 'sulfonicacid'):
+                    a_contributing = [a, ]
+                    a_contributing_orig_idx = [a_orig_idx, ]
+                    [a_contributing.append(pybel.Atom(neighbor)) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom) if
+                     neighbor.GetAtomicNum() == 8]
+                    [a_contributing_orig_idx.append(self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid))
+                     for neighbor in a_contributing]
+                    orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
+                    a_set.append(
+                        data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
+                             type='negative',
+                             center=a.coords, fgroup='sulfonicacid'))
+                elif self.is_functional_group(a, 'sulfate'):
+                    a_contributing = [a, ]
+                    a_contributing_orig_idx = [a_orig_idx, ]
+                    [a_contributing_orig_idx.append(self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid))
+                     for neighbor in a_contributing]
+                    [a_contributing.append(pybel.Atom(neighbor)) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom)]
+                    orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
+                    a_set.append(
+                        data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
+                             type='negative',
+                             center=a.coords, fgroup='sulfate'))
+                if self.is_functional_group(a, 'carboxylate'):
+                    a_contributing = [pybel.Atom(neighbor) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom)
+                                      if neighbor.GetAtomicNum() == 8]
+                    a_contributing_orig_idx = [self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid)
+                                               for neighbor in a_contributing]
+                    orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
+                    a_set.append(
+                        data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
+                             type='negative',
+                             center=centroid([a.coords for a in a_contributing]), fgroup='carboxylate'))
+                elif self.is_functional_group(a, 'guanidine'):
+                    a_contributing = [pybel.Atom(neighbor) for neighbor in pybel.ob.OBAtomAtomIter(a.OBAtom)
+                                      if neighbor.GetAtomicNum() == 7]
+                    a_contributing_orig_idx = [self.Mapper.mapid(neighbor.idx, mtype=self.mtype, bsid=self.bsid)
+                                               for neighbor in a_contributing]
+                    orig_contributing = [self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx]
+                    a_set.append(
+                        data(atoms=a_contributing, orig_atoms=orig_contributing, atoms_orig_idx=a_contributing_orig_idx,
+                             type='positive',
+                             center=a.coords, fgroup='guanidine'))
+        else:
+            """We have peptide/protein chain as ligand"""
+            """Looks for positive charges in arginine, histidine or lysine, for negative in aspartic and glutamic acid."""
+            for res in pybel.ob.OBResidueIter(self.molecule.OBMol):
+                if config.INTRA is not None:
+                    if res.GetChain() != config.INTRA:
+                        continue
+                a_contributing = []
+                a_contributing_orig_idx = []
+                if res.GetName() in ('ARG', 'HIS', 'LYS'):  # Arginine, Histidine or Lysine have charged sidechains
+                    for a in pybel.ob.OBResidueAtomIter(res):
+                        if a.GetType().startswith('N') and res.GetAtomProperty(a, 8) \
+                                and not self.Mapper.mapid(a.GetIdx(), mtype=self.mtype, bsid=self.bsid) in self.altconf:
+                            a_contributing.append(pybel.Atom(a))
+                            a_contributing_orig_idx.append(self.Mapper.mapid(a.GetIdx(), mtype=self.mtype, bsid=self.bsid))
+                    if not len(a_contributing) == 0:
+                        a_set.append(data(atoms=a_contributing,
+                                          orig_atoms=[self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx],
+                                          atoms_orig_idx=a_contributing_orig_idx,
+                                          type='positive',
+                                          center=centroid([ac.coords for ac in a_contributing]),
+                                          fgroup=res.GetName()+str(res.GetNum())+res.GetChain()))
+                if res.GetName() in ('GLU', 'ASP'):  # Aspartic or Glutamic Acid
+                    for a in pybel.ob.OBResidueAtomIter(res):
+                        if a.GetType().startswith('O') and res.GetAtomProperty(a, 8) \
+                                and not self.Mapper.mapid(a.GetIdx(), mtype=self.mtype, bsid=self.bsid) in self.altconf:
+                            a_contributing.append(pybel.Atom(a))
+                            a_contributing_orig_idx.append(self.Mapper.mapid(a.GetIdx(), mtype=self.mtype, bsid=self.bsid))
+                    if not len(a_contributing) == 0:
+                        a_set.append(data(atoms=a_contributing,
+                                          orig_atoms=[self.Mapper.id_to_atom(idx) for idx in a_contributing_orig_idx],
+                                          atoms_orig_idx=a_contributing_orig_idx,
+                                          type='negative',
+                                          center=centroid([ac.coords for ac in a_contributing]),
+                                          fgroup=res.GetName()+str(res.GetNum())+res.GetChain()))
         return a_set
 
     def find_metal_binding(self, lig_atoms, water_oxygens):


### PR DESCRIPTION
Treating a protein chain as a ligand has only been implemented on a superficial level so far. The interaction detection and filtering routines were not adapted accordingly. This pull request addresses this issue in several places - see commit messages for details.