### PR TITLE
Keep modified residues in protein ligands

### DIFF
--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -243,8 +243,14 @@ class LigandFinder:
         try to extract the underlying ligand formed by all residues in the
         given chain without water
         """
-        all_from_chain = [o for o in pybel.ob.OBResidueIter(
-            self.proteincomplex.OBMol) if o.GetChain() == chain and not self.is_het_residue(o)]  # All residues from chain
+        # All residues from chain
+        if config.KEEPMOD:
+            all_from_chain = [o for o in pybel.ob.OBResidueIter(
+                self.proteincomplex.OBMol) if o.GetChain() == chain and (not self.is_het_residue(o) or
+                                                                         o.GetName() in self.modresidues)]
+        else:
+            all_from_chain = [o for o in pybel.ob.OBResidueIter(
+                self.proteincomplex.OBMol) if o.GetChain() == chain and not self.is_het_residue(o)]
         if len(all_from_chain) == 0:
             return None
         else:


### PR DESCRIPTION
If the "keepmod" flag is used together with protein ligands (--chains or --inter or --peptides flag), modified residues are now kept as part of the ligand.
 
Code is extended by an if statement in the "getpeptides" function to check if config.KEEPMOD is True. Modified residues are kept as ligand residues if True.