### PR TITLE
Fixing OverflowError: Python integer -1000 out of bounds for uint32

### DIFF
--- a/plip/basic/supplemental.py
+++ b/plip/basic/supplemental.py
@@ -351,16 +351,14 @@ def canonicalize(lig, preserve_bond_order=False):
 
 
 def int32_to_negative(int32):
-    """Checks if a suspicious number (e.g. ligand position) is in fact a negative number represented as a
-    32 bit integer and returns the actual number.
+    """Checks if a suspicious number (e.g., ligand position) is in fact a negative number represented as a
+    32-bit integer and returns the actual number.
     """
-    dct = {}
     if int32 == 4294967295:  # Special case in some structures (note, this is just a workaround)
         return -1
-    for i in range(-1000, -1):
-        dct[int(np.array(i).astype(np.uint32))] = i
-    if int32 in dct:
-        return dct[int32]
+    uint32_value = np.uint32(int32)
+    if uint32_value >= 2147483648:
+        return int(uint32_value - 4294967296)
     else:
         return int32
 


### PR DESCRIPTION
This patch fix https://github.com/pharmai/plip/issues/157

- This code checks if the input int32 is equal to 4294967295 (which is 2^32 - 1, the maximum value for a 32-bit unsigned integer). If true, it returns -1 like your implementation.

Then here it comes the difference with your implementation:

- uint32_value = np.uint32(int32)  converts int32 to a NumPy unsigned 32-bit integer type.
- Then checks if the unsigned value is greater than or equal to 2^31 (2147483648). If true, it means the value is in the upper half of the 32-bit unsigned integer range. It subtracts 2^32 (4294967296) from it and returns the result as an integer.
- Else, if the value is less than 2^31, it simply returns the original input.

It is simply a more efficient way. 

Here the outcome.

![image](https://github.com/user-attachments/assets/08f2afa9-52aa-43ee-97b8-dc3c2c16ff63)
