### PR TITLE
Dockerfile drop python3-distutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ LABEL maintainer="PharmAI GmbH <contact@pharm.ai>" \
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     pymol \
-    python3-distutils \
     python3-lxml \
     python3-openbabel \
     python3-pymol; \


### PR DESCRIPTION
Docker image is based on debian-stable - now "Trixie" with python3.13. distutils is now the part of setuptools and the Ddebian package python3-distutils is removed from Trixie.