### PR TITLE
Fix/user feedback

### DIFF
--- a/plip/exchange/report.py
+++ b/plip/exchange/report.py
@@ -280,7 +280,7 @@ class BindingSiteReport:
                                       '%.2f' % halogen.distance, '%.2f' % halogen.don_angle, '%.2f' % halogen.acc_angle,
                                       halogen.don_orig_idx, halogen.donortype,
                                       halogen.acc_orig_idx, halogen.acctype,
-                                      halogen.acc.o.coords, halogen.don.x.coords))
+                                      halogen.don.x.coords, halogen.acc.o.coords))
 
         ###################
         # METAL COMPLEXES #

--- a/plip/structure/preparation.py
+++ b/plip/structure/preparation.py
@@ -1486,7 +1486,9 @@ class PDBComplex:
 
         if not as_string:
             self.sourcefiles['filename'] = os.path.basename(self.sourcefiles['pdbcomplex'])
-        self.protcomplex, self.filetype = read_pdb(self.corrected_pdb, as_string= as_string or pdbparser.pdb_file_was_corrected) # self.corrected_pdb may fallback to pdbpath
+            self.protcomplex, self.filetype = read_pdb(self.corrected_pdb, as_string= (self.corrected_pdb != pdbpath)) # self.corrected_pdb may fallback to pdbpath
+        else:
+            self.protcomplex, self.filetype = read_pdb(self.corrected_pdb, as_string=True)
 
         # Update the model in the Mapper class instance
         self.Mapper.original_structure = self.protcomplex.OBMol


### PR DESCRIPTION
Fixed user issue #185 and #186 . PDB as text flag does work as expected now and halogen bond ACC + DON coordinates are correctly assigned to protein and ligand. 