### PR TITLE
Drop "broken" openbabel dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
 dependencies = [
     "numpy>=1.13.3",
     "lxml>=4.2.1",
-    "openbabel>=3.1.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
setup.py suppose to take care of openbabel bindings